### PR TITLE
docs: create AGENTS.md as primary agent instruction surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,27 @@
-See issue #2
+# AGENTS
+
+## Project Identity
+agentd is an autonomous AI agent runtime daemon for running autonomous AI agents on infrastructure you control. It is for builders and operators who need predictable, self-hosted execution of agent workflows without relying on hosted runtimes. The project is being built as a modular Rust workspace so runtime, scheduling, and integration concerns can evolve independently.
+
+## Architecture
+agentd uses a workspace-and-plugin shape: the `agentd` binary crate composes focused crates for runner lifecycle (`agentd-runner`), scheduling (`agentd-scheduler`), shared MCP transport (`mcp-transport`), and Forgejo MCP integration (`forgejo-mcp`). Keep architectural decisions aligned to this modular boundary unless a constraint requires change. See `ARCHITECTURE.md` for design rationale and the full constraint derivation.
+
+## Development Discipline
+
+### Ground Before Designing
+For any new module, API surface, protocol, or data structure, define what capability must exist when the change is complete before inspecting existing implementation patterns. State required outcomes first, then derive constraints from what must be true for those outcomes to hold. Separate actual constraints from inherited assumptions and challenge assumptions unless they are verified by requirements, interfaces, or tests. Compare against existing approaches only after a need-first design exists. Reference: `docs/skills/ground.md`.
+
+### BDD First
+Every change must follow this sequence: behavioral spec -> test -> implementation -> verification. Define done as observable behavior before coding. Write or update tests that fail without the change and pass when behavior is correct. Implement only what is necessary to satisfy the behavioral contract. No PR is complete without behavioral coverage for the change.
+
+### Coherence on Landing
+Each landing PR must verify documentation and code remain aligned. Confirm README claims still match repository reality. Confirm `ARCHITECTURE.md` still describes the actual architecture. Confirm doc comments match runtime behavior and interfaces. Confirm `AGENTS.md` still reflects required agent workflow and quality gates. If drift is found, fix it in the same PR.
+
+## Conventions
+- Commit messages must use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`.
+- Branch names must follow `issue-N-brief-description`.
+- Keep PR scope to one issue and make it small enough for focused review.
+- Rust changes must be `cargo fmt` formatted, `cargo clippy` clean, and warning-free.
+
+## Skill Locations
+Detailed cognitive and process skills live in `docs/skills/`. The foundational skill is `docs/skills/ground.md` (need-first design and verified constraints discipline). Add future skills in this directory and keep `AGENTS.md` as the thin routing layer.

--- a/docs/skills/ground.md
+++ b/docs/skills/ground.md
@@ -1,0 +1,26 @@
+# ground
+
+First-principles cognitive discipline for design and implementation work in agentd.
+
+## Purpose
+Prevent cargo-cult design and implementation drift by establishing what a change must enable before deriving solution shape.
+
+## Workflow
+1. State the required capability in behavioral terms.
+2. List constraints that must hold for the capability to be true.
+3. Mark each constraint as verified fact or assumption.
+4. Convert assumptions into checks, tests, or explicit open questions.
+5. Propose design choices only after constraints are explicit.
+6. Validate the resulting design against the original behavioral need.
+
+## Quality Bar
+- Need is explicit before solution discussion.
+- Constraints are traceable to requirements, interfaces, or tests.
+- Assumptions are identified and either validated or removed.
+- Chosen design is justified by constraints, not by familiarity.
+
+## Anti-Patterns
+- Starting from existing code shape and backfilling rationale.
+- Treating current implementation as required architecture.
+- Copying patterns from other projects without local constraint checks.
+- Writing code before defining observable done behavior.


### PR DESCRIPTION
## Summary
- replace `AGENTS.md` placeholder with a thin routing document for autonomous coding agents
- add required sections: identity, architecture pointer, development discipline, conventions, skill locations
- add `docs/skills/ground.md` and reference it from AGENTS for first-principles discipline

## Verification
- AGENTS is under 200 lines (27 lines)
- required sections/subsections present
- pointers resolve (`ARCHITECTURE.md`, `docs/skills/ground.md`)

Closes #2
