### PR TITLE
docs: add personal skills overlay project feature

### DIFF
--- a/.agents/skills/project-workflow/SKILL.md
+++ b/.agents/skills/project-workflow/SKILL.md
@@ -1,0 +1,15 @@
+# project-workflow
+
+Shared project workflow skill for agentd contributors.
+
+## Purpose
+
+Keep work aligned with repository development discipline:
+
+- Ground before designing.
+- BDD first (spec -> test -> implementation -> verification).
+- Coherence on landing (README, ARCHITECTURE, AGENTS, and behavior in sync).
+
+## Use
+
+Use this skill when planning or implementing changes in this repository to ensure contributor workflow consistency.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,16 @@ Each landing PR must verify documentation and code remain aligned. Confirm READM
 
 ## Skill Locations
 Detailed cognitive and process skills live in `docs/skills/`. The foundational skill is `docs/skills/ground.md` (need-first design and verified constraints discipline). Add future skills in this directory and keep `AGENTS.md` as the thin routing layer.
+
+## Skill Layers
+agentd supports two project-level skill layers:
+
+- Public project skills: tracked in this repository under `.agents/skills/<skill-name>/SKILL.md`. These are shared team tooling.
+- Personal skills overlay: optional local skills installed into `.agents/skills/` on a developer machine. Personal skill content is developer-owned and must not be committed in this repository.
+
+### Personal Overlay Policy
+- The personal overlay mechanism is a supported public project feature.
+- Personal skill names, personal repo URLs, and personal filesystem paths must not appear in committed files.
+- On name collision, personal overlay skills take precedence over project skills by design.
+- Personal overlay paths must be ignored via local-only git excludes (for example `.git/info/exclude`), not `.gitignore`.
+- Contributor setup and verification steps are documented in `docs/skills/overlay.md`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ The system is organized as a Rust workspace with focused crates for runtime, sch
 
 Coming soon.
 
+## Developer Tooling: Skills
+
+agentd supports project-level skills with two layers:
+
+- Shared public skills tracked in this repository at `.agents/skills/`.
+- Optional personal skills overlay installed locally at project level and kept untracked.
+
+See `docs/skills/overlay.md` for the personal overlay workflow, collision policy, and git-clean verification steps.
+
 ## License
 
 Licensed under the terms in [LICENSE](LICENSE).

--- a/docs/skills/overlay.md
+++ b/docs/skills/overlay.md
@@ -1,0 +1,64 @@
+# Personal Skills Overlay
+
+This document defines the supported way to combine shared public skills with personal developer skills at project scope.
+
+## Goal
+
+- Keep shared project skills committed with the repository.
+- Allow each developer to add personal skills locally at project level.
+- Keep personal skill content and identity details out of committed files.
+
+## Directory Contract
+
+- Public skills (tracked): `.agents/skills/<public-skill>/SKILL.md`
+- Personal overlay (local only): `.agents/skills/<personal-skill>/`
+
+## Installation Pattern (Personal Overlay)
+
+1. Store personal skills in a personal location (for example a personal repo clone).
+2. Install them into this project as symlinks under `.agents/skills/`.
+3. Add personal overlay paths to local-only excludes in `.git/info/exclude`.
+
+Example local installation pattern:
+
+```bash
+PROJECT_ROOT=/path/to/agentd
+PERSONAL_ROOT=/path/to/personal-skills
+
+mkdir -p "$PROJECT_ROOT/.agents/skills"
+ln -sfn "$PERSONAL_ROOT/skills/my-personal-skill" \
+  "$PROJECT_ROOT/.agents/skills/my-personal-skill"
+printf '%s\n' '.agents/skills/my-personal-skill' >> "$PROJECT_ROOT/.git/info/exclude"
+```
+
+Use an idempotent local installer script if you have many personal skills.
+
+## Collision Policy
+
+- Personal overlay names may intentionally collide with tracked public skill directory names.
+- On collision, the personal overlay skill overrides the project skill for that developer's local environment.
+- Use this for personal adaptation of shared workflows without changing team-wide defaults.
+
+## Git Hygiene Policy
+
+- Do not add personal overlay patterns to `.gitignore`.
+- Do not commit personal skill names, URLs, or local paths.
+- Use `.git/info/exclude` (or equivalent local-only ignore) for personal overlay entries.
+
+## Verification Checklist
+
+Run after installing or updating personal overlays:
+
+```bash
+git status --porcelain
+```
+
+Expected: no personal overlay paths appear in output.
+
+Optional link verification:
+
+```bash
+find .agents/skills -maxdepth 1 -type l -print
+```
+
+Expected: only intentionally installed personal symlinks are listed.


### PR DESCRIPTION
## Summary
- document project skill layers (public + personal overlay)
- define personal overlay as a supported public project feature
- define collision behavior: personal overlay overrides project skill locally
- add detailed overlay workflow and git hygiene guidance
- add tracked public skill example under `.agents/skills/`

## Files
- `AGENTS.md`
- `README.md`
- `docs/skills/overlay.md`
- `.agents/skills/project-workflow/SKILL.md`

Closes #9