### PR TITLE
refactor: source-agnostic naming in the dispatch layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Clarified the credential source contract so examples, config doc comments, and architecture docs now describe `source` as a daemon-process environment variable name resolved with `std::env::var`, not an opaque secret-store reference.
+- Renamed the `agentd` crate's shared dispatch-layer request and helper APIs from manual/operator-specific names to source-agnostic run names, including the socket-interface integration test surface, so scheduler and operator callers share one clearly neutral dispatch path.
 - Removed the placeholder `mcp-transport` and `forgejo-mcp` crates so the workspace now contains only `agentd`, `agentd-runner`, and `agentd-scheduler`, and added coverage that enforces that three-crate contract.
 - Removed the vendored methodology skill distribution layer from the repository, including loadout configuration, manifests, sync and verify scripts, vendored skill copies, and related smoke tests.
 - Replaced the old skill-focused GitHub Actions workflow with a Rust workspace CI workflow that runs `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, and `cargo test --workspace`.

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -15,7 +15,7 @@ use agentd_runner::SessionOutcome;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{Config, DaemonConfig};
-use crate::{DispatchError, ManualRunRequest, SessionExecutor, dispatch_manual_run};
+use crate::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 
 const ACCEPT_TIMEOUT: Duration = Duration::from_millis(100);
 const RUNTIME_DIR_MODE: u32 = 0o700;
@@ -56,7 +56,7 @@ impl From<io::Error> for DaemonError {
     }
 }
 
-/// Errors returned to operator-side client commands.
+/// Errors returned to daemon client commands.
 #[derive(Debug)]
 pub enum ClientError {
     DaemonNotRunning { path: PathBuf },
@@ -284,10 +284,10 @@ fn log_handler_panic(handler: JoinHandle<()>) {
     }
 }
 
-/// Trigger a manual run against the local daemon and wait for its terminal outcome.
-pub fn request_manual_run(
+/// Trigger a run against the local daemon and wait for its terminal outcome.
+pub fn request_run(
     config: &DaemonConfig,
-    request: &ManualRunRequest,
+    request: &RunRequest,
 ) -> Result<SessionOutcome, ClientError> {
     match send_request(
         config.socket_path(),
@@ -381,9 +381,9 @@ fn handle_connection_inner(
             agent,
             repo_url,
             work_unit,
-        } => match dispatch_manual_run(
+        } => match dispatch_run(
             config,
-            &ManualRunRequest {
+            &RunRequest {
                 agent,
                 repo_url,
                 work_unit,
@@ -397,7 +397,7 @@ fn handle_connection_inner(
                 tracing::warn!(
                     event = "agentd.manual_run_rejected",
                     error = %error,
-                    "manual run request rejected"
+                    "run request rejected"
                 );
                 ResponseMessage::Error {
                     message: dispatch_error_message(&error),

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -7,15 +7,15 @@ use agentd_runner::{
 
 use crate::config::Config;
 
-/// Operator-supplied parameters for a manual session trigger.
+/// Parameters for a daemon run request.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ManualRunRequest {
+pub struct RunRequest {
     pub agent: String,
     pub repo_url: String,
     pub work_unit: Option<String>,
 }
 
-/// Errors produced while mapping a manual run request into a runner session.
+/// Errors produced while mapping a run request into a runner session.
 #[derive(Debug)]
 pub enum DispatchError {
     UnknownAgent {
@@ -84,10 +84,10 @@ impl SessionExecutor for RunnerSessionExecutor {
     }
 }
 
-/// Resolve a named agent plus operator request into a runner session and run it.
-pub fn dispatch_manual_run(
+/// Resolve a named agent plus run request into a runner session and run it.
+pub fn dispatch_run(
     config: &Config,
-    request: &ManualRunRequest,
+    request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
     let agent = config

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -9,9 +9,9 @@ pub mod daemon;
 pub mod dispatch;
 pub mod logging;
 
-pub use daemon::{ClientError, DaemonError, request_manual_run, run_daemon_until_shutdown};
+pub use daemon::{ClientError, DaemonError, request_run, run_daemon_until_shutdown};
 pub use dispatch::{
-    DispatchError, ManualRunRequest, RunnerSessionExecutor, SessionExecutor, dispatch_manual_run,
+    DispatchError, RunRequest, RunnerSessionExecutor, SessionExecutor, dispatch_run,
 };
 pub use logging::{
     LogFormat, LoggingError, ResolvedLoggingConfig, configure_tracing, resolve_logging_config,

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -6,8 +6,7 @@ use std::{error::Error, fmt};
 
 use agentd::config::{Config, DaemonConfig};
 use agentd::{
-    ManualRunRequest, RunnerSessionExecutor, configure_tracing, request_manual_run,
-    run_daemon_until_shutdown,
+    RunRequest, RunnerSessionExecutor, configure_tracing, request_run, run_daemon_until_shutdown,
 };
 use clap::{Parser, Subcommand};
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
@@ -105,9 +104,9 @@ fn run_client(
     repo: String,
     work_unit: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let outcome = request_manual_run(
+    let outcome = request_run(
         &config,
-        &ManualRunRequest {
+        &RunRequest {
             agent,
             repo_url: repo,
             work_unit,

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -8,8 +8,7 @@ use std::time::{Duration, Instant};
 
 use agentd::config::Config;
 use agentd::{
-    ClientError, DaemonError, ManualRunRequest, SessionExecutor, request_manual_run,
-    run_daemon_until_shutdown,
+    ClientError, DaemonError, RunRequest, SessionExecutor, request_run, run_daemon_until_shutdown,
 };
 use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 
@@ -171,7 +170,7 @@ fn wait_for_path_removal(path: &std::path::Path) {
 }
 
 #[test]
-fn daemon_reports_manual_run_outcome_back_through_client_request() {
+fn daemon_reports_run_outcome_back_through_client_request() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -191,9 +190,9 @@ fn daemon_reports_manual_run_outcome_back_through_client_request() {
     });
     wait_for_path(config.daemon().socket_path());
 
-    let outcome = request_manual_run(
+    let outcome = request_run(
         config.daemon(),
-        &ManualRunRequest {
+        &RunRequest {
             agent: "codex".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("task-42".to_string()),
@@ -218,9 +217,9 @@ fn client_reports_clear_error_when_daemon_is_not_running() {
     let runtime_dir = unique_runtime_dir("not-running");
     let config = config_in_runtime_dir(&runtime_dir);
 
-    let error = request_manual_run(
+    let error = request_run(
         config.daemon(),
-        &ManualRunRequest {
+        &RunRequest {
             agent: "codex".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: None,
@@ -324,7 +323,7 @@ fn daemon_shutdown_removes_pid_file_and_socket() {
 }
 
 #[test]
-fn daemon_accepts_additional_manual_runs_while_a_previous_run_is_still_executing() {
+fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -348,9 +347,9 @@ fn daemon_accepts_additional_manual_runs_while_a_previous_run_is_still_executing
 
     let first_config = config.clone();
     let first_request = thread::spawn(move || {
-        request_manual_run(
+        request_run(
             first_config.daemon(),
-            &ManualRunRequest {
+            &RunRequest {
                 agent: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("first".to_string()),
@@ -362,9 +361,9 @@ fn daemon_accepts_additional_manual_runs_while_a_previous_run_is_still_executing
     let second_config = config.clone();
     let (second_tx, second_rx) = mpsc::channel();
     let second_request = thread::spawn(move || {
-        let outcome = request_manual_run(
+        let outcome = request_run(
             second_config.daemon(),
-            &ManualRunRequest {
+            &RunRequest {
                 agent: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("second".to_string()),
@@ -417,7 +416,7 @@ fn daemon_accepts_additional_manual_runs_while_a_previous_run_is_still_executing
 }
 
 #[test]
-fn daemon_shutdown_waits_for_an_in_flight_manual_run_to_finish() {
+fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -439,9 +438,9 @@ fn daemon_shutdown_waits_for_an_in_flight_manual_run_to_finish() {
 
     let client_config = config.clone();
     let client_request = thread::spawn(move || {
-        request_manual_run(
+        request_run(
             client_config.daemon(),
-            &ManualRunRequest {
+            &RunRequest {
                 agent: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("shutdown".to_string()),
@@ -457,7 +456,7 @@ fn daemon_shutdown_waits_for_an_in_flight_manual_run_to_finish() {
 
     assert!(
         !exited_before_release,
-        "daemon exited before the in-flight manual run finished"
+        "daemon exited before the in-flight run finished"
     );
 
     executor.release_first_run();
@@ -478,7 +477,7 @@ fn daemon_shutdown_waits_for_an_in_flight_manual_run_to_finish() {
 }
 
 #[test]
-fn daemon_shutdown_stops_accepting_new_manual_runs() {
+fn daemon_shutdown_stops_accepting_new_runs() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -500,9 +499,9 @@ fn daemon_shutdown_stops_accepting_new_manual_runs() {
 
     let first_config = config.clone();
     let first_request = thread::spawn(move || {
-        request_manual_run(
+        request_run(
             first_config.daemon(),
-            &ManualRunRequest {
+            &RunRequest {
                 agent: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("draining".to_string()),
@@ -514,15 +513,15 @@ fn daemon_shutdown_stops_accepting_new_manual_runs() {
     shutdown.store(true, Ordering::Release);
     wait_for_path_removal(config.daemon().socket_path());
 
-    let error = request_manual_run(
+    let error = request_run(
         config.daemon(),
-        &ManualRunRequest {
+        &RunRequest {
             agent: "codex".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("rejected".to_string()),
         },
     )
-    .expect_err("new manual run should be rejected once shutdown begins");
+    .expect_err("new run should be rejected once shutdown begins");
 
     executor.release_first_run();
     handle

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use agentd::config::Config;
-use agentd::{DispatchError, ManualRunRequest, SessionExecutor, dispatch_manual_run};
+use agentd::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 use agentd_runner::{
     ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
 };
@@ -74,7 +74,7 @@ source = "AGENTD_GITHUB_TOKEN"
 }
 
 #[test]
-fn dispatch_manual_run_resolves_repo_token_without_injecting_it_into_runtime_environment() {
+fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environment() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -83,15 +83,14 @@ fn dispatch_manual_run_resolves_repo_token_without_injecting_it_into_runtime_env
         std::env::set_var("CODEX_REPO_TOKEN", "clone-only-secret");
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
-    let request = ManualRunRequest {
+    let request = RunRequest {
         agent: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: Some("task-42".to_string()),
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
 
-    let outcome =
-        dispatch_manual_run(&config, &request, &executor).expect("dispatch should succeed");
+    let outcome = dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
 
     assert_eq!(outcome, SessionOutcome::Succeeded);
 
@@ -131,7 +130,7 @@ fn dispatch_manual_run_resolves_repo_token_without_injecting_it_into_runtime_env
 }
 
 #[test]
-fn dispatch_manual_run_omits_repo_token_when_source_env_var_is_missing() {
+fn dispatch_run_omits_repo_token_when_source_env_var_is_missing() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -140,14 +139,14 @@ fn dispatch_manual_run_omits_repo_token_when_source_env_var_is_missing() {
         std::env::remove_var("CODEX_REPO_TOKEN");
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
-    let request = ManualRunRequest {
+    let request = RunRequest {
         agent: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
 
-    dispatch_manual_run(&config, &request, &executor).expect("dispatch should succeed");
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
 
     let state = state.lock().expect("recording state should lock");
     let invocation = state
@@ -163,7 +162,7 @@ fn dispatch_manual_run_omits_repo_token_when_source_env_var_is_missing() {
 }
 
 #[test]
-fn dispatch_manual_run_omits_repo_token_when_source_env_var_is_empty() {
+fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -172,14 +171,14 @@ fn dispatch_manual_run_omits_repo_token_when_source_env_var_is_empty() {
         std::env::set_var("CODEX_REPO_TOKEN", "");
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
-    let request = ManualRunRequest {
+    let request = RunRequest {
         agent: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
 
-    dispatch_manual_run(&config, &request, &executor).expect("dispatch should succeed");
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
 
     let state = state.lock().expect("recording state should lock");
     let invocation = state
@@ -196,7 +195,7 @@ fn dispatch_manual_run_omits_repo_token_when_source_env_var_is_empty() {
 }
 
 #[test]
-fn dispatch_manual_run_errors_when_runtime_credential_source_is_missing() {
+fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -205,14 +204,14 @@ fn dispatch_manual_run_errors_when_runtime_credential_source_is_missing() {
         std::env::set_var("CODEX_REPO_TOKEN", "clone-only-secret");
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
-    let request = ManualRunRequest {
+    let request = RunRequest {
         agent: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
     let (executor, _state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
 
-    let error = dispatch_manual_run(&config, &request, &executor)
+    let error = dispatch_run(&config, &request, &executor)
         .expect_err("missing runtime credential sources should fail dispatch");
 
     match error {


### PR DESCRIPTION
## Summary

- Rename the shared dispatch request and helper APIs from manual/operator-specific names to source-agnostic `Run` names.
- Rename the Unix-socket integration test file and affected test cases so they describe the interface and behavior under test without assuming a trigger source.
- Record the API-visible rename in `CHANGELOG.md`; `README.md`, `ARCHITECTURE.md`, and `AGENTS.md` were reviewed and remain accurate.

## Changes

- Replace `ManualRunRequest`, `dispatch_manual_run`, and `request_manual_run` with `RunRequest`, `dispatch_run`, and `request_run` across the dispatch layer, daemon API, public re-exports, and CLI call sites.
- Rename `crates/agentd/tests/daemon_operator_interface.rs` to `crates/agentd/tests/daemon_socket_interface.rs` and update the related integration test names to use source-agnostic run terminology.
- Keep behavior, CLI subcommand naming, socket protocol shape, and runtime flow unchanged.

## Issue(s)

Closes #56

## Test plan

- `cargo fmt --check`
- `cargo clippy -p agentd --tests -- -D warnings`
- `cargo test -p agentd`
