### PR TITLE
docs(architecture): document uniform socket intake principle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,7 +63,7 @@ The workspace contains three crates because there are three distinct rates of ch
 
 | Crate | Responsibility | Needs Served | Boundary Rationale |
 |---|---|---|---|
-| `agentd` | Composition root and daemon entrypoint. Parses configuration, assembles runner and scheduler components, and starts the process. | All, as orchestration | Keeps the binary thin and prevents subsystem concerns from collapsing into the entrypoint. |
+| `agentd` | Composition root and daemon entrypoint. Parses configuration, owns the Unix socket intake, assembles runner and scheduler components, and starts the process. | All, as orchestration | Keeps the binary thin and prevents subsystem concerns from collapsing into the entrypoint while preserving one uniform dispatch path into session execution. |
 | `agentd-runner` | Session lifecycle. Creates execution environments, injects identity, credentials, context, and tool configuration, launches runtimes, and tears sessions down. | Identity, Credentials, Mission, Tool Availability, Context, Network policy application | Session mechanics change independently from scheduling policy and should remain isolated. |
 | `agentd-scheduler` | Triggering and timing. Determines when an agent session should start and with what mission context. | Mission | Scheduling policy has its own evolution path and should not be coupled to session setup mechanics. |
 
@@ -72,6 +72,12 @@ The workspace contains three crates because there are three distinct rates of ch
 ## 4. Session Lifecycle
 
 A session is one execution of one agent from trigger to teardown.
+
+The daemon's Unix socket is the single intake for all session triggers. Manual
+CLI invocation connects to that socket as a client. Scheduling policy also
+connects to that socket as a client when it decides work should start. The
+daemon accepts those run requests uniformly and dispatches them into session
+execution.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so
@@ -83,7 +89,11 @@ environment configuration.
 
 ### Phase 1: Scheduling (`agentd-scheduler`)
 
-The scheduler determines when an agent should run. Triggers may come from time-based schedules, external events, or manual invocation. The scheduler passes agent identity plus mission context to the runner.
+The scheduler determines when an agent should run. Triggers may come from
+time-based schedules, external events, or continuous policies. When scheduling
+decides to start a session, the scheduler is a socket client: it dispatches a
+run request through the daemon's Unix socket, using the same intake path as
+manual CLI invocation. The scheduler does not call the runner directly.
 
 ### Phase 2: Session Setup (`agentd-runner`)
 

--- a/crates/agentd-scheduler/src/lib.rs
+++ b/crates/agentd-scheduler/src/lib.rs
@@ -1,8 +1,10 @@
 //! Job scheduling primitives for agentd.
 //!
 //! This crate will own scheduling policy and timing — determining when agents
-//! run and with what mission context, then handing identity and invocation
-//! parameters to `agentd-runner` for execution. Currently a placeholder
-//! pending scheduler implementation.
+//! run and with what mission context, then dispatching run requests through
+//! the daemon's Unix socket using the same intake path as manual invocation.
+//! The scheduler does not call `agentd-runner` directly. Currently a
+//! placeholder pending scheduler implementation.
 //!
-//! See `ARCHITECTURE.md` section "Scheduler" for the design-level treatment.
+//! See `ARCHITECTURE.md` section "Session Lifecycle" for the design-level
+//! treatment.

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -78,3 +78,21 @@ fn workspace_docs_describe_only_the_three_grounded_crates() {
     assert!(architecture.contains("`agentd-runner`"));
     assert!(architecture.contains("`agentd-scheduler`"));
 }
+
+#[test]
+fn architecture_describes_uniform_socket_intake_for_session_triggers() {
+    let architecture = read_workspace_file("ARCHITECTURE.md");
+
+    assert!(
+        architecture.contains("single intake for all session triggers"),
+        "architecture should describe the Unix socket as the single session intake"
+    );
+    assert!(
+        architecture.contains("scheduler is a socket client"),
+        "architecture should describe the scheduler as a socket client"
+    );
+    assert!(
+        !architecture.contains("The scheduler passes agent identity plus mission context to the runner."),
+        "architecture should not describe the scheduler as handing work directly to the runner"
+    );
+}


### PR DESCRIPTION
## Summary

- document the daemon Unix socket as the single intake for all session triggers
- clarify that scheduler-triggered runs dispatch through the same socket path as manual CLI requests
- add a workspace documentation contract test so the old scheduler-to-runner wording does not return

## Changes

- updated `ARCHITECTURE.md` to describe the socket-first dispatch model in the crate boundary table and session lifecycle overview
- rewrote Scheduling Phase 1 to describe `agentd-scheduler` as a socket client rather than a direct caller of `agentd-runner`
- extended `crates/agentd/tests/workspace_contract.rs` with a regression test for the new architectural wording

## Issue(s)

Closes #57
Refs #24

## Test plan

- `cargo test -p agentd --test workspace_contract --test daemon_socket_interface --test session_dispatch`
- `rg -n "The scheduler passes agent identity plus mission context to the runner|scheduler.*runner directly|single intake for all session triggers|scheduler is a socket client" ARCHITECTURE.md README.md CHANGELOG.md`
