### PR TITLE
refactor: rename agent to profile for reusable environment specifications

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,7 @@ The workspace contains three crates because there are three distinct rates of ch
 
 ## 4. Session Lifecycle
 
-A session is one execution of one profile from trigger to teardown.
+A session is one execution created from a profile, spanning trigger to teardown.
 
 Before the daemon accepts any session trigger, it first reconciles stale
 runner-managed Podman resources from prior runs of the same daemon instance.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,11 @@ agentd is not:
 
 The key architectural consequence is simple: agentd may configure tool availability for a runtime, but it does not proxy the MCP wire protocol or ship domain-specific MCP servers inside this repository.
 
+### Terminology
+
+- **Profile**: a named, reusable environment specification in the daemon config — base image, methodology, credentials, and command. What the operator declares.
+- **Session**: a single execution created from a profile plus invocation parameters (repo, work unit, timeout). What the runner manages.
+
 ## 2. Agent Capability Needs
 
 Every structural decision in the workspace traces to a capability an agent session must eventually have.
@@ -31,13 +36,13 @@ Every structural decision in the workspace traces to a capability an agent sessi
 
 **Need:** agents authenticate to those external services.
 
-**Constraint:** credentials are injected at session setup and remain scoped to the owning agent.
+**Constraint:** credentials are injected at session setup and remain scoped to the owning profile.
 
 ### Identity
 
 **Need:** agents know who they are and can be distinguished clearly per session.
 
-**Constraint:** each session receives stable identity variables and an agent-derived container name inside an ephemeral runtime.
+**Constraint:** each session receives stable identity variables and a profile-derived container name inside an ephemeral runtime.
 
 ### Mission
 
@@ -64,18 +69,18 @@ The workspace contains three crates because there are three distinct rates of ch
 | Crate | Responsibility | Needs Served | Boundary Rationale |
 |---|---|---|---|
 | `agentd` | Composition root and daemon entrypoint. Parses configuration, owns the Unix socket intake, assembles runner and scheduler components, and starts the process. | All, as orchestration | Keeps the binary thin and prevents subsystem concerns from collapsing into the entrypoint while preserving one uniform dispatch path into session execution. |
-| `agentd-runner` | Session lifecycle. Creates execution environments, injects identity, credentials, context, and tool configuration, launches runtimes, and tears sessions down. | Identity, Credentials, Mission, Tool Availability, Context, Network policy application | Session mechanics change independently from scheduling policy and should remain isolated. |
-| `agentd-scheduler` | Triggering and timing. Determines when an agent session should start and with what mission context. | Mission | Scheduling policy has its own evolution path and should not be coupled to session setup mechanics. |
+| `agentd-runner` | Session lifecycle. Creates execution environments, injects identity, credentials, context, and tool configuration, launches runtimes, and tears sessions down. | Identity, Credentials, Mission, Tool Availability, Context, Network policy application | Session mechanics change independently of scheduling policy and should remain isolated. |
+| `agentd-scheduler` | Triggering and timing. Determines when a session should start and with what mission context. | Mission | Scheduling policy has its own evolution path and should not be coupled to session setup mechanics. |
 
 **Reading the table:** if the change is about when work starts, it belongs in `agentd-scheduler`. If it is about how a session is prepared, launched, or cleaned up, it belongs in `agentd-runner`. If it is about wiring the whole daemon together, it belongs in `agentd`.
 
 ## 4. Session Lifecycle
 
-A session is one execution of one agent from trigger to teardown.
+A session is one execution of one profile from trigger to teardown.
 
 Before the daemon accepts any session trigger, it first reconciles stale
 runner-managed Podman resources from prior runs of the same daemon instance.
-Dead session containers named `agentd-{daemon8}-{agent}-{session16}` are
+Dead session containers named `agentd-{daemon8}-{profile}-{session16}` are
 removed, then orphaned runner-managed secrets named
 `agentd-{daemon8}-{session16}-{suffix}` whose session container no longer
 exists are removed. The daemon instance id is derived from the configured
@@ -99,7 +104,7 @@ environment configuration.
 
 ### Phase 1: Scheduling (`agentd-scheduler`)
 
-The scheduler determines when an agent should run. Triggers may come from
+The scheduler determines when a session should run. Triggers may come from
 time-based schedules, external events, or continuous policies. When scheduling
 decides to start a session, the scheduler is a socket client: it dispatches a
 run request through the daemon's Unix socket, using the same intake path as
@@ -109,16 +114,16 @@ manual CLI invocation. The scheduler does not call the runner directly.
 
 The runner prepares the execution environment:
 
-1. Creates an ephemeral Podman container from the agent's configured base image. That image must provide a POSIX-compatible shell at `/bin/sh` because the runner's container entrypoint executes through that path.
-2. Sets identity inside the container, including `AGENT_NAME` and a unique container name derived from the agent.
+1. Creates an ephemeral Podman container from the profile's configured base image. That image must provide a POSIX-compatible shell at `/bin/sh` because the runner's container entrypoint executes through that path.
+2. Sets identity inside the container, including `PROFILE_NAME` and a unique container name derived from the profile.
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
-5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}`, clones the requested repository into `/home/{username}/repo`, and initializes runa from inside that repository so project state lives at `/home/{username}/repo/.runa/`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the agent runtime starts. Base images that lack `/bin/sh`, `git`, `useradd`, or `gosu` are not supported.
+5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, clones the requested repository into `/home/{username}/repo`, and initializes runa from inside that repository so project state lives at `/home/{username}/repo/.runa/`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the agent runtime starts. Base images that lack `/bin/sh`, `git`, `useradd`, or `gosu` are not supported.
 6. Recursively transfers ownership of `/home/{username}` to that user, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready.
 
 ### Phase 3: Execution (`agentd-runner`)
 
-The runner drops privileges with `gosu` and launches `runa run` as the unprivileged agent user from `/home/{username}/repo`, then supervises the container until natural completion or an optional timeout. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange.
+The runner drops privileges with `gosu` and launches `runa run` as the unprivileged session user from `/home/{username}/repo`, then supervises the container until natural completion or an optional timeout. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange.
 
 ### Phase 4: Teardown (`agentd-runner`)
 
@@ -144,26 +149,26 @@ From inside the environment, an agent should see:
 
 ## 6. Credential Flow
 
-Credentials are declared by agent configuration as daemon-side environment variable names. For each configured credential, the daemon resolves `source` with `std::env::var(source)` from its own process environment before calling `agentd-runner`. Operators provide those values through normal host mechanisms such as systemd `EnvironmentFile=`, shell exports, or container environment injection. During session setup, the runner receives only the already-resolved credential values, creates Podman-managed ephemeral secrets for non-empty values, and injects those values into the execution environment as environment variables without placing the secret values on the Podman command line. Empty assignments are injected directly as `NAME=` because Podman secrets reject zero-byte payloads. Once the container reaches the running state, the runner removes the backing Podman secret objects and relies on the in-container environment copy for the rest of the session.
+Credentials are declared by profile configuration as daemon-side environment variable names. For each configured credential, the daemon resolves `source` with `std::env::var(source)` from its own process environment before calling `agentd-runner`. Operators provide those values through normal host mechanisms such as systemd `EnvironmentFile=`, shell exports, or container environment injection. During session setup, the runner receives only the already-resolved credential values, creates Podman-managed ephemeral secrets for non-empty values, and injects those values into the execution environment as environment variables without placing the secret values on the Podman command line. Empty assignments are injected directly as `NAME=` because Podman secrets reject zero-byte payloads. Once the container reaches the running state, the runner removes the backing Podman secret objects and relies on the in-container environment copy for the rest of the session.
 
 Because startup reconciliation is scoped per daemon instance rather than to the
 whole Podman namespace, the daemon removes only runner-managed resources whose
 names carry its own derived daemon id: dead
-`agentd-{daemon8}-{agent}-{session16}` containers are removed first, then
+`agentd-{daemon8}-{profile}-{session16}` containers are removed first, then
 orphaned `agentd-{daemon8}-{session16}-{suffix}` secrets whose session
 container is gone.
 
-Repository clone authentication is a separate invocation concern rather than an agent runtime credential. When an agent config declares `repo_token_source`, the daemon resolves that environment variable at dispatch time and, when the resolved value is non-empty, maps it to `SessionInvocation.repo_token`. The runner then injects that bearer token through its own ephemeral secret, uses it only for the `git clone` invocation, and unsets the internal token variable before `runa run` starts so the token does not persist in git config or the agent runtime environment.
+Repository clone authentication is a separate invocation concern rather than an agent runtime credential. When a profile declares `repo_token_source`, the daemon resolves that environment variable at dispatch time and, when the resolved value is non-empty, maps it to `SessionInvocation.repo_token`. The runner then injects that bearer token through its own ephemeral secret, uses it only for the `git clone` invocation, and unsets the internal token variable before `runa run` starts so the token does not persist in git config or the agent runtime environment.
 
-Isolation is per agent: one agent receives only its own declared credentials. Sharing access to the same external service still requires separate credential declarations per agent so compromise remains scoped.
+Isolation is per profile: one profile receives only its own declared credentials. Sharing access to the same external service still requires separate credential declarations per profile so compromise remains scoped.
 
 ## 7. Verification Matrix
 
 | Need | Architectural Decision | Workspace Evidence | Failure if Violated |
 |---|---|---|---|
 | Network | Session environments receive deployment-controlled network access | `agentd-runner` owns session setup | Agents cannot reach external services |
-| Credentials | Secrets are injected at launch, not stored in code or images | `agentd` resolves configured environment-variable sources and `agentd-runner` accepts the resolved values | Agents cannot authenticate or credentials leak across agents |
-| Identity | Each session receives stable in-container identity variables and container naming | `agentd-runner` session contract and Podman lifecycle | Operators cannot distinguish which agent a session belongs to |
+| Credentials | Secrets are injected at launch, not stored in code or images | `agentd` resolves configured environment-variable sources and `agentd-runner` accepts the resolved values | Sessions cannot authenticate or credentials leak across profiles |
+| Identity | Each session receives stable in-container identity variables and container naming | `agentd-runner` session contract and Podman lifecycle | Operators cannot distinguish which profile a session belongs to |
 | Mission | Scheduling or CLI invocation hands repo and optional work unit into session launch | `agentd-scheduler` plus `agentd-runner` boundary | Agents run without a reason or target |
 | Tool Availability | Tools are provided through the environment; MCP remains a runtime concern | Three-crate workspace with no transport crate | agentd would absorb protocol work it does not need |
 | Context | Methodology assets are mounted read-only into sessions and the repo is freshly cloned per run | `agentd-runner` boundary and crate intent | Agents operate without local awareness |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Renamed the config-level concept from "agent" to "profile" across the entire workspace: `[[agents]]` is now `[[profiles]]`, CLI positional argument is `<profile>`, types use `ProfileConfig`/`profile_name`/`validate_profile_name()`, the injected env var is `PROFILE_NAME`, and documentation, error messages, and examples reflect the new terminology. The daemon name `agentd` and references to the running entity as an "agent" are unchanged.
+
 ### Added
 
-- Added a documented static agent configuration format in `examples/agentd.toml` plus strict TOML parsing in the `agentd` crate for agent identity, base image, methodology mounts, credentials, and static runa command settings.
+- Added a documented static profile configuration format in `examples/agentd.toml` plus strict TOML parsing in the `agentd` crate for profile identity, base image, methodology mounts, credentials, and static runa command settings.
 - Added a Podman-backed session lifecycle in `agentd-runner` that creates ephemeral containers, mounts methodology assets read-only, clones a fresh repository workspace, runs `runa`, injects caller-resolved credentials, supports optional timeouts, and force-removes the container on teardown.
 - Added explicit `SessionInvocation.repo_token` support in `agentd-runner` so private HTTPS repository clones can authenticate with a clone-only bearer token without exposing the token in `podman create` arguments, git argv, or persistent git config.
 - Added extraction-ready tracing bootstrap in `agentd` plus structured runner lifecycle/session events, with timestamped JSON logs to stderr by default, an `info` default filter so normal session lifecycle records are visible without extra env setup, `runner.session_error` for pre-completion failures, stderr fallback for runner failure diagnostics when no tracing subscriber is installed, `AGENTD_LOG_FORMAT=json|pretty` for format selection, and `RUST_LOG`/`AGENTD_LOG` filter control.
-- Added a real foreground `agentd` daemon with single-instance PID-file locking, a local Unix-socket operator interface, `agentd run` manual session dispatch, configurable daemon socket/PID paths, and optional per-agent `repo_token_source` resolution for clone-only HTTPS authentication.
+- Added a real foreground `agentd` daemon with single-instance PID-file locking, a local Unix-socket operator interface, `agentd run` manual session dispatch, configurable daemon socket/PID paths, and optional per-profile `repo_token_source` resolution for clone-only HTTPS authentication.
 - Added runner-owned startup reconciliation for daemon-managed Podman resources so daemon startup removes dead runner-owned `agentd-*` containers and orphaned runner-owned `agentd-*` secrets before binding the operator socket, and emits structured startup reconciliation events.
 
 ### Changed
@@ -21,11 +25,11 @@ All notable changes to this project will be documented in this file.
 - Removed the vendored methodology skill distribution layer from the repository, including loadout configuration, manifests, sync and verify scripts, vendored skill copies, and related smoke tests.
 - Replaced the old skill-focused GitHub Actions workflow with a Rust workspace CI workflow that runs `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace`, and `cargo test --workspace`.
 - Updated repository documentation to describe methodology skills as externally provided rather than vendored in `agentd`.
-- Tightened static agent config parsing so file-loaded `methodology_dir` values resolve from the config file's absolute directory and agent or credential names with leading or trailing whitespace are rejected.
+- Tightened static profile config parsing so file-loaded `methodology_dir` values resolve from the config file's absolute directory and profile or credential names with leading or trailing whitespace are rejected.
 - Narrowed `agentd-runner` repository checkout to `https://`, `http://`, and `git://` `repo_url` forms only, rejecting local paths, SSH-style URLs, and credential-bearing URLs up front while private HTTPS authentication now flows through the explicit `repo_token` invocation field instead of URL userinfo or generic runtime env injection.
 - Restored acceptance of trailing-slash repository remotes such as `https://example.com/repo.git/` while keeping `agentd-runner` restricted to public `https://`, `http://`, and `git://` `repo_url` schemes.
 - Updated `agentd-runner` environment injection so empty resolved values are passed as direct `NAME=` assignments while non-empty values continue through Podman-managed secrets, avoiding Podman's zero-byte secret rejection without exposing non-empty secrets in `podman create` arguments.
-- Updated `agentd-runner` session startup to create a standard `/home/{username}` workspace, run `runa run` as an unprivileged unix user via `gosu`, require `useradd` and `gosu` in the base image contract, and reject configured agent names that are invalid or reserved unix usernames during config validation.
+- Updated `agentd-runner` session startup to create a standard `/home/{username}` workspace, run `runa run` as an unprivileged unix user via `gosu`, require `useradd` and `gosu` in the base image contract, and reject configured profile names that are invalid or reserved unix usernames during config validation.
 - Replaced raw runner lifecycle stderr logging with structured `tracing` events carrying `container_name`, `session_id`, stage, lifecycle kind, and error fields, and added explicit session start, outcome, and teardown events around `run_session`.
-- Scoped startup reconciliation ownership per daemon instance so only runner-created resources named `agentd-{daemon8}-{agent}-{session16}` and `agentd-{daemon8}-{session16}-{suffix}` are eligible for startup cleanup, while resources owned by other daemon instances or legacy pre-namespace names are ignored.
+- Scoped startup reconciliation ownership per daemon instance so only runner-created resources named `agentd-{daemon8}-{profile}-{session16}` and `agentd-{daemon8}-{session16}-{suffix}` are eligible for startup cleanup, while resources owned by other daemon instances or legacy pre-namespace names are ignored.
 - Restored collision-resistant runner session IDs by expanding generated session suffixes to `session16` naming, and made daemon-instance derivation reject relative daemon runtime paths with typed config errors instead of hashing ambiguous `Config::from_str` paths.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Early development. The current build supports:
 - foreground single-instance daemon startup
 - startup reconciliation of stale runner-managed Podman containers and secrets owned by the starting daemon instance before accepting new sessions
 - local Unix-socket operator control
-- manual `agentd run <agent> <repo> [--work-unit <wu>]` session triggers
+- manual `agentd run <profile> <repo> [--work-unit <wu>]` session triggers
 - clone-only repository auth through optional `repo_token_source`
 
 ## Architecture Overview
@@ -17,8 +17,8 @@ The system is organized as a Rust workspace with focused crates for composition,
 
 ## Quick Start
 
-1. Start from [examples/agentd.toml](examples/agentd.toml) and define at least one agent.
-2. Export any runtime credential env vars named by `[[agents.credentials]].source`.
+1. Start from [examples/agentd.toml](examples/agentd.toml) and define at least one profile.
+2. Export any runtime credential env vars named by `[[profiles.credentials]].source`.
 3. Optionally export the env var named by `repo_token_source` when private HTTPS clones need a bearer token for `git clone`.
 4. Start the daemon:
 
@@ -29,7 +29,7 @@ agentd daemon --config /etc/agentd/agentd.toml
 `agentd` with no subcommand is the same as `agentd daemon`.
 
 Before the daemon binds its Unix socket, it reconciles stale runner-managed
-session containers named `agentd-{daemon8}-{agent}-{session16}` and orphaned
+session containers named `agentd-{daemon8}-{profile}-{session16}` and orphaned
 runner-managed secrets named `agentd-{daemon8}-{session16}-{suffix}` left
 behind by prior runs of the same daemon instance. The daemon instance id is
 derived from the configured socket and PID paths, so different runtime-path
@@ -61,7 +61,7 @@ agentd run codex https://github.com/pentaxis93/agentd.git --work-unit issue-52
 ```
 
 `agentd run` reads the same config file for daemon runtime paths. It ignores
-the `agents` registry, but the top-level config shape must still be valid, so
+the `profiles` registry, but the top-level config shape must still be valid, so
 typos like `[deamon]` fail instead of silently falling back to default daemon
 paths.
 

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -3,8 +3,8 @@
 //! Manages the podman container lifecycle: building the entrypoint script,
 //! assembling `podman create` arguments, running the container in attached
 //! mode, and classifying the exit result. The container runs as root (UID 0)
-//! for privileged setup, then drops to an unprivileged agent user via `gosu`
-//! before executing the agent command. Exit code 125 from `podman start
+//! for privileged setup, then drops to an unprivileged profile user via `gosu`
+//! before executing the command. Exit code 125 from `podman start
 //! --attach` is ambiguous (podman infrastructure error vs. container process)
 //! and requires container state inspection to disambiguate.
 
@@ -133,14 +133,14 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 
 // Generates the shell script passed as the container entrypoint via
 // `/bin/sh -lc`. The script runs as root (UID 0) to perform privileged setup:
-// creating the agent's unix user, cloning the repository, initializing runa
-// with the methodology manifest, writing the agent command to runa config, and
+// creating the profile's unix user, cloning the repository, initializing runa
+// with the methodology manifest, writing the command to runa config, and
 // transferring home directory ownership. It then drops privileges permanently
-// via `gosu` and `exec`s `runa run` as the unprivileged agent user. `set -eu`
+// via `gosu` and `exec`s `runa run` as the unprivileged profile user. `set -eu`
 // at the top ensures any setup failure aborts immediately rather than
 // continuing with a broken workspace.
 fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) -> String {
-    let username = &spec.agent_name;
+    let username = &spec.profile_name;
     let home_dir = format!("{HOME_ROOT_DIR}/{username}");
     let repo_dir = format!("{home_dir}/repo");
     let user_group = format!("{username}:{username}");
@@ -159,7 +159,7 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
         "{METHODOLOGY_MOUNT_PATH}/manifest.toml"
     )));
     script.push_str("\ncat >> .runa/config.toml <<'EOF'\n[agent]\ncommand = ");
-    script.push_str(&toml_array(&spec.agent_command));
+    script.push_str(&toml_array(&spec.command));
     script.push_str("\nEOF\nchown -R ");
     script.push_str(&shell_quote(&user_group));
     script.push(' ');

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -127,7 +127,7 @@ fn build_container_script_terminates_git_clone_options_before_repo_url() {
         },
     );
 
-    assert!(script.contains("git clone --no-hardlinks -- '-repo.git' '/home/agent/repo'"));
+    assert!(script.contains("git clone --no-hardlinks -- '-repo.git' '/home/codex/repo'"));
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn build_container_script_disables_git_terminal_prompts() {
 fn build_container_script_creates_home_workspace_and_execs_runa_from_repo_as_unprivileged_user() {
     let script = build_container_script(
         &crate::SessionSpec {
-            agent_name: "agent_name".to_string(),
+            profile_name: "myprofile".to_string(),
             ..test_session_spec()
         },
         &SessionInvocation {
@@ -160,16 +160,16 @@ fn build_container_script_creates_home_workspace_and_execs_runa_from_repo_as_unp
         },
     );
 
-    assert!(script.contains("useradd --create-home --home-dir '/home/agent_name' --shell /bin/sh --user-group 'agent_name'"));
+    assert!(script.contains("useradd --create-home --home-dir '/home/myprofile' --shell /bin/sh --user-group 'myprofile'"));
     assert!(script.contains(
-        "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/agent_name/repo'"
+        "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/myprofile/repo'"
     ));
-    assert!(script.contains("\ncd '/home/agent_name/repo'\n"));
+    assert!(script.contains("\ncd '/home/myprofile/repo'\n"));
     assert!(script.contains("runa init --methodology '/agentd/methodology/manifest.toml'"));
     assert!(script.contains("cat >> .runa/config.toml <<'EOF'"));
-    assert!(script.contains("\nchown -R 'agent_name:agent_name' '/home/agent_name'\n"));
-    assert!(script.contains("\nexport HOME='/home/agent_name'\n"));
-    assert!(script.contains("exec gosu 'agent_name:agent_name' runa run --work-unit 'task-42'"));
+    assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
+    assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
+    assert!(script.contains("exec gosu 'myprofile:myprofile' runa run --work-unit 'task-42'"));
 }
 
 #[cfg(unix)]
@@ -362,7 +362,7 @@ fn attached_start_classifies_exit_code_125_as_runner_error() {
 }
 
 #[test]
-fn attached_start_preserves_agent_exit_code_125_when_inspection_reports_terminal_exit() {
+fn attached_start_preserves_exit_code_125_when_inspection_reports_terminal_exit() {
     let outcome = classify_attached_start_result_with_inspector(
         vec![
             "start".to_string(),
@@ -390,7 +390,7 @@ fn attached_start_classifies_nonzero_exit_as_session_failure() {
         exit_status(23),
         String::new(),
     )
-    .expect("agent exit codes should remain session outcomes");
+    .expect("nonzero exit codes should remain session outcomes");
 
     assert_eq!(outcome, SessionOutcome::Failed { exit_code: 23 });
 }
@@ -461,7 +461,7 @@ fn logs_attached_start_finalization_failures_with_finalization_prefix() {
             "session execution",
             "agentd-agent-session",
             "session-123",
-            &RunnerError::InvalidAgentCommand,
+            &RunnerError::InvalidCommand,
         );
     });
 
@@ -472,7 +472,7 @@ fn logs_attached_start_finalization_failures_with_finalization_prefix() {
     );
     assert_eq!(
         event["fields"]["error"],
-        "agent_command must contain at least one argument"
+        "command must contain at least one argument"
     );
 }
 
@@ -650,11 +650,11 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let fixture = FakePodmanFixture::new();
     fixture.install(&FakePodmanScenario::new());
-    let agent_name = "agent_name";
+    let profile_name = "myprofile";
 
     let methodology_dir = fixture.create_methodology_dir("runner-methodology");
     let outcome = fixture.run_with_fake_podman(crate::SessionSpec {
-        agent_name: agent_name.to_string(),
+        profile_name: profile_name.to_string(),
         methodology_dir,
         environment: vec![ResolvedEnvironmentVariable {
             name: "GITHUB_TOKEN".to_string(),
@@ -686,10 +686,10 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
         .expect("secret create should include a secret name");
 
     let daemon_instance_id = test_session_spec().daemon_instance_id;
-    let container_prefix = format!("agentd-{daemon_instance_id}-{agent_name}-");
+    let container_prefix = format!("agentd-{daemon_instance_id}-{profile_name}-");
     let session_id = container_name
         .strip_prefix(&container_prefix)
-        .expect("container name should include daemon and agent prefix");
+        .expect("container name should include daemon and profile prefix");
     let stage_suffix = stage_dir_name
         .strip_prefix("agentd-session-stage-")
         .expect("staging dir should include session stage prefix");

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -25,10 +25,10 @@ pub(crate) mod test_support;
 
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
-    AgentNameValidationError, EnvironmentNameValidationError, ResolvedEnvironmentVariable,
+    EnvironmentNameValidationError, ProfileNameValidationError, ResolvedEnvironmentVariable,
     RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
-pub use validation::{validate_agent_name, validate_environment_name};
+pub use validation::{validate_environment_name, validate_profile_name};
 
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
 use lifecycle::{
@@ -42,7 +42,7 @@ use resources::{
 };
 use validation::{validate_invocation, validate_spec};
 
-/// Executes a single agent session from validation through teardown.
+/// Executes a single session from validation through teardown.
 ///
 /// Validates `spec` and `invocation`, allocates session resources (methodology
 /// staging directory, podman secrets for non-empty environment values), creates
@@ -63,11 +63,11 @@ pub fn run_session(
     let session_id = unique_suffix()?;
 
     let container_name =
-        format_container_name(&spec.daemon_instance_id, &spec.agent_name, &session_id);
+        format_container_name(&spec.daemon_instance_id, &spec.profile_name, &session_id);
     log_session_started(
         &session_id,
         &container_name,
-        &spec.agent_name,
+        &spec.profile_name,
         invocation.work_unit.is_some(),
         invocation.timeout,
     );

--- a/crates/agentd-runner/src/lifecycle.rs
+++ b/crates/agentd-runner/src/lifecycle.rs
@@ -58,7 +58,7 @@ pub(crate) fn log_lifecycle_failure<E>(
 pub(crate) fn log_session_started(
     session_id: &str,
     container_name: &str,
-    agent_name: &str,
+    profile_name: &str,
     work_unit_present: bool,
     timeout: Option<Duration>,
 ) {
@@ -66,7 +66,7 @@ pub(crate) fn log_session_started(
         event = "runner.session_started",
         session_id = session_id,
         container_name = container_name,
-        agent_name = agent_name,
+        profile_name = profile_name,
         work_unit_present = work_unit_present,
         timeout_ms = timeout.map(|value| value.as_millis() as u64),
         "runner session started"
@@ -276,14 +276,14 @@ mod tests {
             "session-123",
             "agentd-agent-session",
             "session_execution",
-            &RunnerError::InvalidAgentCommand,
+            &RunnerError::InvalidCommand,
         )
         .expect("fallback write should succeed");
 
         let rendered = String::from_utf8(output).expect("fallback output should be utf-8");
         assert_eq!(
             rendered,
-            "session session-123 container agentd-agent-session failed during session_execution: agent_command must contain at least one argument\n"
+            "session session-123 container agentd-agent-session failed during session_execution: command must contain at least one argument\n"
         );
     }
 

--- a/crates/agentd-runner/src/naming.rs
+++ b/crates/agentd-runner/src/naming.rs
@@ -5,7 +5,7 @@ pub(crate) const SESSION_ID_LEN: usize = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ContainerNameParts<'a> {
     pub(crate) daemon_instance_id: &'a str,
-    pub(crate) agent_name: &'a str,
+    pub(crate) profile_name: &'a str,
     pub(crate) session_id: &'a str,
 }
 
@@ -18,10 +18,10 @@ pub(crate) struct SecretNameParts<'a> {
 
 pub(crate) fn format_container_name(
     daemon_instance_id: &str,
-    agent_name: &str,
+    profile_name: &str,
     session_id: &str,
 ) -> String {
-    format!("{PODMAN_RESOURCE_PREFIX}{daemon_instance_id}-{agent_name}-{session_id}")
+    format!("{PODMAN_RESOURCE_PREFIX}{daemon_instance_id}-{profile_name}-{session_id}")
 }
 
 pub(crate) fn format_secret_name(
@@ -35,14 +35,14 @@ pub(crate) fn format_secret_name(
 pub(crate) fn parse_container_name(name: &str) -> Option<ContainerNameParts<'_>> {
     let suffix = name.strip_prefix(PODMAN_RESOURCE_PREFIX)?;
     let (daemon_instance_id, remainder) = suffix.split_once('-')?;
-    let (agent_name, session_id) = remainder.rsplit_once('-')?;
+    let (profile_name, session_id) = remainder.rsplit_once('-')?;
 
     (is_daemon_instance_id(daemon_instance_id)
-        && !agent_name.is_empty()
+        && !profile_name.is_empty()
         && is_session_id(session_id))
     .then_some(ContainerNameParts {
         daemon_instance_id,
-        agent_name,
+        profile_name,
         session_id,
     })
 }

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -14,10 +14,10 @@ const VALID_REMOTE_REPO_URL: &str = "https://example.com/agentd.git";
 pub(crate) fn test_session_spec() -> SessionSpec {
     SessionSpec {
         daemon_instance_id: "1a2b3c4d".to_string(),
-        agent_name: "agent".to_string(),
+        profile_name: "codex".to_string(),
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
-        agent_command: vec!["codex".to_string(), "exec".to_string()],
+        command: vec!["codex".to_string(), "exec".to_string()],
         environment: Vec::new(),
     }
 }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -10,9 +10,9 @@ use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::time::Duration;
 
-/// Static configuration for an agent session.
+/// Static configuration for a session, derived from a profile.
 ///
-/// Describes the agent's identity, container image, methodology, command, and
+/// Describes the profile identity, container image, methodology, command, and
 /// caller-resolved environment variables. Validated by
 /// [`run_session`](crate::run_session) before any resources are allocated.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,11 +21,11 @@ pub struct SessionSpec {
     /// resource names so startup reconciliation can scope ownership to one
     /// daemon instance.
     pub daemon_instance_id: String,
-    /// Agent identity string. Doubles as the in-container unix username, a
-    /// component of the container name, and the value of the `AGENT_NAME`
+    /// Profile identity string. Doubles as the in-container unix username, a
+    /// component of the container name, and the value of the `PROFILE_NAME`
     /// environment variable. Must pass
-    /// [`validate_agent_name`](crate::validate_agent_name).
-    pub agent_name: String,
+    /// [`validate_profile_name`](crate::validate_profile_name).
+    pub profile_name: String,
     /// Container image reference. The image must provide `/bin/sh`, `git`,
     /// `useradd`, `gosu`, and `runa` in `PATH`.
     pub base_image: String,
@@ -35,7 +35,7 @@ pub struct SessionSpec {
     /// Command array written into `.runa/config.toml` as the
     /// `[agent] command` value. Not a shell command — each element becomes a
     /// TOML string in the array.
-    pub agent_command: Vec<String>,
+    pub command: Vec<String>,
     /// Caller-resolved environment variables injected into the container.
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
@@ -47,7 +47,7 @@ pub struct SessionSpec {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedEnvironmentVariable {
     /// Variable name. Must not be empty, contain `,` or `=`, or collide with
-    /// runner-managed names (currently `AGENT_NAME`).
+    /// runner-managed names (currently `PROFILE_NAME`).
     pub name: String,
     /// Variable value. Empty values are legal and are injected as direct
     /// `--env NAME=` assignments rather than podman secrets, which reject
@@ -95,7 +95,7 @@ pub enum SessionOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct StartupReconciliationReport {
     /// Stale runner-managed session containers matching
-    /// `agentd-{daemon8}-{agent}-{session16}` that were removed during startup.
+    /// `agentd-{daemon8}-{profile}-{session16}` that were removed during startup.
     pub removed_container_names: Vec<String>,
     /// Orphaned runner-managed secrets matching `agentd-{daemon8}-{session16}-{suffix}`
     /// that were removed during startup.
@@ -113,10 +113,10 @@ pub enum EnvironmentNameValidationError {
     Reserved,
 }
 
-/// Error returned by [`validate_agent_name`](crate::validate_agent_name)
+/// Error returned by [`validate_profile_name`](crate::validate_profile_name)
 /// when a name violates naming rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AgentNameValidationError {
+pub enum ProfileNameValidationError {
     /// The name is not a valid unix username: must start with a lowercase
     /// letter, contain only lowercase letters, digits, `_`, or `-`, and be
     /// at most 32 characters.
@@ -128,7 +128,7 @@ pub enum AgentNameValidationError {
 
 /// Errors produced during session execution.
 ///
-/// Validation errors ([`InvalidAgentName`](Self::InvalidAgentName),
+/// Validation errors ([`InvalidProfileName`](Self::InvalidProfileName),
 /// [`InvalidBaseImage`](Self::InvalidBaseImage), etc.) are returned before
 /// any resources are allocated. Resource and execution errors
 /// ([`MissingMethodologyManifest`](Self::MissingMethodologyManifest),
@@ -142,9 +142,9 @@ pub enum RunnerError {
     /// The methodology directory does not contain `manifest.toml`. Produced
     /// during resource allocation, after spec and invocation validation pass.
     MissingMethodologyManifest { path: PathBuf },
-    /// The agent name fails unix username rules or matches a reserved system
+    /// The profile name fails unix username rules or matches a reserved system
     /// name. Produced during spec validation.
-    InvalidAgentName,
+    InvalidProfileName,
     /// The base image string is empty or has surrounding whitespace. Produced
     /// during spec validation.
     InvalidBaseImage,
@@ -153,9 +153,9 @@ pub enum RunnerError {
     /// `repo_token` without using `https://`. Produced during invocation
     /// validation.
     InvalidRepoUrl { message: String },
-    /// The agent command array is empty or contains an empty element.
+    /// The command array is empty or contains an empty element.
     /// Produced during spec validation.
-    InvalidAgentCommand,
+    InvalidCommand,
     /// An environment variable name is empty or contains `,` or `=`.
     /// Produced during spec validation.
     InvalidEnvironmentName { name: String },
@@ -190,14 +190,14 @@ impl fmt::Display for RunnerError {
                     path.display()
                 )
             }
-            RunnerError::InvalidAgentName => write!(
+            RunnerError::InvalidProfileName => write!(
                 f,
-                "agent_name must already be a unix username starting with a lowercase letter, containing only lowercase letters, digits, '_', or '-', be at most 32 characters, and not be one of the reserved system names root, nobody, daemon, bin, sys, man, or mail"
+                "profile_name must already be a unix username starting with a lowercase letter, containing only lowercase letters, digits, '_', or '-', be at most 32 characters, and not be one of the reserved system names root, nobody, daemon, bin, sys, man, or mail"
             ),
             RunnerError::InvalidBaseImage => write!(f, "base_image must not be empty"),
             RunnerError::InvalidRepoUrl { message } => write!(f, "repo_url {message}"),
-            RunnerError::InvalidAgentCommand => {
-                write!(f, "agent_command must contain at least one argument")
+            RunnerError::InvalidCommand => {
+                write!(f, "command must contain at least one argument")
             }
             RunnerError::InvalidEnvironmentName { name } => write!(
                 f,

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -2,18 +2,18 @@
 //!
 //! All validation runs before any filesystem or podman interaction, so invalid
 //! inputs are rejected without side effects. The two public validators
-//! ([`validate_agent_name`] and [`validate_environment_name`]) are also used
+//! ([`validate_profile_name`] and [`validate_environment_name`]) are also used
 //! by the configuration layer in the `agentd` crate.
 
 use crate::naming::is_daemon_instance_id;
 use crate::types::{
-    AgentNameValidationError, EnvironmentNameValidationError, RunnerError, SessionInvocation,
+    EnvironmentNameValidationError, ProfileNameValidationError, RunnerError, SessionInvocation,
     SessionSpec,
 };
 
-const AGENT_NAME_ENV: &str = "AGENT_NAME";
+const PROFILE_NAME_ENV: &str = "PROFILE_NAME";
 pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
-const RESERVED_AGENT_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys", "man", "mail"];
+const RESERVED_PROFILE_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys", "man", "mail"];
 const SUPPORTED_REPO_URL_FORMS: &str = "https://, http://, or git://";
 const SUPPORTED_REPO_URL_PREFIXES: [&str; 3] = ["https://", "http://", "git://"];
 
@@ -21,14 +21,14 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     if !is_daemon_instance_id(&spec.daemon_instance_id) {
         return Err(RunnerError::InvalidDaemonInstanceId);
     }
-    if validate_agent_name(&spec.agent_name).is_err() {
-        return Err(RunnerError::InvalidAgentName);
+    if validate_profile_name(&spec.profile_name).is_err() {
+        return Err(RunnerError::InvalidProfileName);
     }
     if spec.base_image.trim().is_empty() || spec.base_image != spec.base_image.trim() {
         return Err(RunnerError::InvalidBaseImage);
     }
-    if spec.agent_command.is_empty() || spec.agent_command.iter().any(|arg| arg.is_empty()) {
-        return Err(RunnerError::InvalidAgentCommand);
+    if spec.command.is_empty() || spec.command.iter().any(|arg| arg.is_empty()) {
+        return Err(RunnerError::InvalidCommand);
     }
 
     for variable in &spec.environment {
@@ -74,7 +74,7 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
 /// Validates an environment variable name against naming rules.
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
-/// runner-managed names (currently `AGENT_NAME` and `AGENTD_REPO_TOKEN`). Used both by
+/// runner-managed names (currently `PROFILE_NAME` and `AGENTD_REPO_TOKEN`). Used both by
 /// [`run_session`](crate::run_session) during spec validation and by the
 /// configuration layer for credential name validation.
 pub fn validate_environment_name(name: &str) -> Result<(), EnvironmentNameValidationError> {
@@ -88,19 +88,19 @@ pub fn validate_environment_name(name: &str) -> Result<(), EnvironmentNameValida
     Ok(())
 }
 
-/// Validates an agent name against unix username rules and reserved names.
+/// Validates a profile name against unix username rules and reserved names.
 ///
 /// The name must start with a lowercase ASCII letter, contain only lowercase
 /// letters, digits, `_`, or `-`, and be at most 32 characters. Names matching
 /// reserved system usernames (`root`, `nobody`, `daemon`, `bin`, `sys`, `man`,
 /// `mail`) are also rejected. Used both by [`run_session`](crate::run_session)
 /// during spec validation and by the configuration layer.
-pub fn validate_agent_name(name: &str) -> Result<(), AgentNameValidationError> {
+pub fn validate_profile_name(name: &str) -> Result<(), ProfileNameValidationError> {
     if !is_valid_unix_username(name) {
-        return Err(AgentNameValidationError::Invalid);
+        return Err(ProfileNameValidationError::Invalid);
     }
-    if is_reserved_agent_name(name) {
-        return Err(AgentNameValidationError::Reserved);
+    if is_reserved_profile_name(name) {
+        return Err(ProfileNameValidationError::Reserved);
     }
 
     Ok(())
@@ -111,7 +111,7 @@ pub fn validate_agent_name(name: &str) -> Result<(), AgentNameValidationError> {
 /// These names are reserved — callers cannot use them in
 /// [`SessionSpec::environment`] because the runner injects them directly.
 pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> [(&str, &str); 1] {
-    [(AGENT_NAME_ENV, &spec.agent_name)]
+    [(PROFILE_NAME_ENV, &spec.profile_name)]
 }
 
 fn is_supported_repo_url(repo_url: &str) -> bool {
@@ -172,11 +172,11 @@ fn repo_token_requires_https_error() -> RunnerError {
 }
 
 fn is_reserved_environment_name(name: &str) -> bool {
-    matches!(name, AGENT_NAME_ENV | REPO_TOKEN_ENV)
+    matches!(name, PROFILE_NAME_ENV | REPO_TOKEN_ENV)
 }
 
-fn is_reserved_agent_name(name: &str) -> bool {
-    RESERVED_AGENT_NAMES.contains(&name)
+fn is_reserved_profile_name(name: &str) -> bool {
+    RESERVED_PROFILE_NAMES.contains(&name)
 }
 
 fn is_valid_unix_username(name: &str) -> bool {
@@ -200,12 +200,12 @@ fn is_valid_unix_username(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ResolvedEnvironmentVariable, test_support::test_session_spec};
+    use crate::{test_support::test_session_spec, ResolvedEnvironmentVariable};
     use std::path::PathBuf;
 
     #[test]
     fn validate_spec_rejects_reserved_environment_names() {
-        for reserved_name in ["AGENT_NAME", REPO_TOKEN_ENV] {
+        for reserved_name in ["PROFILE_NAME", REPO_TOKEN_ENV] {
             let error = validate_spec(&SessionSpec {
                 environment: vec![ResolvedEnvironmentVariable {
                     name: reserved_name.to_string(),
@@ -295,93 +295,95 @@ mod tests {
     }
 
     #[test]
-    fn validate_spec_accepts_valid_unix_agent_names() {
-        for agent_name in [
-            "agent",
-            "agent-01",
-            "agent_01",
-            "agent-name_01",
+    fn validate_spec_accepts_valid_unix_profile_names() {
+        for profile_name in [
+            "codex",
+            "codex-01",
+            "codex_01",
+            "codex-name_01",
             &"a".repeat(32),
         ] {
             validate_spec(&SessionSpec {
-                agent_name: agent_name.to_string(),
+                profile_name: profile_name.to_string(),
                 ..test_session_spec()
             })
-            .unwrap_or_else(|error| panic!("expected {agent_name:?} to be accepted, got {error}"));
-        }
-    }
-
-    #[test]
-    fn validate_agent_name_accepts_valid_unix_agent_names() {
-        for agent_name in [
-            "agent",
-            "agent-01",
-            "agent_01",
-            "agent-name_01",
-            &"a".repeat(32),
-        ] {
-            validate_agent_name(agent_name).unwrap_or_else(|error| {
-                panic!("expected {agent_name:?} to be accepted, got {error:?}")
+            .unwrap_or_else(|error| {
+                panic!("expected {profile_name:?} to be accepted, got {error}")
             });
         }
     }
 
     #[test]
-    fn validate_agent_name_rejects_invalid_unix_usernames() {
-        for agent_name in [
+    fn validate_profile_name_accepts_valid_unix_profile_names() {
+        for profile_name in [
+            "codex",
+            "codex-01",
+            "codex_01",
+            "codex-name_01",
+            &"a".repeat(32),
+        ] {
+            validate_profile_name(profile_name).unwrap_or_else(|error| {
+                panic!("expected {profile_name:?} to be accepted, got {error:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn validate_profile_name_rejects_invalid_unix_usernames() {
+        for profile_name in [
             "",
             "   ",
-            "Agent 01",
-            "123agent",
+            "Codex 01",
+            "123codex",
             "---",
-            "_agent",
-            "agent__name!",
+            "_codex",
+            "codex__name!",
             &format!("a{}", "b".repeat(32)),
         ] {
-            let error = validate_agent_name(agent_name)
+            let error = validate_profile_name(profile_name)
                 .expect_err("invalid unix usernames should be rejected");
 
             assert_eq!(
                 error,
-                AgentNameValidationError::Invalid,
-                "expected Invalid for {agent_name:?}, got {error:?}"
+                ProfileNameValidationError::Invalid,
+                "expected Invalid for {profile_name:?}, got {error:?}"
             );
         }
     }
 
     #[test]
-    fn validate_agent_name_rejects_reserved_names() {
-        for agent_name in ["root", "nobody", "daemon", "bin", "sys", "man", "mail"] {
-            let error =
-                validate_agent_name(agent_name).expect_err("reserved names should be rejected");
+    fn validate_profile_name_rejects_reserved_names() {
+        for profile_name in ["root", "nobody", "daemon", "bin", "sys", "man", "mail"] {
+            let error = validate_profile_name(profile_name)
+                .expect_err("reserved names should be rejected");
 
             assert_eq!(
                 error,
-                AgentNameValidationError::Reserved,
-                "expected Reserved for {agent_name:?}, got {error:?}"
+                ProfileNameValidationError::Reserved,
+                "expected Reserved for {profile_name:?}, got {error:?}"
             );
         }
     }
 
     #[test]
-    fn validate_spec_maps_invalid_or_reserved_agent_names_to_runner_error() {
-        for agent_name in ["123agent", "root"] {
+    fn validate_spec_maps_invalid_or_reserved_profile_names_to_runner_error() {
+        for profile_name in ["123codex", "root"] {
             let error = validate_spec(&SessionSpec {
-                agent_name: agent_name.to_string(),
+                profile_name: profile_name.to_string(),
                 ..test_session_spec()
             })
-            .expect_err("invalid sanitized agent names should be rejected");
+            .expect_err("invalid profile names should be rejected");
 
             assert!(
-                matches!(error, RunnerError::InvalidAgentName),
-                "expected InvalidAgentName for {agent_name:?}, got {error:?}"
+                matches!(error, RunnerError::InvalidProfileName),
+                "expected InvalidProfileName for {profile_name:?}, got {error:?}"
             );
         }
     }
 
     #[test]
-    fn invalid_agent_name_error_mentions_format_and_reserved_names() {
-        let message = RunnerError::InvalidAgentName.to_string();
+    fn invalid_profile_name_error_mentions_format_and_reserved_names() {
+        let message = RunnerError::InvalidProfileName.to_string();
 
         assert!(
             message.contains("must already be a unix username"),
@@ -606,10 +608,10 @@ mod tests {
     }
 
     #[test]
-    fn run_session_rejects_reserved_agent_name_before_methodology_validation() {
+    fn run_session_rejects_reserved_profile_name_before_methodology_validation() {
         let error = crate::run_session(
             SessionSpec {
-                agent_name: "root".to_string(),
+                profile_name: "root".to_string(),
                 methodology_dir: PathBuf::from("/tmp/does-not-exist"),
                 ..test_session_spec()
             },
@@ -620,11 +622,11 @@ mod tests {
                 timeout: None,
             },
         )
-        .expect_err("reserved agent name should be rejected before setup");
+        .expect_err("reserved profile name should be rejected before setup");
 
         assert!(
-            matches!(error, RunnerError::InvalidAgentName),
-            "expected InvalidAgentName, got {error:?}"
+            matches!(error, RunnerError::InvalidProfileName),
+            "expected InvalidProfileName, got {error:?}"
         );
     }
 }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -30,10 +30,10 @@ fn succeeds_without_timeout_and_cleans_up_container() {
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            agent_name: "success-agent".to_string(),
+            profile_name: "success-agent".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            agent_command: vec![
+            command: vec![
                 "codex".to_string(),
                 "exec".to_string(),
                 "--sandbox".to_string(),
@@ -79,10 +79,10 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            agent_name: "mixed-env-agent".to_string(),
+            profile_name: "mixed-env-agent".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            agent_command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["codex".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -129,10 +129,10 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            agent_name: "failure-agent".to_string(),
+            profile_name: "failure-agent".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            agent_command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["codex".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -175,10 +175,10 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            agent_name: "failure-agent-125".to_string(),
+            profile_name: "failure-agent-125".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            agent_command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["codex".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -222,10 +222,10 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            agent_name: "comma-methodology-agent".to_string(),
+            profile_name: "comma-methodology-agent".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            agent_command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["codex".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -266,10 +266,10 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            agent_name: "timeout-agent".to_string(),
+            profile_name: "timeout-agent".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            agent_command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["codex".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -313,10 +313,10 @@ fn releases_session_secret_after_container_reaches_running_state() {
         run_session(
             SessionSpec {
                 daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-                agent_name: "running-secret-agent".to_string(),
+                profile_name: "running-secret-agent".to_string(),
                 base_image: image,
                 methodology_dir,
-                agent_command: vec!["codex".to_string(), "exec".to_string()],
+                command: vec!["codex".to_string(), "exec".to_string()],
                 environment: vec![
                     ResolvedEnvironmentVariable {
                         name: "GITHUB_TOKEN".to_string(),
@@ -352,21 +352,21 @@ fn releases_session_secret_after_container_reaches_running_state() {
 
 struct SessionFixture {
     root: PathBuf,
-    agent_name: String,
+    profile_name: String,
     baseline_runner_secret_names: BTreeSet<String>,
     repo_server: RepoHttpServer,
 }
 
 impl SessionFixture {
-    fn new(agent_name: &str) -> Self {
-        Self::new_with_repo_server(agent_name, &format!("agentd-runner-{agent_name}"))
+    fn new(profile_name: &str) -> Self {
+        Self::new_with_repo_server(profile_name, &format!("agentd-runner-{profile_name}"))
     }
 
-    fn new_with_root_prefix(agent_name: &str, root_prefix: &str) -> Self {
-        Self::new_with_repo_server(agent_name, root_prefix)
+    fn new_with_root_prefix(profile_name: &str, root_prefix: &str) -> Self {
+        Self::new_with_repo_server(profile_name, root_prefix)
     }
 
-    fn new_with_repo_server(agent_name: &str, root_prefix: &str) -> Self {
+    fn new_with_repo_server(profile_name: &str, root_prefix: &str) -> Self {
         let root = unique_temp_dir(root_prefix);
         fs::create_dir_all(&root).expect("fixture root should be created");
 
@@ -384,7 +384,7 @@ impl SessionFixture {
 
         Self {
             root,
-            agent_name: agent_name.to_string(),
+            profile_name: profile_name.to_string(),
             baseline_runner_secret_names: list_runner_secret_names(),
             repo_server: RepoHttpServer::start(repo_root),
         }
@@ -411,7 +411,7 @@ impl SessionFixture {
         fs::write(context_dir.join("Containerfile"), CONTAINERFILE)
             .expect("containerfile should be written");
 
-        let tag = format!("agentd-runner-test:{}", self.agent_name);
+        let tag = format!("agentd-runner-test:{}", self.profile_name);
         let status = Command::new("podman")
             .args(["build", "--tag", &tag, context_dir.to_str().unwrap()])
             .stdout(Stdio::inherit())
@@ -435,7 +435,7 @@ impl SessionFixture {
         );
 
         let names = String::from_utf8(output.stdout).expect("podman ps output should be utf-8");
-        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.agent_name);
+        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.profile_name);
         assert!(
             !names.lines().any(|name| name.starts_with(&expected_prefix)),
             "runner left container behind with prefix {expected_prefix}: {names}"
@@ -457,7 +457,7 @@ impl SessionFixture {
 
     fn wait_for_runner_container_to_be_running(&self, timeout: Duration) -> String {
         let deadline = Instant::now() + timeout;
-        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.agent_name);
+        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.profile_name);
 
         loop {
             let running_container_names = list_running_container_names();
@@ -481,7 +481,7 @@ impl SessionFixture {
         let expected_secret_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{session_id}-");
         let expected_container_prefix = format!(
             "agentd-{TEST_DAEMON_INSTANCE_ID}-{}-{session_id}",
-            self.agent_name
+            self.profile_name
         );
 
         loop {
@@ -808,14 +808,14 @@ EOF
         ;;
     run)
         [ -f /agentd/methodology/manifest.toml ]
-        [ "${AGENT_NAME:-}" != "" ]
+        [ "${PROFILE_NAME:-}" != "" ]
         if [ "${GITHUB_TOKEN+set}" = "set" ]; then
             [ "${GITHUB_TOKEN}" = "test-token" ]
         fi
         [ "$(id -u)" != "0" ]
-        [ "$(id -un)" = "${AGENT_NAME}" ]
-        [ "${HOME:-}" = "/home/${AGENT_NAME}" ]
-        [ "$(pwd)" = "/home/${AGENT_NAME}/repo" ]
+        [ "$(id -un)" = "${PROFILE_NAME}" ]
+        [ "${HOME:-}" = "/home/${PROFILE_NAME}" ]
+        [ "$(pwd)" = "/home/${PROFILE_NAME}/repo" ]
         [ -w "${HOME}" ]
         [ -w "${HOME}/repo" ]
         [ -f "${HOME}/repo/README.md" ]

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -24,13 +24,13 @@ fn succeeds_without_timeout_and_cleans_up_container() {
         .lock()
         .expect("podman test lock should be acquired");
 
-    let fixture = SessionFixture::new("success-agent");
+    let fixture = SessionFixture::new("success-run");
     let image = fixture.build_image();
 
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "success-agent".to_string(),
+            profile_name: "success-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec![
@@ -73,13 +73,13 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
         .lock()
         .expect("podman test lock should be acquired");
 
-    let fixture = SessionFixture::new("mixed-env-agent");
+    let fixture = SessionFixture::new("mixed-env-run");
     let image = fixture.build_image();
 
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "mixed-env-agent".to_string(),
+            profile_name: "mixed-env-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec!["codex".to_string(), "exec".to_string()],
@@ -123,13 +123,13 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
         .lock()
         .expect("podman test lock should be acquired");
 
-    let fixture = SessionFixture::new("failure-agent");
+    let fixture = SessionFixture::new("failure-run");
     let image = fixture.build_image();
 
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "failure-agent".to_string(),
+            profile_name: "failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec!["codex".to_string(), "exec".to_string()],
@@ -169,13 +169,13 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
         .lock()
         .expect("podman test lock should be acquired");
 
-    let fixture = SessionFixture::new("failure-agent-125");
+    let fixture = SessionFixture::new("failure-run-125");
     let image = fixture.build_image();
 
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "failure-agent-125".to_string(),
+            profile_name: "failure-run-125".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec!["codex".to_string(), "exec".to_string()],
@@ -214,7 +214,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new_with_root_prefix(
-        "comma-methodology-agent",
+        "comma-methodology-run",
         "agentd-runner,comma,methodology",
     );
     let image = fixture.build_image();
@@ -222,7 +222,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "comma-methodology-agent".to_string(),
+            profile_name: "comma-methodology-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec!["codex".to_string(), "exec".to_string()],
@@ -260,13 +260,13 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
         .lock()
         .expect("podman test lock should be acquired");
 
-    let fixture = SessionFixture::new("timeout-agent");
+    let fixture = SessionFixture::new("timeout-run");
     let image = fixture.build_image();
 
     let outcome = run_session(
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "timeout-agent".to_string(),
+            profile_name: "timeout-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec!["codex".to_string(), "exec".to_string()],
@@ -304,7 +304,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
         .lock()
         .expect("podman test lock should be acquired");
 
-    let fixture = SessionFixture::new("running-secret-agent");
+    let fixture = SessionFixture::new("running-secret-run");
     let image = fixture.build_image();
     let methodology_dir = fixture.methodology_dir();
     let repo_url = fixture.repo_url();
@@ -313,7 +313,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
         run_session(
             SessionSpec {
                 daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-                profile_name: "running-secret-agent".to_string(),
+                profile_name: "running-secret-run".to_string(),
                 base_image: image,
                 methodology_dir,
                 command: vec!["codex".to_string(), "exec".to_string()],

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -1,8 +1,8 @@
-//! TOML configuration parsing and validation for the daemon and agent registry.
+//! TOML configuration parsing and validation for the daemon and profile registry.
 //!
 //! Bridges operator-facing configuration to daemon dispatch and the runner's
 //! [`SessionSpec`] model. Validation here is stricter than the runner's own
-//! validation — it enforces uniqueness (no duplicate agent or credential
+//! validation — it enforces uniqueness (no duplicate profile or credential
 //! names), non-empty fields, and whitespace hygiene in addition to the
 //! runner's format and reservation rules. Relative daemon runtime paths and
 //! `methodology_dir` are resolved against the configuration file location when
@@ -15,13 +15,13 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use agentd_runner::{RunnerError, validate_agent_name, validate_environment_name};
+use agentd_runner::{RunnerError, validate_environment_name, validate_profile_name};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-/// Validated daemon and agent registry parsed from a TOML configuration file.
+/// Validated daemon and profile registry parsed from a TOML configuration file.
 ///
-/// Guarantees that daemon runtime paths are present, all agent names are
+/// Guarantees that daemon runtime paths are present, all profile names are
 /// unique and valid, all required fields are non-empty, and all credential
 /// names are valid environment variable names. Relative daemon runtime paths
 /// and `methodology_dir` paths are resolved against the configuration file's
@@ -29,7 +29,7 @@ use sha2::{Digest, Sha256};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     daemon: DaemonConfig,
-    agents: Vec<AgentConfig>,
+    profiles: Vec<ProfileConfig>,
 }
 
 impl Config {
@@ -45,9 +45,9 @@ impl Config {
         Self::parse(&contents, base_dir.as_deref())
     }
 
-    /// Returns all configured agents.
-    pub fn agents(&self) -> &[AgentConfig] {
-        &self.agents
+    /// Returns all configured profiles.
+    pub fn profiles(&self) -> &[ProfileConfig] {
+        &self.profiles
     }
 
     /// Returns the daemon-wide runtime paths.
@@ -55,55 +55,55 @@ impl Config {
         &self.daemon
     }
 
-    /// Looks up an agent by name. Returns `None` if no agent matches.
-    pub fn agent(&self, name: &str) -> Option<&AgentConfig> {
-        self.agents.iter().find(|agent| agent.name == name)
+    /// Looks up a profile by name. Returns `None` if no profile matches.
+    pub fn profile(&self, name: &str) -> Option<&ProfileConfig> {
+        self.profiles.iter().find(|profile| profile.name == name)
     }
 
     fn parse(contents: &str, base_dir: Option<&Path>) -> Result<Self, ConfigError> {
         let raw: RawConfig = toml::from_str(contents)?;
         let daemon = DaemonConfig::parse(raw.daemon, base_dir)?;
 
-        if raw.agents.is_empty() {
-            return Err(ConfigError::NoAgents);
+        if raw.profiles.is_empty() {
+            return Err(ConfigError::NoProfiles);
         }
 
-        let mut seen_agents = HashSet::new();
-        let mut agents = Vec::with_capacity(raw.agents.len());
+        let mut seen_profiles = HashSet::new();
+        let mut profiles = Vec::with_capacity(raw.profiles.len());
 
-        for raw_agent in raw.agents {
-            validate_lookup_key("name", &raw_agent.name, None, None)?;
-            if validate_agent_name(&raw_agent.name).is_err() {
-                return Err(ConfigError::InvalidAgentName {
-                    name: raw_agent.name,
+        for raw_profile in raw.profiles {
+            validate_lookup_key("name", &raw_profile.name, None, None)?;
+            if validate_profile_name(&raw_profile.name).is_err() {
+                return Err(ConfigError::InvalidProfileName {
+                    name: raw_profile.name,
                 });
             }
 
-            if !seen_agents.insert(raw_agent.name.clone()) {
-                return Err(ConfigError::DuplicateAgentName {
-                    name: raw_agent.name,
+            if !seen_profiles.insert(raw_profile.name.clone()) {
+                return Err(ConfigError::DuplicateProfileName {
+                    name: raw_profile.name,
                 });
             }
 
             validate_non_empty(
                 "base_image",
-                &raw_agent.base_image,
-                Some(raw_agent.name.as_str()),
+                &raw_profile.base_image,
+                Some(raw_profile.name.as_str()),
                 None,
             )?;
             validate_non_empty(
                 "methodology_dir",
-                &raw_agent.methodology_dir,
-                Some(raw_agent.name.as_str()),
+                &raw_profile.methodology_dir,
+                Some(raw_profile.name.as_str()),
                 None,
             )?;
-            let repo_token_source = match raw_agent.repo_token_source {
+            let repo_token_source = match raw_profile.repo_token_source {
                 Some(value) if value.is_empty() => None,
                 Some(value) => {
                     validate_lookup_key(
                         "repo_token_source",
                         &value,
-                        Some(raw_agent.name.as_str()),
+                        Some(raw_profile.name.as_str()),
                         None,
                     )?;
                     Some(value)
@@ -111,48 +111,48 @@ impl Config {
                 None => None,
             };
 
-            if raw_agent.runa.command.is_empty() {
+            if raw_profile.runa.command.is_empty() {
                 return Err(ConfigError::EmptyCommand {
-                    agent: raw_agent.name.clone(),
+                    profile: raw_profile.name.clone(),
                 });
             }
 
-            let mut command = Vec::with_capacity(raw_agent.runa.command.len());
-            for element in raw_agent.runa.command {
+            let mut command = Vec::with_capacity(raw_profile.runa.command.len());
+            for element in raw_profile.runa.command {
                 validate_non_empty(
                     "runa.command",
                     &element,
-                    Some(raw_agent.name.as_str()),
+                    Some(raw_profile.name.as_str()),
                     None,
                 )?;
                 command.push(element);
             }
 
             let mut seen_credentials = HashSet::new();
-            let mut credentials = Vec::with_capacity(raw_agent.credentials.len());
-            for raw_credential in raw_agent.credentials {
+            let mut credentials = Vec::with_capacity(raw_profile.credentials.len());
+            for raw_credential in raw_profile.credentials {
                 validate_lookup_key(
                     "credentials.name",
                     &raw_credential.name,
-                    Some(raw_agent.name.as_str()),
+                    Some(raw_profile.name.as_str()),
                     None,
                 )?;
                 if validate_environment_name(&raw_credential.name).is_err() {
                     return Err(ConfigError::InvalidCredentialName {
-                        agent: raw_agent.name.clone(),
+                        profile: raw_profile.name.clone(),
                         name: raw_credential.name,
                     });
                 }
                 validate_non_empty(
                     "credentials.source",
                     &raw_credential.source,
-                    Some(raw_agent.name.as_str()),
+                    Some(raw_profile.name.as_str()),
                     Some(raw_credential.name.as_str()),
                 )?;
 
                 if !seen_credentials.insert(raw_credential.name.clone()) {
                     return Err(ConfigError::DuplicateCredentialName {
-                        agent: raw_agent.name.clone(),
+                        profile: raw_profile.name.clone(),
                         name: raw_credential.name,
                     });
                 }
@@ -163,10 +163,10 @@ impl Config {
                 });
             }
 
-            let methodology_dir = resolve_methodology_dir(base_dir, &raw_agent.methodology_dir);
-            agents.push(AgentConfig {
-                name: raw_agent.name,
-                base_image: raw_agent.base_image,
+            let methodology_dir = resolve_methodology_dir(base_dir, &raw_profile.methodology_dir);
+            profiles.push(ProfileConfig {
+                name: raw_profile.name,
+                base_image: raw_profile.base_image,
                 methodology_dir,
                 repo_token_source,
                 credentials,
@@ -174,7 +174,7 @@ impl Config {
             });
         }
 
-        Ok(Self { daemon, agents })
+        Ok(Self { daemon, profiles })
     }
 }
 
@@ -190,13 +190,13 @@ impl FromStr for Config {
     }
 }
 
-/// Configuration for a single agent in the registry.
+/// Configuration for a single profile in the registry.
 ///
-/// Fields are private; use the accessor methods to read values. The agent
+/// Fields are private; use the accessor methods to read values. The profile
 /// name has been validated as a legal unix username and is unique within the
 /// [`Config`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentConfig {
+pub struct ProfileConfig {
     name: String,
     base_image: String,
     methodology_dir: PathBuf,
@@ -205,13 +205,13 @@ pub struct AgentConfig {
     runa: RunaConfig,
 }
 
-impl AgentConfig {
-    /// Agent identity string, validated as a legal unix username.
+impl ProfileConfig {
+    /// Profile identity string, validated as a legal unix username.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Container image reference for this agent's sessions.
+    /// Container image reference for this profile's sessions.
     pub fn base_image(&self) -> &str {
         &self.base_image
     }
@@ -225,24 +225,24 @@ impl AgentConfig {
 
     /// Optional environment variable name resolved by the daemon at dispatch
     /// time to authenticate the runner-managed `git clone` only. This value is
-    /// not injected into the agent runtime environment.
+    /// not injected into the session runtime environment.
     pub fn repo_token_source(&self) -> Option<&str> {
         self.repo_token_source.as_deref()
     }
 
-    /// Declared credentials for this agent. Each credential's name is a
-    /// valid environment variable name, unique within this agent.
+    /// Declared credentials for this profile. Each credential's name is a
+    /// valid environment variable name, unique within this profile.
     pub fn credentials(&self) -> &[CredentialConfig] {
         &self.credentials
     }
 
-    /// Runa runtime configuration for this agent.
+    /// Runa runtime configuration for this profile.
     pub fn runa(&self) -> &RunaConfig {
         &self.runa
     }
 }
 
-/// A declared credential for an agent.
+/// A declared credential for a profile.
 ///
 /// The `name` becomes the environment variable name inside the container.
 /// The `source` is the name of an environment variable that the daemon reads
@@ -267,7 +267,7 @@ impl CredentialConfig {
     }
 }
 
-/// Runa runtime configuration for an agent.
+/// Runa runtime configuration for a profile.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunaConfig {
     command: Vec<String>,
@@ -294,7 +294,7 @@ impl DaemonConfig {
     /// configuration file at `path`.
     ///
     /// Relative daemon runtime paths are resolved against the directory
-    /// containing `path`. The agent registry is ignored entirely, but other
+    /// containing `path`. The profile registry is ignored entirely, but other
     /// top-level sections must match the daemon config schema.
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
         let contents = std::fs::read_to_string(path)?;
@@ -357,21 +357,21 @@ pub enum ConfigError {
     Io(std::io::Error),
     /// The file contains invalid TOML or violates the expected schema.
     Parse(toml::de::Error),
-    /// The configuration defines zero agents. At least one must be declared.
-    NoAgents,
-    /// Two agents share the same name.
-    DuplicateAgentName { name: String },
-    /// An agent name fails the runner's [`validate_agent_name`] rules.
-    InvalidAgentName { name: String },
-    /// Two credentials within the same agent share a name.
-    DuplicateCredentialName { agent: String, name: String },
+    /// The configuration defines zero profiles. At least one must be declared.
+    NoProfiles,
+    /// Two profiles share the same name.
+    DuplicateProfileName { name: String },
+    /// A profile name fails the runner's [`validate_profile_name`] rules.
+    InvalidProfileName { name: String },
+    /// Two credentials within the same profile share a name.
+    DuplicateCredentialName { profile: String, name: String },
     /// A credential name fails [`validate_environment_name`] (contains `,`
-    /// or `=`, or is the reserved `AGENT_NAME`).
-    InvalidCredentialName { agent: String, name: String },
+    /// or `=`, or is the reserved `PROFILE_NAME`).
+    InvalidCredentialName { profile: String, name: String },
     /// A required string field is empty or whitespace-only.
     EmptyField {
         field: &'static str,
-        agent: Option<String>,
+        profile: Option<String>,
         credential: Option<String>,
     },
     /// A lookup-key field has leading or trailing whitespace. Caught
@@ -379,13 +379,13 @@ pub enum ConfigError {
     /// whitespace itself is the error.
     FieldHasOuterWhitespace {
         field: &'static str,
-        agent: Option<String>,
+        profile: Option<String>,
         credential: Option<String>,
     },
     /// Deriving the daemon instance id requires absolute daemon runtime paths.
     RelativeDaemonRuntimePath { field: &'static str, path: PathBuf },
-    /// The `runa.command` array is empty for an agent.
-    EmptyCommand { agent: String },
+    /// The `runa.command` array is empty for a profile.
+    EmptyCommand { profile: String },
 }
 
 impl fmt::Display for ConfigError {
@@ -393,38 +393,38 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::Io(error) => write!(f, "failed to read config: {error}"),
             ConfigError::Parse(error) => write!(f, "invalid config: {error}"),
-            ConfigError::NoAgents => write!(f, "config must define at least one agent"),
-            ConfigError::DuplicateAgentName { name } => {
-                write!(f, "duplicate agent name: {name}")
+            ConfigError::NoProfiles => write!(f, "config must define at least one profile"),
+            ConfigError::DuplicateProfileName { name } => {
+                write!(f, "duplicate profile name: {name}")
             }
-            ConfigError::InvalidAgentName { name } => {
+            ConfigError::InvalidProfileName { name } => {
                 write!(
                     f,
-                    "invalid agent name '{name}'; {}",
-                    RunnerError::InvalidAgentName
+                    "invalid profile name '{name}'; {}",
+                    RunnerError::InvalidProfileName
                 )
             }
-            ConfigError::DuplicateCredentialName { agent, name } => {
+            ConfigError::DuplicateCredentialName { profile, name } => {
                 write!(
                     f,
-                    "agent '{agent}' defines duplicate credential name '{name}'"
+                    "profile '{profile}' defines duplicate credential name '{name}'"
                 )
             }
-            ConfigError::InvalidCredentialName { agent, name } => {
+            ConfigError::InvalidCredentialName { profile, name } => {
                 write!(
                     f,
-                    "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use reserved name 'AGENT_NAME'"
+                    "profile '{profile}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use reserved name 'PROFILE_NAME'"
                 )
             }
             ConfigError::EmptyField {
                 field,
-                agent,
+                profile,
                 credential,
             } => {
                 write!(f, "field '{field}' must not be empty")?;
 
-                if let Some(agent) = agent {
-                    write!(f, " for agent '{agent}'")?;
+                if let Some(profile) = profile {
+                    write!(f, " for profile '{profile}'")?;
                 }
                 if let Some(credential) = credential {
                     write!(f, " credential '{credential}'")?;
@@ -434,7 +434,7 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                agent,
+                profile,
                 credential,
             } => {
                 write!(
@@ -442,8 +442,8 @@ impl fmt::Display for ConfigError {
                     "field '{field}' must not have leading or trailing whitespace"
                 )?;
 
-                if let Some(agent) = agent {
-                    write!(f, " for agent '{agent}'")?;
+                if let Some(profile) = profile {
+                    write!(f, " for profile '{profile}'")?;
                 }
                 if let Some(credential) = credential {
                     write!(f, " credential '{credential}'")?;
@@ -458,8 +458,8 @@ impl fmt::Display for ConfigError {
                     path.display()
                 )
             }
-            ConfigError::EmptyCommand { agent } => {
-                write!(f, "agent '{agent}' must define a non-empty runa.command")
+            ConfigError::EmptyCommand { profile } => {
+                write!(f, "profile '{profile}' must define a non-empty runa.command")
             }
         }
     }
@@ -493,7 +493,7 @@ struct RawConfig {
     #[serde(default)]
     daemon: RawDaemonConfig,
     #[serde(default)]
-    agents: Vec<RawAgentConfig>,
+    profiles: Vec<RawProfileConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -501,8 +501,8 @@ struct RawConfig {
 struct RawDaemonOnlyConfig {
     #[serde(default)]
     daemon: RawDaemonConfig,
-    #[serde(default, rename = "agents")]
-    _agents: Option<toml::Value>,
+    #[serde(default, rename = "profiles")]
+    _profiles: Option<toml::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -525,7 +525,7 @@ impl Default for RawDaemonConfig {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawAgentConfig {
+struct RawProfileConfig {
     name: String,
     base_image: String,
     methodology_dir: String,
@@ -596,13 +596,13 @@ fn hex_encode(bytes: &[u8]) -> String {
 fn validate_non_empty(
     field: &'static str,
     value: &str,
-    agent: Option<&str>,
+    profile: Option<&str>,
     credential: Option<&str>,
 ) -> Result<(), ConfigError> {
     if value.trim().is_empty() {
         return Err(ConfigError::EmptyField {
             field,
-            agent: agent.map(str::to_owned),
+            profile: profile.map(str::to_owned),
             credential: credential.map(str::to_owned),
         });
     }
@@ -613,15 +613,15 @@ fn validate_non_empty(
 fn validate_lookup_key(
     field: &'static str,
     value: &str,
-    agent: Option<&str>,
+    profile: Option<&str>,
     credential: Option<&str>,
 ) -> Result<(), ConfigError> {
-    validate_non_empty(field, value, agent, credential)?;
+    validate_non_empty(field, value, profile, credential)?;
 
     if value != value.trim() {
         return Err(ConfigError::FieldHasOuterWhitespace {
             field,
-            agent: agent.map(str::to_owned),
+            profile: profile.map(str::to_owned),
             credential: credential.map(str::to_owned),
         });
     }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -121,7 +121,7 @@ impl From<serde_json::Error> for ClientError {
 enum RequestMessage {
     Ping,
     Run {
-        agent: String,
+        profile: String,
         repo_url: String,
         work_unit: Option<String>,
     },
@@ -338,7 +338,7 @@ pub fn request_run(
     match send_request(
         config.socket_path(),
         &RequestMessage::Run {
-            agent: request.agent.clone(),
+            profile: request.profile.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
         },
@@ -424,13 +424,13 @@ fn handle_connection_inner(
     let response = match request {
         RequestMessage::Ping => ResponseMessage::Pong,
         RequestMessage::Run {
-            agent,
+            profile,
             repo_url,
             work_unit,
         } => match dispatch_run(
             config,
             &RunRequest {
-                agent,
+                profile,
                 repo_url,
                 work_unit,
             },
@@ -711,15 +711,15 @@ mod tests {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -10,7 +10,7 @@ use crate::config::{Config, ConfigError};
 /// Parameters for a daemon run request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunRequest {
-    pub agent: String,
+    pub profile: String,
     pub repo_url: String,
     pub work_unit: Option<String>,
 }
@@ -18,11 +18,11 @@ pub struct RunRequest {
 /// Errors produced while mapping a run request into a runner session.
 #[derive(Debug)]
 pub enum DispatchError {
-    UnknownAgent {
-        agent: String,
+    UnknownProfile {
+        profile: String,
     },
     MissingCredentialSource {
-        agent: String,
+        profile: String,
         credential: String,
         source: String,
     },
@@ -33,14 +33,14 @@ pub enum DispatchError {
 impl fmt::Display for DispatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnknownAgent { agent } => write!(f, "unknown agent '{agent}'"),
+            Self::UnknownProfile { profile } => write!(f, "unknown profile '{profile}'"),
             Self::MissingCredentialSource {
-                agent,
+                profile,
                 credential,
                 source,
             } => write!(
                 f,
-                "agent '{agent}' credential '{credential}' requires daemon environment variable '{source}'"
+                "profile '{profile}' credential '{credential}' requires daemon environment variable '{source}'"
             ),
             Self::Config(error) => write!(f, "{error}"),
             Self::Runner(error) => write!(f, "{error}"),
@@ -93,26 +93,26 @@ impl SessionExecutor for RunnerSessionExecutor {
     }
 }
 
-/// Resolve a named agent plus run request into a runner session and run it.
+/// Resolve a named profile plus run request into a runner session and run it.
 pub fn dispatch_run(
     config: &Config,
     request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
-    let agent = config
-        .agent(&request.agent)
-        .ok_or_else(|| DispatchError::UnknownAgent {
-            agent: request.agent.clone(),
+    let profile = config
+        .profile(&request.profile)
+        .ok_or_else(|| DispatchError::UnknownProfile {
+            profile: request.profile.clone(),
         })?;
     let daemon_instance_id = config.daemon().daemon_instance_id()?;
 
-    let environment = agent
+    let environment = profile
         .credentials()
         .iter()
         .map(|credential| {
             let value = std::env::var(credential.source()).map_err(|_| {
                 DispatchError::MissingCredentialSource {
-                    agent: agent.name().to_string(),
+                    profile: profile.name().to_string(),
                     credential: credential.name().to_string(),
                     source: credential.source().to_string(),
                 }
@@ -125,7 +125,7 @@ pub fn dispatch_run(
         })
         .collect::<Result<Vec<_>, DispatchError>>()?;
 
-    let repo_token = agent
+    let repo_token = profile
         .repo_token_source()
         .and_then(|source| std::env::var(source).ok())
         .filter(|value| !value.is_empty());
@@ -134,10 +134,10 @@ pub fn dispatch_run(
         .run_session(
             SessionSpec {
                 daemon_instance_id,
-                agent_name: agent.name().to_string(),
-                base_image: agent.base_image().to_string(),
-                methodology_dir: agent.methodology_dir().to_path_buf(),
-                agent_command: agent.runa().command().to_vec(),
+                profile_name: profile.name().to_string(),
+                base_image: profile.base_image().to_string(),
+                methodology_dir: profile.methodology_dir().to_path_buf(),
+                command: profile.runa().command().to_vec(),
                 environment,
             },
             SessionInvocation {

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -1,6 +1,6 @@
 //! Composition root for the agentd daemon.
 //!
-//! Exposes the [`config`] module for TOML-based agent configuration. The
+//! Exposes the [`config`] module for TOML-based profile configuration. The
 //! binary crate (`main.rs`) assembles runner and scheduler from the parsed
 //! configuration and starts the daemon.
 

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -45,7 +45,7 @@ enum Command {
     Daemon,
     /// Trigger a manual session through the running daemon.
     Run {
-        agent: String,
+        profile: String,
         repo: String,
         #[arg(long)]
         work_unit: Option<String>,
@@ -73,10 +73,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         None | Some(Command::Daemon) => run_daemon(Config::load(&cli.config)?),
         Some(Command::Run {
-            agent,
+            profile,
             repo,
             work_unit,
-        }) => run_client(DaemonConfig::load(&cli.config)?, agent, repo, work_unit),
+        }) => run_client(DaemonConfig::load(&cli.config)?, profile, repo, work_unit),
     }
 }
 
@@ -100,14 +100,14 @@ fn register_termination_handlers(shutdown: Arc<AtomicBool>) -> Result<(), std::i
 
 fn run_client(
     config: DaemonConfig,
-    agent: String,
+    profile: String,
     repo: String,
     work_unit: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let outcome = request_run(
         &config,
         &RunRequest {
-            agent,
+            profile,
             repo_url: repo,
             work_unit,
         },

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -50,12 +50,12 @@ fn daemon_test_config(socket_path: &Path, pid_file: &Path) -> String {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
         socket_path = socket_path.display(),
@@ -70,15 +70,15 @@ fn daemon_test_config_with_credential(socket_path: &Path, pid_file: &Path) -> St
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -336,7 +336,7 @@ fn binary_run_command_exits_non_zero_and_reports_timed_out_sessions_on_stderr() 
 }
 
 #[test]
-fn binary_run_command_succeeds_when_agent_registry_becomes_invalid_after_daemon_start() {
+fn binary_run_command_succeeds_when_profile_registry_becomes_invalid_after_daemon_start() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-invalid-registry-{}-{}",
         std::process::id(),
@@ -362,12 +362,12 @@ fn binary_run_command_succeeds_when_agent_registry_becomes_invalid_after_daemon_
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[agents]]
+[[profiles]]
 name = "Codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
             socket_path = socket_path.display(),

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -687,7 +687,7 @@ fn rejects_uppercase_profile_names_at_parse_time() {
 
 #[test]
 fn rejects_digit_prefixed_profile_names_at_parse_time() {
-    assert_invalid_profile_name_parse_error("123agent");
+    assert_invalid_profile_name_parse_error("123codex");
 }
 
 #[test]

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -16,23 +16,23 @@ fn example_config() -> String {
         .expect("example config should be readable")
 }
 
-fn assert_invalid_agent_name_parse_error(name: &str) {
+fn assert_invalid_profile_name_parse_error(name: &str) {
     let error = Config::from_str(&format!(
         r#"
-[[agents]]
+[[profiles]]
 name = "{name}"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#
     ))
-    .expect_err("invalid agent names should be rejected at parse time");
+    .expect_err("invalid profile names should be rejected at parse time");
 
     match error {
-        ConfigError::InvalidAgentName { name: invalid_name } => assert_eq!(invalid_name, name),
-        other => panic!("expected invalid agent name error, got {other}"),
+        ConfigError::InvalidProfileName { name: invalid_name } => assert_eq!(invalid_name, name),
+        other => panic!("expected invalid profile name error, got {other}"),
     }
 }
 
@@ -73,11 +73,11 @@ fn write_temp_config_under(base_dir: &Path, name: &str, contents: &str) -> PathB
 }
 
 #[test]
-fn parses_example_config_into_static_agent_settings() {
+fn parses_example_config_into_static_profile_settings() {
     let config = Config::from_str(&example_config()).expect("example config should parse");
-    let agent = config.agent("codex").expect("example agent should exist");
+    let profile = config.profile("codex").expect("example profile should exist");
 
-    assert_eq!(config.agents().len(), 1);
+    assert_eq!(config.profiles().len(), 1);
     assert_eq!(
         config.daemon().socket_path(),
         Path::new("/run/agentd/agentd.sock")
@@ -86,17 +86,17 @@ fn parses_example_config_into_static_agent_settings() {
         config.daemon().pid_file(),
         Path::new("/run/agentd/agentd.pid")
     );
-    assert_eq!(agent.name(), "codex");
-    assert_eq!(agent.base_image(), "ghcr.io/example/codex:latest");
-    assert_eq!(agent.methodology_dir(), Path::new("../groundwork"));
-    assert_eq!(agent.repo_token_source(), Some("CODEX_REPO_TOKEN"));
+    assert_eq!(profile.name(), "codex");
+    assert_eq!(profile.base_image(), "ghcr.io/example/codex:latest");
+    assert_eq!(profile.methodology_dir(), Path::new("../groundwork"));
+    assert_eq!(profile.repo_token_source(), Some("CODEX_REPO_TOKEN"));
     assert_eq!(
-        agent.runa().command(),
+        profile.runa().command(),
         &["codex".to_string(), "exec".to_string()]
     );
-    assert_eq!(agent.credentials().len(), 1);
-    assert_eq!(agent.credentials()[0].name(), "GITHUB_TOKEN");
-    assert_eq!(agent.credentials()[0].source(), "AGENTD_GITHUB_TOKEN");
+    assert_eq!(profile.credentials().len(), 1);
+    assert_eq!(profile.credentials()[0].name(), "GITHUB_TOKEN");
+    assert_eq!(profile.credentials()[0].source(), "AGENTD_GITHUB_TOKEN");
 }
 
 #[test]
@@ -104,21 +104,21 @@ fn loading_config_resolves_relative_methodology_path_from_file_location() {
     let path = write_temp_config(
         "relative-path",
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
 
     let config = Config::load(&path).expect("config file should parse");
-    let agent = config.agent("codex").expect("agent should exist");
+    let profile = config.profile("codex").expect("profile should exist");
 
     assert_eq!(
-        agent.methodology_dir(),
+        profile.methodology_dir(),
         path.parent()
             .expect("config file should have a parent directory")
             .join("../groundwork")
@@ -132,12 +132,12 @@ fn loading_config_from_a_relative_path_resolves_methodology_dir_from_an_absolute
         &current_dir.join("target"),
         "relative-load-path",
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
@@ -146,16 +146,16 @@ command = ["codex", "exec"]
         .expect("fixture path should be under the current directory");
 
     let config = Config::load(relative_path).expect("config file should parse");
-    let agent = config.agent("codex").expect("agent should exist");
+    let profile = config.profile("codex").expect("profile should exist");
 
     assert_eq!(
-        agent.methodology_dir(),
+        profile.methodology_dir(),
         path.parent()
             .expect("config file should have a parent directory")
             .join("../groundwork")
     );
     assert!(
-        agent.methodology_dir().is_absolute(),
+        profile.methodology_dir().is_absolute(),
         "loaded methodology_dir should be absolute when loaded from a file"
     );
 }
@@ -169,12 +169,12 @@ fn loading_config_resolves_relative_daemon_paths_from_file_location() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
@@ -205,12 +205,12 @@ fn loading_config_from_a_relative_path_resolves_relative_daemon_paths_from_an_ab
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
@@ -249,12 +249,12 @@ fn daemon_instance_id_is_stable_for_the_same_runtime_paths() {
 socket_path = "/run/agentd/a.sock"
 pid_file = "/run/agentd/a.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -287,12 +287,12 @@ fn daemon_instance_id_changes_when_daemon_runtime_paths_change() {
 socket_path = "/run/agentd/a.sock"
 pid_file = "/run/agentd/a.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -303,12 +303,12 @@ command = ["codex", "exec"]
 socket_path = "/run/agentd/b.sock"
 pid_file = "/run/agentd/a.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -334,12 +334,12 @@ fn daemon_instance_id_rejects_relative_daemon_runtime_paths_from_str_configs() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -363,12 +363,12 @@ command = ["codex", "exec"]
 fn parses_default_daemon_paths_when_daemon_section_is_omitted() {
     let config = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -392,12 +392,12 @@ fn daemon_instance_id_rejects_relative_pid_file_after_absolute_socket_path() {
 socket_path = "/run/agentd/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -425,12 +425,12 @@ fn parses_explicit_daemon_paths() {
 socket_path = "/tmp/agentd-test.sock"
 pid_file = "/tmp/agentd-test.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -450,42 +450,42 @@ command = ["codex", "exec"]
 fn parses_repo_token_source_as_optional_clone_auth_lookup_key() {
     let config = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "CODEX_REPO_TOKEN"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
     .expect("config should parse repo token source");
 
-    let agent = config.agent("codex").expect("agent should exist");
+    let profile = config.profile("codex").expect("profile should exist");
 
-    assert_eq!(agent.repo_token_source(), Some("CODEX_REPO_TOKEN"));
+    assert_eq!(profile.repo_token_source(), Some("CODEX_REPO_TOKEN"));
 }
 
 #[test]
 fn normalizes_empty_repo_token_source_to_none() {
     let config = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 repo_token_source = ""
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
     .expect("empty repo token source should disable clone auth");
 
-    let agent = config.agent("codex").expect("agent should exist");
+    let profile = config.profile("codex").expect("profile should exist");
 
-    assert_eq!(agent.repo_token_source(), None);
+    assert_eq!(profile.repo_token_source(), None);
 }
 
 #[test]
@@ -493,13 +493,13 @@ fn rejects_repo_token_source_with_outer_whitespace() {
     for repo_token_source in [" CODEX_REPO_TOKEN", "CODEX_REPO_TOKEN "] {
         let error = Config::from_str(&format!(
             r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#
         ))
@@ -508,11 +508,11 @@ command = ["codex", "exec"]
         match error {
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                agent,
+                profile,
                 credential,
             } => {
                 assert_eq!(field, "repo_token_source");
-                assert_eq!(agent.as_deref(), Some("codex"));
+                assert_eq!(profile.as_deref(), Some("codex"));
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -521,16 +521,16 @@ command = ["codex", "exec"]
 }
 
 #[test]
-fn rejects_unknown_fields_in_agent_config() {
+fn rejects_unknown_fields_in_profile_config() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 extra = "nope"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -548,12 +548,12 @@ fn rejects_unknown_fields_in_daemon_config() {
 socket_path = "/tmp/agentd.sock"
 extra = "nope"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -564,58 +564,58 @@ command = ["codex", "exec"]
 }
 
 #[test]
-fn rejects_duplicate_agent_names() {
+fn rejects_duplicate_profile_names() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:stable"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
-    .expect_err("duplicate agent names should be rejected");
+    .expect_err("duplicate profile names should be rejected");
 
     match error {
-        ConfigError::DuplicateAgentName { name } => assert_eq!(name, "codex"),
-        other => panic!("expected duplicate agent name error, got {other}"),
+        ConfigError::DuplicateProfileName { name } => assert_eq!(name, "codex"),
+        other => panic!("expected duplicate profile name error, got {other}"),
     }
 }
 
 #[test]
-fn rejects_configs_without_agents() {
-    let error = Config::from_str("").expect_err("configs must define at least one agent");
+fn rejects_configs_without_profiles() {
+    let error = Config::from_str("").expect_err("configs must define at least one profile");
 
-    assert!(error.to_string().contains("at least one agent"));
+    assert!(error.to_string().contains("at least one profile"));
 }
 
 #[test]
-fn rejects_duplicate_credential_names_within_an_agent() {
+fn rejects_duplicate_credential_names_within_a_profile() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_OTHER_TOKEN"
 "#,
@@ -623,8 +623,8 @@ source = "AGENTD_GITHUB_OTHER_TOKEN"
     .expect_err("duplicate credential names should be rejected");
 
     match error {
-        ConfigError::DuplicateCredentialName { agent, name } => {
-            assert_eq!(agent, "codex");
+        ConfigError::DuplicateCredentialName { profile, name } => {
+            assert_eq!(profile, "codex");
             assert_eq!(name, "GITHUB_TOKEN");
         }
         other => panic!("expected duplicate credential name error, got {other}"),
@@ -635,12 +635,12 @@ source = "AGENTD_GITHUB_OTHER_TOKEN"
 fn rejects_empty_required_string_fields() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = ""
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
@@ -650,29 +650,29 @@ command = ["codex", "exec"]
 }
 
 #[test]
-fn rejects_agent_names_with_leading_or_trailing_whitespace() {
+fn rejects_profile_names_with_leading_or_trailing_whitespace() {
     for name in [" codex", "codex "] {
         let error = Config::from_str(&format!(
             r#"
-[[agents]]
+[[profiles]]
 name = "{name}"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#
         ))
-        .expect_err("whitespace-padded agent names should be rejected");
+        .expect_err("whitespace-padded profile names should be rejected");
 
         match error {
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                agent,
+                profile,
                 credential,
             } => {
                 assert_eq!(field, "name");
-                assert_eq!(agent, None);
+                assert_eq!(profile, None);
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -681,23 +681,23 @@ command = ["codex", "exec"]
 }
 
 #[test]
-fn rejects_uppercase_agent_names_at_parse_time() {
-    assert_invalid_agent_name_parse_error("Codex");
+fn rejects_uppercase_profile_names_at_parse_time() {
+    assert_invalid_profile_name_parse_error("Codex");
 }
 
 #[test]
-fn rejects_digit_prefixed_agent_names_at_parse_time() {
-    assert_invalid_agent_name_parse_error("123agent");
+fn rejects_digit_prefixed_profile_names_at_parse_time() {
+    assert_invalid_profile_name_parse_error("123agent");
 }
 
 #[test]
-fn rejects_reserved_agent_names_at_parse_time() {
-    assert_invalid_agent_name_parse_error("root");
+fn rejects_reserved_profile_names_at_parse_time() {
+    assert_invalid_profile_name_parse_error("root");
 }
 
 #[test]
-fn rejects_agent_names_longer_than_thirty_two_characters_at_parse_time() {
-    assert_invalid_agent_name_parse_error(&format!("a{}", "b".repeat(32)));
+fn rejects_profile_names_longer_than_thirty_two_characters_at_parse_time() {
+    assert_invalid_profile_name_parse_error(&format!("a{}", "b".repeat(32)));
 }
 
 #[test]
@@ -705,15 +705,15 @@ fn rejects_credential_names_with_leading_or_trailing_whitespace() {
     for name in [" GITHUB_TOKEN", "GITHUB_TOKEN "] {
         let error = Config::from_str(&format!(
             r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "{name}"
 source = "AGENTD_GITHUB_TOKEN"
 "#
@@ -723,11 +723,11 @@ source = "AGENTD_GITHUB_TOKEN"
         match error {
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                agent,
+                profile,
                 credential,
             } => {
                 assert_eq!(field, "credentials.name");
-                assert_eq!(agent.as_deref(), Some("codex"));
+                assert_eq!(profile.as_deref(), Some("codex"));
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -739,15 +739,15 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_credential_names_containing_commas() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "TOKEN,EXTRA"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -755,8 +755,8 @@ source = "AGENTD_GITHUB_TOKEN"
     .expect_err("comma-delimited credential names should be rejected");
 
     match error {
-        ConfigError::InvalidCredentialName { agent, name } => {
-            assert_eq!(agent, "codex");
+        ConfigError::InvalidCredentialName { profile, name } => {
+            assert_eq!(profile, "codex");
             assert_eq!(name, "TOKEN,EXTRA");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -767,15 +767,15 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_credential_names_containing_equals_signs() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "FOO=BAR"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -783,8 +783,8 @@ source = "AGENTD_GITHUB_TOKEN"
     .expect_err("credential names containing '=' should be rejected");
 
     match error {
-        ConfigError::InvalidCredentialName { agent, name } => {
-            assert_eq!(agent, "codex");
+        ConfigError::InvalidCredentialName { profile, name } => {
+            assert_eq!(profile, "codex");
             assert_eq!(name, "FOO=BAR");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -795,25 +795,25 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_reserved_credential_names() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
-name = "AGENT_NAME"
+[[profiles.credentials]]
+name = "PROFILE_NAME"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
     )
     .expect_err("runner-reserved credential names should be rejected");
 
     match error {
-        ConfigError::InvalidCredentialName { agent, name } => {
-            assert_eq!(agent, "codex");
-            assert_eq!(name, "AGENT_NAME");
+        ConfigError::InvalidCredentialName { profile, name } => {
+            assert_eq!(profile, "codex");
+            assert_eq!(name, "PROFILE_NAME");
         }
         other => panic!("expected invalid credential name error, got {other}"),
     }
@@ -823,12 +823,12 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_empty_command_arrays_and_empty_command_elements() {
     let empty_command_error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = []
 "#,
     )
@@ -836,12 +836,12 @@ command = []
 
     let empty_element_error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", ""]
 "#,
     )
@@ -855,7 +855,7 @@ command = ["codex", ""]
 fn rejects_missing_runa_table() {
     let error = Config::from_str(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
@@ -894,12 +894,12 @@ fn loading_daemon_config_resolves_relative_paths_from_file_location() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "Codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
@@ -918,12 +918,12 @@ fn loading_daemon_config_uses_defaults_when_daemon_section_is_omitted() {
     let path = write_temp_config(
         "daemon-only-defaults",
         r#"
-[[agents]]
+[[profiles]]
 name = "Codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
@@ -943,12 +943,12 @@ fn loading_daemon_config_rejects_unknown_fields_in_daemon_section() {
 socket_path = "/tmp/agentd.sock"
 extra = "nope"
 
-[[agents]]
+[[profiles]]
 name = "Codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     );
@@ -967,7 +967,7 @@ fn loading_daemon_config_rejects_unknown_top_level_sections() {
 [deamon]
 socket_path = "/tmp/agentd.sock"
 
-[[agents]]
+[[profiles]]
 unexpected = "still allowed to exist here"
 "#,
     );
@@ -980,16 +980,16 @@ unexpected = "still allowed to exist here"
 }
 
 #[test]
-fn loading_daemon_config_ignores_invalid_agent_registry_entries() {
+fn loading_daemon_config_ignores_invalid_profile_registry_entries() {
     let path = write_temp_config(
-        "daemon-only-ignores-agents",
+        "daemon-only-ignores-profiles",
         r#"
 [daemon]
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
-unexpected = "daemon loader should ignore agent schema entirely"
+[[profiles]]
+unexpected = "daemon loader should ignore profile schema entirely"
 "#,
     );
 

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -127,15 +127,15 @@ fn config_in_runtime_dir(runtime_dir: &std::path::Path) -> Config {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -193,7 +193,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     let outcome = request_run(
         config.daemon(),
         &RunRequest {
-            agent: "codex".to_string(),
+            profile: "codex".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("task-42".to_string()),
         },
@@ -220,7 +220,7 @@ fn client_reports_clear_error_when_daemon_is_not_running() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            agent: "codex".to_string(),
+            profile: "codex".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: None,
         },
@@ -350,7 +350,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         request_run(
             first_config.daemon(),
             &RunRequest {
-                agent: "codex".to_string(),
+                profile: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("first".to_string()),
             },
@@ -364,7 +364,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         let outcome = request_run(
             second_config.daemon(),
             &RunRequest {
-                agent: "codex".to_string(),
+                profile: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("second".to_string()),
             },
@@ -441,7 +441,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
         request_run(
             client_config.daemon(),
             &RunRequest {
-                agent: "codex".to_string(),
+                profile: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("shutdown".to_string()),
             },
@@ -502,7 +502,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
         request_run(
             first_config.daemon(),
             &RunRequest {
-                agent: "codex".to_string(),
+                profile: "codex".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("draining".to_string()),
             },
@@ -516,7 +516,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            agent: "codex".to_string(),
+            profile: "codex".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("rejected".to_string()),
         },
@@ -563,15 +563,15 @@ fn daemon_created_runtime_socket_and_directory_are_private() {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -659,12 +659,12 @@ fn daemon_startup_rejects_relative_daemon_runtime_paths_before_claiming_runtime(
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -56,16 +56,16 @@ impl SessionExecutor for RecordingExecutor {
 fn config_with_repo_token_source(repo_token_source: &str) -> Config {
     Config::from_str(&format!(
         r#"
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#
@@ -84,7 +84,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
     let request = RunRequest {
-        agent: "codex".to_string(),
+        profile: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: Some("task-42".to_string()),
     };
@@ -104,7 +104,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
         .as_ref()
         .expect("executor should receive invocation");
 
-    assert_eq!(spec.agent_name, "codex");
+    assert_eq!(spec.profile_name, "codex");
     assert_eq!(spec.base_image, "ghcr.io/example/codex:latest");
     assert_eq!(spec.methodology_dir, Path::new("../groundwork"));
     assert_eq!(
@@ -115,7 +115,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
             .expect("daemon instance id should resolve")
     );
     assert_eq!(
-        spec.agent_command,
+        spec.command,
         vec!["codex".to_string(), "exec".to_string()]
     );
     assert_eq!(
@@ -147,7 +147,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_missing() {
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
     let request = RunRequest {
-        agent: "codex".to_string(),
+        profile: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
@@ -179,7 +179,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
     let request = RunRequest {
-        agent: "codex".to_string(),
+        profile: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
@@ -212,7 +212,7 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
     }
     let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
     let request = RunRequest {
-        agent: "codex".to_string(),
+        profile: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
@@ -223,11 +223,11 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
 
     match error {
         DispatchError::MissingCredentialSource {
-            agent,
+            profile,
             credential,
             source,
         } => {
-            assert_eq!(agent, "codex");
+            assert_eq!(profile, "codex");
             assert_eq!(credential, "GITHUB_TOKEN");
             assert_eq!(source, "AGENTD_GITHUB_TOKEN");
         }
@@ -247,18 +247,18 @@ fn dispatch_run_rejects_relative_daemon_runtime_paths_as_config_errors() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[agents]]
+[[profiles]]
 name = "codex"
 base_image = "ghcr.io/example/codex:latest"
 methodology_dir = "../groundwork"
 
-[agents.runa]
+[profiles.runa]
 command = ["codex", "exec"]
 "#,
     )
     .expect("config should parse");
     let request = RunRequest {
-        agent: "codex".to_string(),
+        profile: "codex".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -1,8 +1,8 @@
-# Static agent registry for agentd.
+# Static profile registry for agentd.
 # Session-specific inputs such as repo and work unit come from the CLI at run time.
 
-[[agents]]
-# Stable operator-facing agent name used for lookup and container identity.
+[[profiles]]
+# Stable operator-facing profile name used for lookup and container identity.
 name = "codex"
 # Prebuilt image containing the agent runtime and runa.
 base_image = "ghcr.io/example/codex:latest"
@@ -12,11 +12,11 @@ methodology_dir = "../groundwork"
 # repository authentication. This value does not flow into the agent runtime.
 repo_token_source = "CODEX_REPO_TOKEN"
 
-[agents.runa]
+[profiles.runa]
 # Static agent-runtime command executed by runa inside the container.
 command = ["codex", "exec"]
 
-[[agents.credentials]]
+[[profiles.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"
 # Environment variable name read from the daemon's own process environment.


### PR DESCRIPTION
## Summary

- Renames the config concept "agent" to "profile" across the entire workspace, distinguishing the reusable environment specification (what the operator declares) from the per-session entity (what runs inside a container)
- Unblocks #50 (cron scheduling) and #42 (README) by establishing clear terminology for where `repo`, `schedule`, and other invocation-level fields belong
- No behavioral changes — all 161 tests pass with updated names

## Changes

**Config schema**: `[[agents]]` / `[agents.runa]` / `[[agents.credentials]]` renamed to `[[profiles]]` / `[profiles.runa]` / `[[profiles.credentials]]`.

**Public types**: `AgentConfig` -> `ProfileConfig`, `AgentNameValidationError` -> `ProfileNameValidationError`, `RunnerError::InvalidAgentName` -> `InvalidProfileName`, `RunnerError::InvalidAgentCommand` -> `InvalidCommand` (prefix dropped — context already scopes the meaning).

**Session types**: `SessionSpec.agent_name` -> `profile_name`, `SessionSpec.agent_command` -> `command` (prefix dropped).

**Dispatch**: `RunRequest.agent` -> `profile`, `DispatchError::UnknownAgent` -> `UnknownProfile`.

**CLI**: `agentd run <profile> <repo>` (was `<agent>`).

**Environment variable**: `AGENT_NAME` -> `PROFILE_NAME` (injected into containers).

**Documentation**: ARCHITECTURE.md defines the profile/session distinction. README, CHANGELOG, and example config updated.

## Issue(s)

Closes #64

## Test plan

- `cargo build` compiles without errors
- `cargo test` — all 161 tests pass
- `cargo clippy` — no warnings
- `grep -rni 'agent' --include='*.rs' --include='*.toml'` — no stale references outside of `agentd`/`AGENTD_*` (daemon name, out of scope)
- Verify `examples/agentd.toml` uses `[[profiles]]` syntax
- Verify ARCHITECTURE.md defines the profile/session terminology
