### PR TITLE
Replace vendor-specific example profile name across the workspace

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ agentd is:
 agentd is not:
 - **A hosted platform**: there is no control plane operated elsewhere
 - **An AI model**: inference belongs to the chosen runtime or provider
-- **An MCP transport layer**: runtimes such as Codex or Claude Code already speak MCP directly
+- **An MCP transport layer**: MCP-capable runtimes already speak MCP directly
 - **An in-tree domain tool suite**: domain integrations live outside this workspace
 
 The key architectural consequence is simple: agentd may configure tool availability for a runtime, but it does not proxy the MCP wire protocol or ship domain-specific MCP servers inside this repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Replaced the old vendor-specific example profile across the workspace with role-based examples: operator-facing docs and `examples/agentd.toml` now show `site-builder` and `code-reviewer`, while single-profile tests and runner fixtures use realistic `site-builder` naming instead of product branding.
 - Renamed the config-level concept from "agent" to "profile" across the entire workspace: `[[agents]]` is now `[[profiles]]`, CLI positional argument is `<profile>`, types use `ProfileConfig`/`profile_name`/`validate_profile_name()`, the injected env var is `PROFILE_NAME`, and documentation, error messages, and examples reflect the new terminology. The daemon name `agentd` and references to the running entity as an "agent" are unchanged.
 - Decoupled the profile session-command interface from runa: profiles now declare a top-level `command` array, the runner executes that argv directly from the cloned repository, `AGENTD_WORK_UNIT` carries optional mission context into the runtime environment, and the runa example now shows the full operator-owned bootstrap in profile config.
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,13 @@ file — start from [`examples/agentd.toml`](examples/agentd.toml):
 
 [[profiles]]
 # Stable operator-facing profile name used for lookup and container identity.
-name = "codex"
+name = "site-builder"
 # Prebuilt image containing the agent runtime and runa.
-base_image = "ghcr.io/example/codex:latest"
+base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
-# Static session command executed from the cloned repository. This example
-# keeps runa as the runtime, so the profile owns runa initialization, the
-# agent command written into `.runa/config.toml`, and optional work-unit
-# forwarding from the generic AGENTD_WORK_UNIT contract.
+# Static session command executed from the cloned repository. This profile is
+# tightly bound to one app, so the session repo is the project being built.
 command = [
   "/bin/sh",
   "-lc",
@@ -60,7 +58,7 @@ command = [
 runa init --methodology /agentd/methodology/manifest.toml
 cat > .runa/config.toml <<'EOF'
 [agent]
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 EOF
 if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
   exec runa run --work-unit "${AGENTD_WORK_UNIT}"
@@ -70,12 +68,39 @@ exec runa run
 ]
 # Optional environment variable name resolved by the daemon for clone-only
 # repository authentication. This value does not flow into the agent runtime.
-repo_token_source = "CODEX_REPO_TOKEN"
+repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 
 [[profiles.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"
 # Environment variable name read from the daemon's own process environment.
+source = "AGENTD_GITHUB_TOKEN"
+
+[[profiles]]
+# A home-repo review agent that carries its own review configuration and scans
+# repositories beyond the repo used to launch the session.
+name = "code-reviewer"
+base_image = "ghcr.io/example/code-reviewer:latest"
+methodology_dir = "../groundwork"
+command = [
+  "/bin/sh",
+  "-lc",
+  '''
+runa init --methodology /agentd/methodology/manifest.toml
+cat > .runa/config.toml <<'EOF'
+[agent]
+command = ["code-reviewer", "exec"]
+EOF
+if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
+  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
+fi
+exec runa run
+''',
+]
+repo_token_source = "CODE_REVIEWER_REPO_TOKEN"
+
+[[profiles.credentials]]
+name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 ```
 
@@ -106,15 +131,15 @@ signal exits immediately.
 Trigger a session through the running daemon:
 
 ```bash
-agentd run codex https://github.com/pentaxis93/agentd.git --work-unit issue-42
+agentd run site-builder https://github.com/pentaxis93/agentd.git --work-unit issue-42
 ```
 
 `agentd run` reads the same config file and connects to the socket path defined
-there. This dispatches a session using the `codex` profile. Inside the
+there. This dispatches a session using the `site-builder` profile. Inside the
 container, the agent sees:
 
-- An unprivileged user with `$HOME` at `/home/codex`
-- A fresh clone of the repository at `/home/codex/repo`
+- An unprivileged user with `$HOME` at `/home/site-builder`
+- A fresh clone of the repository at `/home/site-builder/repo`
 - Read-only methodology mount at `/agentd/methodology`
 - Credentials injected as environment variables
 - `AGENTD_WORK_UNIT` when the invocation includes one

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -127,7 +127,7 @@ fn build_container_script_terminates_git_clone_options_before_repo_url() {
         },
     );
 
-    assert!(script.contains("git clone --no-hardlinks -- '-repo.git' '/home/codex/repo'"));
+    assert!(script.contains("git clone --no-hardlinks -- '-repo.git' '/home/site-builder/repo'"));
 }
 
 #[test]
@@ -169,7 +169,7 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
     assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
     assert!(script.contains("\nexport AGENTD_WORK_UNIT='task-42'\n"));
-    assert!(script.contains("exec gosu 'myprofile:myprofile' 'codex' 'exec'"));
+    assert!(script.contains("exec gosu 'myprofile:myprofile' 'site-builder' 'exec'"));
     assert!(!script.contains("runa init"));
     assert!(!script.contains(".runa/config.toml"));
     assert!(!script.contains("runa run"));
@@ -192,7 +192,7 @@ fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
 
     assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
     assert!(script.contains("\nunset AGENTD_WORK_UNIT\n"));
-    assert!(script.contains("\nexec gosu 'myprofile:myprofile' 'codex' 'exec'"));
+    assert!(script.contains("\nexec gosu 'myprofile:myprofile' 'site-builder' 'exec'"));
 }
 
 #[cfg(unix)]
@@ -290,13 +290,13 @@ fn clone_command_omits_git_auth_environment_when_repo_token_is_absent() {
 #[test]
 fn shell_join_quotes_each_argument_for_direct_exec() {
     let joined = shell_join(&[
-        "codex".to_string(),
+        "site-builder".to_string(),
         "exec".to_string(),
         "--prompt".to_string(),
         "hello world".to_string(),
     ]);
 
-    assert_eq!(joined, "'codex' 'exec' '--prompt' 'hello world'");
+    assert_eq!(joined, "'site-builder' 'exec' '--prompt' 'hello world'");
 }
 
 #[test]

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -338,7 +338,7 @@ mod tests {
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[
                         (
-                            &["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa"],
+                            &["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa"],
                             "exited",
                             "Exited (0) 10s ago",
                         ),
@@ -408,7 +408,7 @@ mod tests {
         assert_eq!(
             report.removed_container_names,
             vec![
-                "agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa".to_string(),
+                "agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa".to_string(),
                 "agentd-1a2b3c4d-review-bbbbbbbbbbbbbbbb".to_string(),
                 "agentd-1a2b3c4d-build-cccccccccccccccc".to_string(),
                 "agentd-1a2b3c4d-prepare-dddddddddddddddd".to_string(),
@@ -427,7 +427,7 @@ mod tests {
         );
         assert_eq!(
             fixture.read_log("rm-commands.log"),
-            "rm --force --ignore agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa agentd-1a2b3c4d-review-bbbbbbbbbbbbbbbb agentd-1a2b3c4d-build-cccccccccccccccc agentd-1a2b3c4d-prepare-dddddddddddddddd agentd-1a2b3c4d-init-1212121212121212\n"
+            "rm --force --ignore agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa agentd-1a2b3c4d-review-bbbbbbbbbbbbbbbb agentd-1a2b3c4d-build-cccccccccccccccc agentd-1a2b3c4d-prepare-dddddddddddddddd agentd-1a2b3c4d-init-1212121212121212\n"
         );
         assert_eq!(
             fixture.secret_commands(),
@@ -445,7 +445,7 @@ mod tests {
             &FakePodmanScenario::new()
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[(
-                        &["agentd-1a2b3c4d-codex-dddddddddddddddd"],
+                        &["agentd-1a2b3c4d-site-builder-dddddddddddddddd"],
                         "running",
                         "Up 2 minutes",
                     )]),
@@ -475,7 +475,7 @@ mod tests {
             &FakePodmanScenario::new()
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[(
-                        &["agentd-1a2b3c4d-codex-dddddddddddddddd"],
+                        &["agentd-1a2b3c4d-site-builder-dddddddddddddddd"],
                         "mystery-state",
                         "Something odd just happened",
                     )]),
@@ -507,7 +507,7 @@ mod tests {
                     &fake_podman_ps_json(&[
                         (&["agentd-proxy"], "exited", "Exited (0) 10s ago"),
                         (
-                            &["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa"],
+                            &["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa"],
                             "exited",
                             "Exited (0) 10s ago",
                         ),
@@ -530,7 +530,7 @@ mod tests {
 
         assert_eq!(
             report.removed_container_names,
-            vec!["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa".to_string(),]
+            vec!["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa".to_string(),]
         );
         assert_eq!(
             report.removed_secret_names,
@@ -538,7 +538,7 @@ mod tests {
         );
         assert_eq!(
             fixture.read_log("rm-commands.log"),
-            "rm --force --ignore agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa\n"
+            "rm --force --ignore agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa\n"
         );
         assert_eq!(
             fixture.secret_commands(),
@@ -557,12 +557,12 @@ mod tests {
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[
                         (
-                            &["agentd-1a2b3c4d-codex-AAAAAAAAAAAAAAAA"],
+                            &["agentd-1a2b3c4d-site-builder-AAAAAAAAAAAAAAAA"],
                             "exited",
                             "Exited (0) 10s ago",
                         ),
                         (
-                            &["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa"],
+                            &["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa"],
                             "exited",
                             "Exited (0) 10s ago",
                         ),
@@ -586,7 +586,7 @@ mod tests {
 
         assert_eq!(
             report.removed_container_names,
-            vec!["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa".to_string()]
+            vec!["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa".to_string()]
         );
         assert_eq!(
             report.removed_secret_names,
@@ -594,7 +594,7 @@ mod tests {
         );
         assert_eq!(
             fixture.read_log("rm-commands.log"),
-            "rm --force --ignore agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa\n"
+            "rm --force --ignore agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa\n"
         );
         assert_eq!(
             fixture.secret_commands(),
@@ -612,7 +612,7 @@ mod tests {
             &FakePodmanScenario::new()
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[(
-                        &["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa"],
+                        &["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa"],
                         "exited",
                         "Exited (0) 10s ago",
                     )]),
@@ -635,7 +635,7 @@ mod tests {
 
         assert_eq!(
             report.removed_container_names,
-            vec!["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa".to_string()]
+            vec!["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa".to_string()]
         );
         assert_eq!(
             report.removed_secret_names,
@@ -643,7 +643,7 @@ mod tests {
         );
         assert_eq!(
             fixture.read_log("rm-commands.log"),
-            "rm --force --ignore agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa\n"
+            "rm --force --ignore agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa\n"
         );
         assert_eq!(
             fixture.secret_commands(),
@@ -725,7 +725,7 @@ mod tests {
             &FakePodmanScenario::new()
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[(
-                        &["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa"],
+                        &["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa"],
                         "exited",
                         "Exited (0) 10s ago",
                     )]),
@@ -754,7 +754,7 @@ mod tests {
                         "rm",
                         "--force",
                         "--ignore",
-                        "agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa",
+                        "agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa",
                     ]
                 );
                 assert_eq!(status.code(), Some(51));
@@ -764,7 +764,7 @@ mod tests {
         }
         assert_eq!(
             fixture.read_log("rm-commands.log"),
-            "--force --ignore agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa\n"
+            "--force --ignore agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa\n"
         );
     }
 
@@ -779,12 +779,12 @@ mod tests {
                 .with_ps(CommandBehavior::from_outcome(CommandOutcome::new().stdout(
                     &fake_podman_ps_json(&[
                         (
-                            &["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa"],
+                            &["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa"],
                             "exited",
                             "Exited (0) 10s ago",
                         ),
                         (
-                            &["agentd-deadbeef-codex-bbbbbbbbbbbbbbbb"],
+                            &["agentd-deadbeef-site-builder-bbbbbbbbbbbbbbbb"],
                             "exited",
                             "Exited (0) 10s ago",
                         ),
@@ -808,7 +808,7 @@ mod tests {
 
         assert_eq!(
             report.removed_container_names,
-            vec!["agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa".to_string()]
+            vec!["agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa".to_string()]
         );
         assert_eq!(
             report.removed_secret_names,
@@ -816,7 +816,7 @@ mod tests {
         );
         assert_eq!(
             fixture.read_log("rm-commands.log"),
-            "rm --force --ignore agentd-1a2b3c4d-codex-aaaaaaaaaaaaaaaa\n"
+            "rm --force --ignore agentd-1a2b3c4d-site-builder-aaaaaaaaaaaaaaaa\n"
         );
         assert_eq!(
             fixture.secret_commands(),

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -14,10 +14,10 @@ const VALID_REMOTE_REPO_URL: &str = "https://example.com/agentd.git";
 pub(crate) fn test_session_spec() -> SessionSpec {
     SessionSpec {
         daemon_instance_id: "1a2b3c4d".to_string(),
-        profile_name: "codex".to_string(),
+        profile_name: "site-builder".to_string(),
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
-        command: vec!["codex".to_string(), "exec".to_string()],
+        command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),
     }
 }

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -299,10 +299,10 @@ mod tests {
     #[test]
     fn validate_spec_accepts_valid_unix_profile_names() {
         for profile_name in [
-            "codex",
-            "codex-01",
-            "codex_01",
-            "codex-name_01",
+            "site-builder",
+            "site-builder-01",
+            "site-builder_01",
+            "site-builder-name_01",
             &"a".repeat(32),
         ] {
             validate_spec(&SessionSpec {
@@ -318,10 +318,10 @@ mod tests {
     #[test]
     fn validate_profile_name_accepts_valid_unix_profile_names() {
         for profile_name in [
-            "codex",
-            "codex-01",
-            "codex_01",
-            "codex-name_01",
+            "site-builder",
+            "site-builder-01",
+            "site-builder_01",
+            "site-builder-name_01",
             &"a".repeat(32),
         ] {
             validate_profile_name(profile_name).unwrap_or_else(|error| {
@@ -335,11 +335,11 @@ mod tests {
         for profile_name in [
             "",
             "   ",
-            "Codex 01",
-            "123codex",
+            "Site-Builder 01",
+            "123site-builder",
             "---",
-            "_codex",
-            "codex__name!",
+            "_site-builder",
+            "site-builder__name!",
             &format!("a{}", "b".repeat(32)),
         ] {
             let error = validate_profile_name(profile_name)
@@ -369,7 +369,7 @@ mod tests {
 
     #[test]
     fn validate_spec_maps_invalid_or_reserved_profile_names_to_runner_error() {
-        for profile_name in ["123codex", "root"] {
+        for profile_name in ["123site-builder", "root"] {
             let error = validate_spec(&SessionSpec {
                 profile_name: profile_name.to_string(),
                 ..test_session_spec()

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -34,7 +34,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             command: vec![
-                "codex".to_string(),
+                "site-builder".to_string(),
                 "exec".to_string(),
                 "--sandbox".to_string(),
                 "workspace-write".to_string(),
@@ -82,7 +82,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             profile_name: "mixed-env-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -130,7 +130,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             profile_name: "unset-work-unit-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "success-without-work-unit".to_string(),
@@ -170,7 +170,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             profile_name: "failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -216,7 +216,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             profile_name: "failure-run-125".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -263,7 +263,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             profile_name: "comma-methodology-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -307,7 +307,7 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             profile_name: "timeout-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
-            command: vec!["codex".to_string(), "exec".to_string()],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -354,7 +354,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 profile_name: "running-secret-run".to_string(),
                 base_image: image,
                 methodology_dir,
-                command: vec!["codex".to_string(), "exec".to_string()],
+                command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![
                     ResolvedEnvironmentVariable {
                         name: "GITHUB_TOKEN".to_string(),
@@ -451,7 +451,8 @@ impl SessionFixture {
         let context_dir = self.root.join("image-context");
         fs::create_dir_all(&context_dir).expect("image context should be created");
 
-        fs::write(context_dir.join("codex"), CODEX_STUB).expect("codex stub should be written");
+        fs::write(context_dir.join("site-builder"), SITE_BUILDER_STUB)
+            .expect("site-builder stub should be written");
         fs::write(context_dir.join("entrypoint.sh"), ENTRYPOINT_SH)
             .expect("entrypoint script should be written");
         let containerfile = work_unit
@@ -709,9 +710,9 @@ FROM docker.io/library/debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git gosu passwd \
     && rm -rf /var/lib/apt/lists/*
-COPY codex /usr/local/bin/codex
+COPY site-builder /usr/local/bin/site-builder
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /usr/local/bin/codex /entrypoint.sh
+RUN chmod +x /usr/local/bin/site-builder /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
@@ -842,7 +843,7 @@ fn write_http_response(stream: &mut TcpStream, status: &str, body: &[u8], head_o
     }
 }
 
-const CODEX_STUB: &str = r#"#!/bin/sh
+const SITE_BUILDER_STUB: &str = r#"#!/bin/sh
 set -eu
 
 command_name="$1"
@@ -903,7 +904,7 @@ case "$command_name" in
         exit 99
         ;;
     *)
-        echo "unexpected codex subcommand: $command_name" >&2
+        echo "unexpected site-builder subcommand: $command_name" >&2
         exit 98
         ;;
 esac

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -712,11 +712,11 @@ socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "GITHUB_TOKEN"

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -51,11 +51,11 @@ socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
         socket_path = socket_path.display(),
         pid_file = pid_file.display()
@@ -70,11 +70,11 @@ socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "GITHUB_TOKEN"
@@ -198,7 +198,7 @@ fn binary_run_command_reports_clear_error_when_daemon_is_not_running() {
             "--config",
             config_path.to_str().expect("config path should be utf-8"),
             "run",
-            "codex",
+            "site-builder",
             "https://example.com/repo.git",
         ])
         .output()
@@ -245,7 +245,7 @@ fn binary_run_command_exits_non_zero_and_reports_failed_sessions_on_stderr() {
             "--config",
             config_path.to_str().expect("config path should be utf-8"),
             "run",
-            "codex",
+            "site-builder",
             "https://example.com/repo.git",
         ])
         .output()
@@ -303,7 +303,7 @@ fn binary_run_command_exits_non_zero_and_reports_timed_out_sessions_on_stderr() 
             "--config",
             config_path.to_str().expect("config path should be utf-8"),
             "run",
-            "codex",
+            "site-builder",
             "https://example.com/repo.git",
         ])
         .output()
@@ -361,11 +361,11 @@ socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
 [[profiles]]
-name = "Codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "Site-Builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
             socket_path = socket_path.display(),
             pid_file = pid_file.display()
@@ -378,7 +378,7 @@ command = ["codex", "exec"]
             "--config",
             config_path.to_str().expect("config path should be utf-8"),
             "run",
-            "codex",
+            "site-builder",
             "https://example.com/repo.git",
         ])
         .output()

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -21,10 +21,10 @@ fn assert_invalid_profile_name_parse_error(name: &str) {
         r#"
 [[profiles]]
 name = "{name}"
-base_image = "ghcr.io/example/codex:latest"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#
     ))
     .expect_err("invalid profile names should be rejected at parse time");
@@ -74,11 +74,14 @@ fn write_temp_config_under(base_dir: &Path, name: &str, contents: &str) -> PathB
 #[test]
 fn parses_example_config_into_static_profile_settings() {
     let config = Config::from_str(&example_config()).expect("example config should parse");
-    let profile = config
-        .profile("codex")
-        .expect("example profile should exist");
+    let site_builder = config
+        .profile("site-builder")
+        .expect("site-builder profile should exist");
+    let code_reviewer = config
+        .profile("code-reviewer")
+        .expect("code-reviewer profile should exist");
 
-    assert_eq!(config.profiles().len(), 1);
+    assert_eq!(config.profiles().len(), 2);
     assert_eq!(
         config.daemon().socket_path(),
         Path::new("/run/agentd/agentd.sock")
@@ -87,19 +90,51 @@ fn parses_example_config_into_static_profile_settings() {
         config.daemon().pid_file(),
         Path::new("/run/agentd/agentd.pid")
     );
-    assert_eq!(profile.name(), "codex");
-    assert_eq!(profile.base_image(), "ghcr.io/example/codex:latest");
-    assert_eq!(profile.methodology_dir(), Path::new("../groundwork"));
-    assert_eq!(profile.repo_token_source(), Some("CODEX_REPO_TOKEN"));
-    assert_eq!(profile.command()[0], "/bin/sh");
-    assert_eq!(profile.command()[1], "-lc");
-    assert!(profile.command()[2].contains("runa init --methodology"));
-    assert!(profile.command()[2].contains("/agentd/methodology/manifest.toml"));
-    assert!(profile.command()[2].contains("command = [\"codex\", \"exec\"]"));
-    assert!(profile.command()[2].contains("AGENTD_WORK_UNIT"));
-    assert_eq!(profile.credentials().len(), 1);
-    assert_eq!(profile.credentials()[0].name(), "GITHUB_TOKEN");
-    assert_eq!(profile.credentials()[0].source(), "AGENTD_GITHUB_TOKEN");
+    assert_eq!(site_builder.name(), "site-builder");
+    assert_eq!(
+        site_builder.base_image(),
+        "ghcr.io/example/site-builder:latest"
+    );
+    assert_eq!(site_builder.methodology_dir(), Path::new("../groundwork"));
+    assert_eq!(
+        site_builder.repo_token_source(),
+        Some("SITE_BUILDER_REPO_TOKEN")
+    );
+    assert_eq!(site_builder.command()[0], "/bin/sh");
+    assert_eq!(site_builder.command()[1], "-lc");
+    assert!(site_builder.command()[2].contains("runa init --methodology"));
+    assert!(site_builder.command()[2].contains("/agentd/methodology/manifest.toml"));
+    assert!(site_builder.command()[2].contains("command = [\"site-builder\", \"exec\"]"));
+    assert!(site_builder.command()[2].contains("AGENTD_WORK_UNIT"));
+    assert_eq!(site_builder.credentials().len(), 1);
+    assert_eq!(site_builder.credentials()[0].name(), "GITHUB_TOKEN");
+    assert_eq!(
+        site_builder.credentials()[0].source(),
+        "AGENTD_GITHUB_TOKEN"
+    );
+
+    assert_eq!(code_reviewer.name(), "code-reviewer");
+    assert_eq!(
+        code_reviewer.base_image(),
+        "ghcr.io/example/code-reviewer:latest"
+    );
+    assert_eq!(code_reviewer.methodology_dir(), Path::new("../groundwork"));
+    assert_eq!(
+        code_reviewer.repo_token_source(),
+        Some("CODE_REVIEWER_REPO_TOKEN")
+    );
+    assert_eq!(code_reviewer.command()[0], "/bin/sh");
+    assert_eq!(code_reviewer.command()[1], "-lc");
+    assert!(code_reviewer.command()[2].contains("runa init --methodology"));
+    assert!(code_reviewer.command()[2].contains("/agentd/methodology/manifest.toml"));
+    assert!(code_reviewer.command()[2].contains("command = [\"code-reviewer\", \"exec\"]"));
+    assert!(code_reviewer.command()[2].contains("AGENTD_WORK_UNIT"));
+    assert_eq!(code_reviewer.credentials().len(), 1);
+    assert_eq!(code_reviewer.credentials()[0].name(), "GITHUB_TOKEN");
+    assert_eq!(
+        code_reviewer.credentials()[0].source(),
+        "AGENTD_GITHUB_TOKEN"
+    );
 }
 
 #[test]
@@ -108,16 +143,18 @@ fn loading_config_resolves_relative_methodology_path_from_file_location() {
         "relative-path",
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
 
     let config = Config::load(&path).expect("config file should parse");
-    let profile = config.profile("codex").expect("profile should exist");
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
 
     assert_eq!(
         profile.methodology_dir(),
@@ -135,11 +172,11 @@ fn loading_config_from_a_relative_path_resolves_methodology_dir_from_an_absolute
         "relative-load-path",
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
     let relative_path = path
@@ -147,7 +184,9 @@ command = ["codex", "exec"]
         .expect("fixture path should be under the current directory");
 
     let config = Config::load(relative_path).expect("config file should parse");
-    let profile = config.profile("codex").expect("profile should exist");
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
 
     assert_eq!(
         profile.methodology_dir(),
@@ -171,11 +210,11 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
 
@@ -206,11 +245,11 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
     let relative_path = path
@@ -249,11 +288,11 @@ socket_path = "/run/agentd/a.sock"
 pid_file = "/run/agentd/a.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -286,11 +325,11 @@ socket_path = "/run/agentd/a.sock"
 pid_file = "/run/agentd/a.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("first config should parse");
@@ -301,11 +340,11 @@ socket_path = "/run/agentd/b.sock"
 pid_file = "/run/agentd/a.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("second config should parse");
@@ -331,11 +370,11 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -359,11 +398,11 @@ fn parses_default_daemon_paths_when_daemon_section_is_omitted() {
     let config = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse with daemon defaults");
@@ -387,11 +426,11 @@ socket_path = "/run/agentd/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -419,11 +458,11 @@ socket_path = "/tmp/agentd-test.sock"
 pid_file = "/tmp/agentd-test.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse explicit daemon paths");
@@ -443,19 +482,21 @@ fn parses_repo_token_source_as_optional_clone_auth_lookup_key() {
     let config = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
-repo_token_source = "CODEX_REPO_TOKEN"
+repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse repo token source");
 
-    let profile = config.profile("codex").expect("profile should exist");
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
 
-    assert_eq!(profile.repo_token_source(), Some("CODEX_REPO_TOKEN"));
+    assert_eq!(profile.repo_token_source(), Some("SITE_BUILDER_REPO_TOKEN"));
 }
 
 #[test]
@@ -463,33 +504,35 @@ fn normalizes_empty_repo_token_source_to_none() {
     let config = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = ""
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("empty repo token source should disable clone auth");
 
-    let profile = config.profile("codex").expect("profile should exist");
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
 
     assert_eq!(profile.repo_token_source(), None);
 }
 
 #[test]
 fn rejects_repo_token_source_with_outer_whitespace() {
-    for repo_token_source in [" CODEX_REPO_TOKEN", "CODEX_REPO_TOKEN "] {
+    for repo_token_source in [" SITE_BUILDER_REPO_TOKEN", "SITE_BUILDER_REPO_TOKEN "] {
         let error = Config::from_str(&format!(
             r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#
         ))
         .expect_err("whitespace-padded repo token sources should be rejected");
@@ -501,7 +544,7 @@ command = ["codex", "exec"]
                 credential,
             } => {
                 assert_eq!(field, "repo_token_source");
-                assert_eq!(profile.as_deref(), Some("codex"));
+                assert_eq!(profile.as_deref(), Some("site-builder"));
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -514,12 +557,12 @@ fn rejects_unknown_fields_in_profile_config() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 extra = "nope"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect_err("unknown fields should be rejected");
@@ -537,11 +580,11 @@ socket_path = "/tmp/agentd.sock"
 extra = "nope"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect_err("unknown daemon fields should be rejected");
@@ -555,24 +598,24 @@ fn rejects_duplicate_profile_names() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:stable"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:stable"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect_err("duplicate profile names should be rejected");
 
     match error {
-        ConfigError::DuplicateProfileName { name } => assert_eq!(name, "codex"),
+        ConfigError::DuplicateProfileName { name } => assert_eq!(name, "site-builder"),
         other => panic!("expected duplicate profile name error, got {other}"),
     }
 }
@@ -589,11 +632,11 @@ fn rejects_duplicate_credential_names_within_a_profile() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "GITHUB_TOKEN"
@@ -608,7 +651,7 @@ source = "AGENTD_GITHUB_OTHER_TOKEN"
 
     match error {
         ConfigError::DuplicateCredentialName { profile, name } => {
-            assert_eq!(profile, "codex");
+            assert_eq!(profile, "site-builder");
             assert_eq!(name, "GITHUB_TOKEN");
         }
         other => panic!("expected duplicate credential name error, got {other}"),
@@ -621,10 +664,10 @@ fn rejects_empty_required_string_fields() {
         r#"
 [[profiles]]
 name = ""
-base_image = "ghcr.io/example/codex:latest"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect_err("empty names should be rejected");
@@ -634,15 +677,15 @@ command = ["codex", "exec"]
 
 #[test]
 fn rejects_profile_names_with_leading_or_trailing_whitespace() {
-    for name in [" codex", "codex "] {
+    for name in [" site-builder", "site-builder "] {
         let error = Config::from_str(&format!(
             r#"
 [[profiles]]
 name = "{name}"
-base_image = "ghcr.io/example/codex:latest"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#
         ))
         .expect_err("whitespace-padded profile names should be rejected");
@@ -664,12 +707,12 @@ command = ["codex", "exec"]
 
 #[test]
 fn rejects_uppercase_profile_names_at_parse_time() {
-    assert_invalid_profile_name_parse_error("Codex");
+    assert_invalid_profile_name_parse_error("Site-Builder");
 }
 
 #[test]
 fn rejects_digit_prefixed_profile_names_at_parse_time() {
-    assert_invalid_profile_name_parse_error("123codex");
+    assert_invalid_profile_name_parse_error("123site-builder");
 }
 
 #[test]
@@ -688,11 +731,11 @@ fn rejects_credential_names_with_leading_or_trailing_whitespace() {
         let error = Config::from_str(&format!(
             r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "{name}"
@@ -708,7 +751,7 @@ source = "AGENTD_GITHUB_TOKEN"
                 credential,
             } => {
                 assert_eq!(field, "credentials.name");
-                assert_eq!(profile.as_deref(), Some("codex"));
+                assert_eq!(profile.as_deref(), Some("site-builder"));
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -721,11 +764,11 @@ fn rejects_credential_names_containing_commas() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "TOKEN,EXTRA"
@@ -736,7 +779,7 @@ source = "AGENTD_GITHUB_TOKEN"
 
     match error {
         ConfigError::InvalidCredentialName { profile, name } => {
-            assert_eq!(profile, "codex");
+            assert_eq!(profile, "site-builder");
             assert_eq!(name, "TOKEN,EXTRA");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -748,11 +791,11 @@ fn rejects_credential_names_containing_equals_signs() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "FOO=BAR"
@@ -763,7 +806,7 @@ source = "AGENTD_GITHUB_TOKEN"
 
     match error {
         ConfigError::InvalidCredentialName { profile, name } => {
-            assert_eq!(profile, "codex");
+            assert_eq!(profile, "site-builder");
             assert_eq!(name, "FOO=BAR");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -775,11 +818,11 @@ fn rejects_reserved_credential_names() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "PROFILE_NAME"
@@ -790,7 +833,7 @@ source = "AGENTD_GITHUB_TOKEN"
 
     match error {
         ConfigError::InvalidCredentialName { profile, name } => {
-            assert_eq!(profile, "codex");
+            assert_eq!(profile, "site-builder");
             assert_eq!(name, "PROFILE_NAME");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -802,8 +845,8 @@ fn rejects_empty_command_arrays_and_empty_command_elements() {
     let empty_command_error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
 command = []
@@ -814,11 +857,11 @@ command = []
     let empty_element_error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", ""]
+command = ["site-builder", ""]
 "#,
     )
     .expect_err("empty command elements should be rejected");
@@ -832,8 +875,8 @@ fn rejects_missing_command_field() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 "#,
     )
@@ -847,12 +890,12 @@ fn rejects_legacy_runa_table() {
     let error = Config::from_str(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
 [profiles.runa]
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect_err("legacy runa table should be rejected");
@@ -889,11 +932,11 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "Codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "Site-Builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
 
@@ -912,11 +955,11 @@ fn loading_daemon_config_uses_defaults_when_daemon_section_is_omitted() {
         "daemon-only-defaults",
         r#"
 [[profiles]]
-name = "Codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "Site-Builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
 
@@ -936,11 +979,11 @@ socket_path = "/tmp/agentd.sock"
 extra = "nope"
 
 [[profiles]]
-name = "Codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "Site-Builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     );
 

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -128,11 +128,11 @@ socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "GITHUB_TOKEN"
@@ -192,7 +192,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     let outcome = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "codex".to_string(),
+            profile: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("task-42".to_string()),
         },
@@ -219,7 +219,7 @@ fn client_reports_clear_error_when_daemon_is_not_running() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "codex".to_string(),
+            profile: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: None,
         },
@@ -349,7 +349,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         request_run(
             first_config.daemon(),
             &RunRequest {
-                profile: "codex".to_string(),
+                profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("first".to_string()),
             },
@@ -363,7 +363,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         let outcome = request_run(
             second_config.daemon(),
             &RunRequest {
-                profile: "codex".to_string(),
+                profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("second".to_string()),
             },
@@ -440,7 +440,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
         request_run(
             client_config.daemon(),
             &RunRequest {
-                profile: "codex".to_string(),
+                profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("shutdown".to_string()),
             },
@@ -501,7 +501,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
         request_run(
             first_config.daemon(),
             &RunRequest {
-                profile: "codex".to_string(),
+                profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("draining".to_string()),
             },
@@ -515,7 +515,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "codex".to_string(),
+            profile: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("rejected".to_string()),
         },
@@ -563,11 +563,11 @@ socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "GITHUB_TOKEN"
@@ -658,11 +658,11 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -57,12 +57,12 @@ fn config_with_repo_token_source(repo_token_source: &str) -> Config {
     Config::from_str(&format!(
         r#"
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 
 [[profiles.credentials]]
 name = "GITHUB_TOKEN"
@@ -79,11 +79,11 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
-        std::env::set_var("CODEX_REPO_TOKEN", "clone-only-secret");
+        std::env::set_var("SITE_BUILDER_REPO_TOKEN", "clone-only-secret");
     }
-    let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
+    let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "codex".to_string(),
+        profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: Some("task-42".to_string()),
     };
@@ -103,8 +103,8 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
         .as_ref()
         .expect("executor should receive invocation");
 
-    assert_eq!(spec.profile_name, "codex");
-    assert_eq!(spec.base_image, "ghcr.io/example/codex:latest");
+    assert_eq!(spec.profile_name, "site-builder");
+    assert_eq!(spec.base_image, "ghcr.io/example/site-builder:latest");
     assert_eq!(spec.methodology_dir, Path::new("../groundwork"));
     assert_eq!(
         spec.daemon_instance_id,
@@ -113,7 +113,10 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
             .daemon_instance_id()
             .expect("daemon instance id should resolve")
     );
-    assert_eq!(spec.command, vec!["codex".to_string(), "exec".to_string()]);
+    assert_eq!(
+        spec.command,
+        vec!["site-builder".to_string(), "exec".to_string()]
+    );
     assert_eq!(
         spec.environment,
         vec![ResolvedEnvironmentVariable {
@@ -128,7 +131,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
 
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
-        std::env::remove_var("CODEX_REPO_TOKEN");
+        std::env::remove_var("SITE_BUILDER_REPO_TOKEN");
     }
 }
 
@@ -139,11 +142,11 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_missing() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
-        std::env::remove_var("CODEX_REPO_TOKEN");
+        std::env::remove_var("SITE_BUILDER_REPO_TOKEN");
     }
-    let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
+    let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "codex".to_string(),
+        profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
@@ -171,11 +174,11 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
-        std::env::set_var("CODEX_REPO_TOKEN", "");
+        std::env::set_var("SITE_BUILDER_REPO_TOKEN", "");
     }
-    let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
+    let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "codex".to_string(),
+        profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
@@ -193,7 +196,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
 
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
-        std::env::remove_var("CODEX_REPO_TOKEN");
+        std::env::remove_var("SITE_BUILDER_REPO_TOKEN");
     }
 }
 
@@ -204,11 +207,11 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
-        std::env::set_var("CODEX_REPO_TOKEN", "clone-only-secret");
+        std::env::set_var("SITE_BUILDER_REPO_TOKEN", "clone-only-secret");
     }
-    let config = config_with_repo_token_source("CODEX_REPO_TOKEN");
+    let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "codex".to_string(),
+        profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
@@ -223,7 +226,7 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
             credential,
             source,
         } => {
-            assert_eq!(profile, "codex");
+            assert_eq!(profile, "site-builder");
             assert_eq!(credential, "GITHUB_TOKEN");
             assert_eq!(source, "AGENTD_GITHUB_TOKEN");
         }
@@ -231,7 +234,7 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
     }
 
     unsafe {
-        std::env::remove_var("CODEX_REPO_TOKEN");
+        std::env::remove_var("SITE_BUILDER_REPO_TOKEN");
     }
 }
 
@@ -244,16 +247,16 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
 [[profiles]]
-name = "codex"
-base_image = "ghcr.io/example/codex:latest"
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
     let request = RunRequest {
-        profile: "codex".to_string(),
+        profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -3,15 +3,13 @@
 
 [[profiles]]
 # Stable operator-facing profile name used for lookup and container identity.
-name = "codex"
+name = "site-builder"
 # Prebuilt image containing the agent runtime and runa.
-base_image = "ghcr.io/example/codex:latest"
+base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
-# Static session command executed from the cloned repository. This example
-# keeps runa as the runtime, so the profile owns runa initialization, the
-# agent command written into `.runa/config.toml`, and optional work-unit
-# forwarding from the generic AGENTD_WORK_UNIT contract.
+# Static session command executed from the cloned repository. This profile is
+# tightly bound to one codebase, so the session repo is the app it builds.
 command = [
   "/bin/sh",
   "-lc",
@@ -19,7 +17,7 @@ command = [
 runa init --methodology /agentd/methodology/manifest.toml
 cat > .runa/config.toml <<'EOF'
 [agent]
-command = ["codex", "exec"]
+command = ["site-builder", "exec"]
 EOF
 if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
   exec runa run --work-unit "${AGENTD_WORK_UNIT}"
@@ -29,10 +27,36 @@ exec runa run
 ]
 # Optional environment variable name resolved by the daemon for clone-only
 # repository authentication. This value does not flow into the agent runtime.
-repo_token_source = "CODEX_REPO_TOKEN"
+repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 
 [[profiles.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"
 # Environment variable name read from the daemon's own process environment.
+source = "AGENTD_GITHUB_TOKEN"
+
+[[profiles]]
+# A profile whose home repo contains its own review policy and target selection.
+name = "code-reviewer"
+base_image = "ghcr.io/example/code-reviewer:latest"
+methodology_dir = "../groundwork"
+command = [
+  "/bin/sh",
+  "-lc",
+  '''
+runa init --methodology /agentd/methodology/manifest.toml
+cat > .runa/config.toml <<'EOF'
+[agent]
+command = ["code-reviewer", "exec"]
+EOF
+if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
+  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
+fi
+exec runa run
+''',
+]
+repo_token_source = "CODE_REVIEWER_REPO_TOKEN"
+
+[[profiles.credentials]]
+name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"


### PR DESCRIPTION
## Summary

- replace vendor-specific example profile names with role-based `site-builder` and `code-reviewer` examples
- keep the existing `runa` wrapper pattern while updating operator-facing docs, config examples, and changelog coverage
- standardize workspace test fixtures and runner lifecycle assets on realistic role-based profile names

## Changes

- update `examples/agentd.toml`, `README.md`, and `ARCHITECTURE.md` to remove vendor-specific example naming and show the two-profile operator example
- rename single-profile parser, daemon, runner, and CLI fixtures to `site-builder`, including clone-token env vars and container/home-path expectations
- rename the session lifecycle fake runtime assets and startup-reconciliation expectations to match the new role-based profile naming

## Issue(s)

Closes #69

## Test plan

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `rg -n --hidden --glob '!target' --glob '!.git' 'codex|Codex' .`
