### PR TITLE
feat(scheduler): cron-based profile scheduling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ The key architectural consequence is simple: agentd may configure tool availabil
 
 ### Terminology
 
-- **Profile**: a named, reusable environment specification in the daemon config — base image, methodology, credentials, and command. What the operator declares.
+- **Profile**: a named, reusable environment specification in the daemon config — base image, methodology, optional default repo, optional schedule, credentials, and command. What the operator declares.
 - **Session**: a single execution created from a profile plus invocation parameters (repo, work unit, timeout). What the runner manages.
 
 ## 2. Agent Capability Needs
@@ -104,11 +104,13 @@ environment configuration.
 
 ### Phase 1: Scheduling (`agentd-scheduler`)
 
-The scheduler determines when a session should run. Triggers may come from
-time-based schedules, external events, or continuous policies. When scheduling
-decides to start a session, the scheduler is a socket client: it dispatches a
-run request through the daemon's Unix socket, using the same intake path as
-manual CLI invocation. The scheduler does not call the runner directly.
+The scheduler determines when a session should run. Today it evaluates each
+profile's optional cron schedule in daemon-local time. When scheduling decides
+to start a session, the scheduler is a socket client: it dispatches a run
+request through the daemon's Unix socket, using the same intake path as manual
+CLI invocation. The scheduler does not call the runner directly. Missed
+occurrences while the daemon is down are not backfilled, and session outcomes
+do not influence later schedule evaluation.
 
 ### Phase 2: Session Setup (`agentd-runner`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 
 - Clarified the credential source contract so examples, config doc comments, and architecture docs now describe `source` as a daemon-process environment variable name resolved with `std::env::var`, not an opaque secret-store reference.
 - Changed `agentd run` so the repo argument is optional when the selected profile declares a default `repo`, while an explicit CLI repo still overrides the configured default.
+- Fixed the daemon exit path for scheduled profiles so hard listener `accept()` failures now assert shared shutdown before joining the scheduler thread, avoiding a shutdown hang that could mask the original accept error.
+- Restored `agentd run <profile>` diagnostics when the repo argument is omitted so unknown profiles report `unknown profile '<name>'` instead of incorrectly reporting a missing configured repo.
 - Renamed the `agentd` crate's shared dispatch-layer request and helper APIs from manual/operator-specific names to source-agnostic run names, including the socket-interface integration test surface, so scheduler and operator callers share one clearly neutral dispatch path.
 - Removed the placeholder `mcp-transport` and `forgejo-mcp` crates so the workspace now contains only `agentd`, `agentd-runner`, and `agentd-scheduler`, and added coverage that enforces that three-crate contract.
 - Removed the vendored methodology skill distribution layer from the repository, including loadout configuration, manifests, sync and verify scripts, vendored skill copies, and related smoke tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added a documented static profile configuration format in `examples/agentd.toml` plus strict TOML parsing in the `agentd` crate for profile identity, base image, methodology mounts, credentials, and static session-command settings.
+- Added optional profile-level `repo` defaults and cron `schedule` expressions, plus a real `agentd-scheduler` implementation that evaluates scheduled profiles in daemon-local time and dispatches them through the daemon's Unix socket instead of calling the runner directly.
 - Added a Podman-backed session lifecycle in `agentd-runner` that creates ephemeral containers, mounts methodology assets read-only, clones a fresh repository workspace, executes the configured session command, injects caller-resolved credentials, supports optional timeouts, and force-removes the container on teardown.
 - Added explicit `SessionInvocation.repo_token` support in `agentd-runner` so private HTTPS repository clones can authenticate with a clone-only bearer token without exposing the token in `podman create` arguments, git argv, or persistent git config.
 - Added extraction-ready tracing bootstrap in `agentd` plus structured runner lifecycle/session events, with timestamped JSON logs to stderr by default, an `info` default filter so normal session lifecycle records are visible without extra env setup, `runner.session_error` for pre-completion failures, stderr fallback for runner failure diagnostics when no tracing subscriber is installed, `AGENTD_LOG_FORMAT=json|pretty` for format selection, and `RUST_LOG`/`AGENTD_LOG` filter control.
@@ -22,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Clarified the credential source contract so examples, config doc comments, and architecture docs now describe `source` as a daemon-process environment variable name resolved with `std::env::var`, not an opaque secret-store reference.
+- Changed `agentd run` so the repo argument is optional when the selected profile declares a default `repo`, while an explicit CLI repo still overrides the configured default.
 - Renamed the `agentd` crate's shared dispatch-layer request and helper APIs from manual/operator-specific names to source-agnostic run names, including the socket-interface integration test surface, so scheduler and operator callers share one clearly neutral dispatch path.
 - Removed the placeholder `mcp-transport` and `forgejo-mcp` crates so the workspace now contains only `agentd`, `agentd-runner`, and `agentd-scheduler`, and added coverage that enforces that three-crate contract.
 - Removed the vendored methodology skill distribution layer from the repository, including loadout configuration, manifests, sync and verify scripts, vendored skill copies, and related smoke tests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "agentd-runner",
  "agentd-scheduler",
  "clap",
+ "croner",
  "libc",
  "serde",
  "serde_json",
@@ -34,6 +35,10 @@ dependencies = [
 [[package]]
 name = "agentd-scheduler"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "croner",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -42,6 +47,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -101,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,10 +136,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -168,12 +217,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
 ]
 
 [[package]]
@@ -184,6 +250,72 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -211,6 +343,18 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -263,10 +407,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -291,6 +465,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -338,6 +522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -408,6 +601,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -488,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +723,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -709,6 +935,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,10 +1014,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ startup, operator-triggered sessions, ephemeral Podman containers, credential
 injection, execution, and teardown. Startup reconciliation cleans stale
 resources from prior runs. Structured JSON tracing provides operational
 visibility.
-
-Scheduling policy does not exist yet — sessions are triggered manually via
-`agentd run`.
+Profiles may now declare a default repository and an optional cron schedule.
+Manual runs still flow through `agentd run`, and scheduled runs dispatch
+through the same daemon socket intake without introducing a separate job type.
 
 ## Configuration
 
 A profile is a named environment specification: base image, methodology
-directory, credentials, and runtime command. Define profiles in a TOML config
-file — start from [`examples/agentd.toml`](examples/agentd.toml):
+directory, optional default repo, optional cron schedule, credentials, and
+runtime command. Define profiles in a TOML config file — start from
+[`examples/agentd.toml`](examples/agentd.toml):
 
 ```toml
 # Static profile registry for agentd.
-# Session-specific inputs such as repo and work unit come from the CLI at run time.
+# A profile can carry its own default repo and optional schedule.
 
 [[profiles]]
 # Stable operator-facing profile name used for lookup and container identity.
@@ -49,6 +50,11 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
+# Default repository URL cloned for manual runs when `agentd run` omits a repo,
+# and for every scheduled run of this profile.
+repo = "https://github.com/pentaxis93/agentd.git"
+# Optional five-field cron expression in daemon-local time.
+schedule = "*/15 * * * *"
 # Static session command executed from the cloned repository. This profile is
 # tightly bound to one app, so the session repo is the project being built.
 command = [
@@ -82,6 +88,7 @@ source = "AGENTD_GITHUB_TOKEN"
 name = "code-reviewer"
 base_image = "ghcr.io/example/code-reviewer:latest"
 methodology_dir = "../groundwork"
+repo = "https://github.com/pentaxis93/agentd.git"
 command = [
   "/bin/sh",
   "-lc",
@@ -107,7 +114,9 @@ source = "AGENTD_GITHUB_TOKEN"
 Credential `source` fields name environment variables in the daemon's process
 environment — export them before starting the daemon. The base image must
 provide `/bin/sh`, `git`, `useradd`, `gosu`, and whatever binaries the
-configured session command uses.
+configured session command uses. When a profile declares `schedule`, it must
+also declare `repo`. Schedules are evaluated in daemon-local time and missed
+fires are not backfilled after downtime.
 
 ## Running a Session
 
@@ -131,12 +140,19 @@ signal exits immediately.
 Trigger a session through the running daemon:
 
 ```bash
-agentd run site-builder https://github.com/pentaxis93/agentd.git --work-unit issue-42
+agentd run site-builder --work-unit issue-42
 ```
 
 `agentd run` reads the same config file and connects to the socket path defined
-there. This dispatches a session using the `site-builder` profile. Inside the
-container, the agent sees:
+there. When the profile declares `repo`, the CLI can omit the positional repo
+argument; an explicit repo still overrides the configured default:
+
+```bash
+agentd run site-builder https://github.com/pentaxis93/agentd.git --work-unit issue-42
+```
+
+Both manual and scheduled dispatches use the same daemon socket intake. Inside
+the container, the agent sees:
 
 - An unprivileged user with `$HOME` at `/home/site-builder`
 - A fresh clone of the repository at `/home/site-builder/repo`
@@ -147,6 +163,14 @@ container, the agent sees:
 
 The container is force-removed on completion. No session state persists on the
 host.
+
+## Scheduled Runs
+
+Profiles with `schedule` run autonomously while the daemon is up. The scheduler
+evaluates cron expressions in daemon-local time and opens the same Unix-socket
+client path that `agentd run` uses. Multiple scheduled profiles may overlap,
+and their sessions dispatch independently. Session outcomes do not affect later
+schedule evaluation: the next occurrence runs at its next scheduled time.
 
 ## Going Deeper
 

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -28,7 +28,7 @@ pub use types::{
     EnvironmentNameValidationError, ProfileNameValidationError, ResolvedEnvironmentVariable,
     RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
-pub use validation::{validate_environment_name, validate_profile_name};
+pub use validation::{validate_environment_name, validate_profile_name, validate_repo_url};
 
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
 use lifecycle::{

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -52,20 +52,9 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
 }
 
 pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), RunnerError> {
-    let repo_url = invocation.repo_url.as_str();
-    if repo_url.trim().is_empty() || repo_url != repo_url.trim() {
-        return Err(unsupported_repo_url_error());
-    }
+    validate_repo_url(&invocation.repo_url)?;
 
-    if has_repo_url_userinfo(repo_url) {
-        return Err(credential_bearing_repo_url_error());
-    }
-
-    if !is_supported_repo_url(repo_url) {
-        return Err(unsupported_repo_url_error());
-    }
-
-    if invocation.repo_token.is_some() && !repo_url.starts_with("https://") {
+    if invocation.repo_token.is_some() && !invocation.repo_url.starts_with("https://") {
         return Err(repo_token_requires_https_error());
     }
 
@@ -103,6 +92,27 @@ pub fn validate_profile_name(name: &str) -> Result<(), ProfileNameValidationErro
     }
     if is_reserved_profile_name(name) {
         return Err(ProfileNameValidationError::Reserved);
+    }
+
+    Ok(())
+}
+
+/// Validates a remote repository URL against the runner's supported forms.
+///
+/// Accepts only trimmed `https://`, `http://`, and `git://` remote URLs with a
+/// non-empty authority and path. Credential-bearing URLs and URLs with query or
+/// fragment components are rejected.
+pub fn validate_repo_url(repo_url: &str) -> Result<(), RunnerError> {
+    if repo_url.trim().is_empty() || repo_url != repo_url.trim() {
+        return Err(unsupported_repo_url_error());
+    }
+
+    if has_repo_url_userinfo(repo_url) {
+        return Err(credential_bearing_repo_url_error());
+    }
+
+    if !is_supported_repo_url(repo_url) {
+        return Err(unsupported_repo_url_error());
     }
 
     Ok(())

--- a/crates/agentd-scheduler/Cargo.toml
+++ b/crates/agentd-scheduler/Cargo.toml
@@ -6,3 +6,5 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+chrono = "0.4.44"
+croner = "3.0.1"

--- a/crates/agentd-scheduler/src/lib.rs
+++ b/crates/agentd-scheduler/src/lib.rs
@@ -1,10 +1,353 @@
-//! Job scheduling primitives for agentd.
+//! Cron-based scheduling for agentd profiles.
 //!
-//! This crate will own scheduling policy and timing — determining when agents
-//! run and with what mission context, then dispatching run requests through
-//! the daemon's Unix socket using the same intake path as manual invocation.
-//! The scheduler does not call `agentd-runner` directly. Currently a
-//! placeholder pending scheduler implementation.
-//!
-//! See `ARCHITECTURE.md` section "Session Lifecycle" for the design-level
-//! treatment.
+//! The scheduler owns timing policy only: it evaluates cron expressions in
+//! daemon-local time and dispatches run requests through an abstract
+//! [`Dispatcher`]. It does not call `agentd-runner` directly.
+
+use std::error::Error;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use chrono::{DateTime, Local};
+use croner::Cron;
+use croner::errors::CronError;
+use croner::parser::{CronParser, Seconds, Year};
+
+const MAX_IDLE_SLEEP: Duration = Duration::from_secs(1);
+
+/// One scheduled autonomous run source: profile identity, default repo, and a
+/// parsed cron expression.
+#[derive(Debug, Clone)]
+pub struct ScheduledProfile {
+    request: ScheduledRunRequest,
+    cron: Cron,
+}
+
+impl ScheduledProfile {
+    /// Parses a five-field cron expression for a scheduled profile.
+    pub fn new(profile: String, repo_url: String, schedule: &str) -> Result<Self, CronError> {
+        Ok(Self {
+            request: ScheduledRunRequest { profile, repo_url },
+            cron: parse_schedule(schedule)?,
+        })
+    }
+}
+
+/// A concrete run request emitted by the scheduler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduledRunRequest {
+    pub profile: String,
+    pub repo_url: String,
+}
+
+/// Errors returned by a dispatcher implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchError {
+    message: String,
+}
+
+impl DispatchError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for DispatchError {}
+
+/// Dispatch boundary used by the daemon adapter.
+pub trait Dispatcher {
+    fn dispatch(&self, request: ScheduledRunRequest) -> Result<(), DispatchError>;
+}
+
+/// Time source and sleep boundary for the scheduler loop.
+pub trait Clock {
+    fn now(&self) -> DateTime<Local>;
+    fn sleep(&self, duration: Duration);
+}
+
+/// Production clock backed by `chrono::Local` and `std::thread::sleep`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Local> {
+        Local::now()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
+
+/// In-memory scheduler state that tracks the next fire time per profile.
+#[derive(Debug, Clone)]
+pub struct Scheduler {
+    entries: Vec<ScheduledEntry>,
+}
+
+impl Scheduler {
+    /// Builds scheduler state from the configured scheduled profiles.
+    pub fn new(profiles: Vec<ScheduledProfile>, now: DateTime<Local>) -> Result<Self, CronError> {
+        let mut entries = Vec::with_capacity(profiles.len());
+        for profile in profiles {
+            entries.push(ScheduledEntry::new(profile, now)?);
+        }
+
+        Ok(Self { entries })
+    }
+
+    /// Returns whether the scheduler has any active profiles.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns the next scheduled wake time across all entries.
+    pub fn next_wake_at(&self) -> Option<DateTime<Local>> {
+        self.entries.iter().map(|entry| entry.next_fire).min()
+    }
+
+    /// Dispatches every profile whose next fire time is due at `now`.
+    ///
+    /// Each due profile dispatches at most once per tick. After dispatch, the
+    /// next fire time advances to the first occurrence strictly after `now`,
+    /// which intentionally skips missed occurrences instead of backfilling.
+    pub fn dispatch_due<D: Dispatcher>(
+        &mut self,
+        now: DateTime<Local>,
+        dispatcher: &D,
+    ) -> Vec<Result<ScheduledRunRequest, DispatchError>> {
+        let mut results = Vec::new();
+
+        for entry in &mut self.entries {
+            if entry.next_fire > now {
+                continue;
+            }
+
+            let request = entry.profile.request.clone();
+            let dispatch_result = dispatcher.dispatch(request.clone()).map(|_| request);
+            entry.next_fire = entry.profile.cron.find_next_occurrence(&now, false).expect(
+                "validated schedules should always have a next occurrence after the current time",
+            );
+            results.push(dispatch_result);
+        }
+
+        results
+    }
+
+    fn sleep_duration(&self, now: DateTime<Local>) -> Duration {
+        match self.next_wake_at() {
+            Some(next_wake_at) => next_wake_at
+                .signed_duration_since(now)
+                .to_std()
+                .unwrap_or(Duration::ZERO)
+                .min(MAX_IDLE_SLEEP),
+            None => MAX_IDLE_SLEEP,
+        }
+    }
+}
+
+/// Runs the scheduler loop until `shutdown` becomes true.
+pub fn run_until_shutdown<D: Dispatcher, C: Clock>(
+    scheduler: &mut Scheduler,
+    dispatcher: &D,
+    clock: &C,
+    shutdown: &AtomicBool,
+) {
+    while !shutdown.load(Ordering::Acquire) {
+        let now = clock.now();
+        scheduler.dispatch_due(now, dispatcher);
+
+        if shutdown.load(Ordering::Acquire) {
+            break;
+        }
+
+        clock.sleep(scheduler.sleep_duration(now));
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ScheduledEntry {
+    profile: ScheduledProfile,
+    next_fire: DateTime<Local>,
+}
+
+impl ScheduledEntry {
+    fn new(profile: ScheduledProfile, now: DateTime<Local>) -> Result<Self, CronError> {
+        let next_fire = profile.cron.find_next_occurrence(&now, false)?;
+        Ok(Self { profile, next_fire })
+    }
+}
+
+fn parse_schedule(schedule: &str) -> Result<Cron, CronError> {
+    CronParser::builder()
+        .seconds(Seconds::Disallowed)
+        .year(Year::Disallowed)
+        .build()
+        .parse(schedule)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use chrono::{LocalResult, TimeZone};
+
+    #[derive(Debug, Default)]
+    struct RecordingDispatcher {
+        requests: Arc<Mutex<Vec<ScheduledRunRequest>>>,
+    }
+
+    impl RecordingDispatcher {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn requests(&self) -> Vec<ScheduledRunRequest> {
+            self.requests.lock().expect("requests should lock").clone()
+        }
+    }
+
+    impl Dispatcher for RecordingDispatcher {
+        fn dispatch(&self, request: ScheduledRunRequest) -> Result<(), DispatchError> {
+            self.requests
+                .lock()
+                .expect("requests should lock")
+                .push(request);
+            Ok(())
+        }
+    }
+
+    fn local_datetime(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+    ) -> DateTime<Local> {
+        match Local.with_ymd_and_hms(year, month, day, hour, minute, second) {
+            LocalResult::Single(datetime) => datetime,
+            other => panic!("expected a single local datetime, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatches_due_profiles_once_each_when_schedules_overlap() {
+        let start = local_datetime(2026, 4, 10, 10, 0, 30);
+        let mut scheduler = Scheduler::new(
+            vec![
+                ScheduledProfile::new(
+                    "site-builder".to_string(),
+                    "https://example.com/site.git".to_string(),
+                    "*/15 * * * *",
+                )
+                .expect("schedule should parse"),
+                ScheduledProfile::new(
+                    "code-reviewer".to_string(),
+                    "https://example.com/review.git".to_string(),
+                    "*/15 * * * *",
+                )
+                .expect("schedule should parse"),
+            ],
+            start,
+        )
+        .expect("scheduler should build");
+        let dispatcher = RecordingDispatcher::new();
+
+        let outcomes = scheduler.dispatch_due(local_datetime(2026, 4, 10, 10, 15, 0), &dispatcher);
+
+        assert_eq!(outcomes.len(), 2, "both overlapping schedules should fire");
+        assert_eq!(
+            dispatcher.requests(),
+            vec![
+                ScheduledRunRequest {
+                    profile: "site-builder".to_string(),
+                    repo_url: "https://example.com/site.git".to_string(),
+                },
+                ScheduledRunRequest {
+                    profile: "code-reviewer".to_string(),
+                    repo_url: "https://example.com/review.git".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_missed_occurrences_instead_of_backfilling() {
+        let start = local_datetime(2026, 4, 10, 10, 0, 30);
+        let mut scheduler = Scheduler::new(
+            vec![
+                ScheduledProfile::new(
+                    "site-builder".to_string(),
+                    "https://example.com/site.git".to_string(),
+                    "* * * * *",
+                )
+                .expect("schedule should parse"),
+            ],
+            start,
+        )
+        .expect("scheduler should build");
+        let dispatcher = RecordingDispatcher::new();
+
+        let outcomes = scheduler.dispatch_due(local_datetime(2026, 4, 10, 10, 3, 0), &dispatcher);
+
+        assert_eq!(outcomes.len(), 1, "one late tick should dispatch once");
+        assert_eq!(
+            dispatcher.requests().len(),
+            1,
+            "missed runs should not backfill"
+        );
+
+        let second_tick =
+            scheduler.dispatch_due(local_datetime(2026, 4, 10, 10, 3, 30), &dispatcher);
+        assert!(
+            second_tick.is_empty(),
+            "the scheduler should advance straight to the next occurrence after now"
+        );
+
+        let third_tick = scheduler.dispatch_due(local_datetime(2026, 4, 10, 10, 4, 0), &dispatcher);
+        assert_eq!(
+            third_tick.len(),
+            1,
+            "the next scheduled minute should still fire"
+        );
+    }
+
+    #[test]
+    fn next_wake_at_tracks_the_earliest_scheduled_profile() {
+        let start = local_datetime(2026, 4, 10, 10, 0, 0);
+        let scheduler = Scheduler::new(
+            vec![
+                ScheduledProfile::new(
+                    "site-builder".to_string(),
+                    "https://example.com/site.git".to_string(),
+                    "*/20 * * * *",
+                )
+                .expect("schedule should parse"),
+                ScheduledProfile::new(
+                    "code-reviewer".to_string(),
+                    "https://example.com/review.git".to_string(),
+                    "*/5 * * * *",
+                )
+                .expect("schedule should parse"),
+            ],
+            start,
+        )
+        .expect("scheduler should build");
+
+        assert_eq!(
+            scheduler.next_wake_at(),
+            Some(local_datetime(2026, 4, 10, 10, 5, 0))
+        );
+    }
+}

--- a/crates/agentd-scheduler/src/lib.rs
+++ b/crates/agentd-scheduler/src/lib.rs
@@ -120,6 +120,8 @@ impl Scheduler {
     /// Each due profile dispatches at most once per tick. After dispatch, the
     /// next fire time advances to the first occurrence strictly after `now`,
     /// which intentionally skips missed occurrences instead of backfilling.
+    /// Startup seeding is inclusive, but post-dispatch advancement is
+    /// intentionally exclusive so one instant cannot dispatch twice.
     pub fn dispatch_due<D: Dispatcher>(
         &mut self,
         now: DateTime<Local>,
@@ -182,7 +184,7 @@ struct ScheduledEntry {
 
 impl ScheduledEntry {
     fn new(profile: ScheduledProfile, now: DateTime<Local>) -> Result<Self, CronError> {
-        let next_fire = profile.cron.find_next_occurrence(&now, false)?;
+        let next_fire = profile.cron.find_next_occurrence(&now, true)?;
         Ok(Self { profile, next_fire })
     }
 }
@@ -324,8 +326,51 @@ mod tests {
     }
 
     #[test]
+    fn startup_on_a_schedule_boundary_dispatches_immediately_once() {
+        let start = local_datetime(2026, 4, 10, 10, 15, 0);
+        let mut scheduler = Scheduler::new(
+            vec![
+                ScheduledProfile::new(
+                    "site-builder".to_string(),
+                    "https://example.com/site.git".to_string(),
+                    "*/15 * * * *",
+                )
+                .expect("schedule should parse"),
+            ],
+            start,
+        )
+        .expect("scheduler should build");
+        let dispatcher = RecordingDispatcher::new();
+
+        let first_tick = scheduler.dispatch_due(start, &dispatcher);
+        assert_eq!(
+            first_tick.len(),
+            1,
+            "startup on the exact boundary should fire immediately"
+        );
+        assert_eq!(
+            dispatcher.requests(),
+            vec![ScheduledRunRequest {
+                profile: "site-builder".to_string(),
+                repo_url: "https://example.com/site.git".to_string(),
+            }]
+        );
+        assert_eq!(
+            scheduler.next_wake_at(),
+            Some(local_datetime(2026, 4, 10, 10, 30, 0)),
+            "after firing at startup the next wake should advance past the current instant"
+        );
+
+        let second_tick = scheduler.dispatch_due(start, &dispatcher);
+        assert!(
+            second_tick.is_empty(),
+            "the same boundary instant should not dispatch twice"
+        );
+    }
+
+    #[test]
     fn next_wake_at_tracks_the_earliest_scheduled_profile() {
-        let start = local_datetime(2026, 4, 10, 10, 0, 0);
+        let start = local_datetime(2026, 4, 10, 10, 0, 30);
         let scheduler = Scheduler::new(
             vec![
                 ScheduledProfile::new(

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 agentd-runner.workspace = true
 agentd-scheduler.workspace = true
 clap = { version = "4.5", features = ["derive"] }
+croner = "3.0.1"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -15,7 +15,10 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use agentd_runner::{RunnerError, validate_environment_name, validate_profile_name};
+use agentd_runner::{
+    RunnerError, validate_environment_name, validate_profile_name, validate_repo_url,
+};
+use croner::parser::{CronParser, Seconds, Year};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
@@ -97,6 +100,28 @@ impl Config {
                 Some(raw_profile.name.as_str()),
                 None,
             )?;
+            let repo = match raw_profile.repo {
+                Some(value) => {
+                    validate_lookup_key("repo", &value, Some(raw_profile.name.as_str()), None)?;
+                    validate_repo_url(&value).map_err(|error| ConfigError::InvalidRepo {
+                        profile: raw_profile.name.clone(),
+                        message: error.to_string(),
+                    })?;
+                    Some(value)
+                }
+                None => None,
+            };
+            let schedule = match raw_profile.schedule {
+                Some(value) => {
+                    validate_lookup_key("schedule", &value, Some(raw_profile.name.as_str()), None)?;
+                    validate_schedule(&value).map_err(|_| ConfigError::InvalidSchedule {
+                        profile: raw_profile.name.clone(),
+                        schedule: value.clone(),
+                    })?;
+                    Some(value)
+                }
+                None => None,
+            };
             let repo_token_source = match raw_profile.repo_token_source {
                 Some(value) if value.is_empty() => None,
                 Some(value) => {
@@ -158,11 +183,19 @@ impl Config {
                 });
             }
 
+            if schedule.is_some() && repo.is_none() {
+                return Err(ConfigError::ScheduleRequiresRepo {
+                    profile: raw_profile.name.clone(),
+                });
+            }
+
             let methodology_dir = resolve_methodology_dir(base_dir, &raw_profile.methodology_dir);
             profiles.push(ProfileConfig {
                 name: raw_profile.name,
                 base_image: raw_profile.base_image,
                 methodology_dir,
+                repo,
+                schedule,
                 repo_token_source,
                 credentials,
                 command,
@@ -195,6 +228,8 @@ pub struct ProfileConfig {
     name: String,
     base_image: String,
     methodology_dir: PathBuf,
+    repo: Option<String>,
+    schedule: Option<String>,
     repo_token_source: Option<String>,
     credentials: Vec<CredentialConfig>,
     command: Vec<String>,
@@ -216,6 +251,16 @@ impl ProfileConfig {
     /// constructed via the [`FromStr`] impl.
     pub fn methodology_dir(&self) -> &Path {
         &self.methodology_dir
+    }
+
+    /// Optional default repository URL for sessions launched from this profile.
+    pub fn repo(&self) -> Option<&str> {
+        self.repo.as_deref()
+    }
+
+    /// Optional five-field cron expression evaluated in daemon-local time.
+    pub fn schedule(&self) -> Option<&str> {
+        self.schedule.as_deref()
     }
 
     /// Optional environment variable name resolved by the daemon at dispatch
@@ -366,6 +411,12 @@ pub enum ConfigError {
     RelativeDaemonRuntimePath { field: &'static str, path: PathBuf },
     /// The `command` array is empty for a profile.
     EmptyCommand { profile: String },
+    /// A profile declares a default repository URL the runner would reject.
+    InvalidRepo { profile: String, message: String },
+    /// A profile declares an invalid cron expression.
+    InvalidSchedule { profile: String, schedule: String },
+    /// A scheduled profile must declare a default repo for autonomous runs.
+    ScheduleRequiresRepo { profile: String },
 }
 
 impl fmt::Display for ConfigError {
@@ -441,6 +492,21 @@ impl fmt::Display for ConfigError {
             ConfigError::EmptyCommand { profile } => {
                 write!(f, "profile '{profile}' must define a non-empty command")
             }
+            ConfigError::InvalidRepo { profile, message } => {
+                write!(f, "profile '{profile}' defines invalid repo: {message}")
+            }
+            ConfigError::InvalidSchedule { profile, schedule } => {
+                write!(
+                    f,
+                    "profile '{profile}' defines invalid schedule '{schedule}'"
+                )
+            }
+            ConfigError::ScheduleRequiresRepo { profile } => {
+                write!(
+                    f,
+                    "profile '{profile}' defines schedule but no repo; scheduled profiles must define a repo"
+                )
+            }
         }
     }
 }
@@ -510,6 +576,8 @@ struct RawProfileConfig {
     base_image: String,
     methodology_dir: String,
     command: Vec<String>,
+    repo: Option<String>,
+    schedule: Option<String>,
     repo_token_source: Option<String>,
     #[serde(default)]
     credentials: Vec<RawCredentialConfig>,
@@ -616,6 +684,15 @@ fn absolute_config_dir(path: &Path) -> Result<Option<PathBuf>, ConfigError> {
 
 fn resolve_methodology_dir(base_dir: Option<&Path>, methodology_dir: &str) -> PathBuf {
     resolve_config_path(base_dir, methodology_dir)
+}
+
+fn validate_schedule(schedule: &str) -> Result<(), croner::errors::CronError> {
+    CronParser::builder()
+        .seconds(Seconds::Disallowed)
+        .year(Year::Disallowed)
+        .build()
+        .parse(schedule)
+        .map(|_| ())
 }
 
 fn validate_absolute_daemon_runtime_path(

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -17,6 +17,7 @@ use agentd_runner::{
 use serde::{Deserialize, Serialize};
 
 use crate::config::{Config, ConfigError, DaemonConfig};
+use crate::scheduler::{join_scheduler_thread, spawn_scheduler_thread};
 use crate::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 
 const ACCEPT_TIMEOUT: Duration = Duration::from_millis(100);
@@ -168,7 +169,7 @@ impl From<OutcomeMessage> for SessionOutcome {
 pub fn run_daemon_until_shutdown(
     config: Config,
     executor: impl SessionExecutor + Send + Sync + Clone + 'static,
-    shutdown: &AtomicBool,
+    shutdown: Arc<AtomicBool>,
 ) -> Result<(), DaemonError> {
     let daemon_instance_id = config.daemon().daemon_instance_id()?;
     run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
@@ -179,7 +180,7 @@ pub fn run_daemon_until_shutdown(
 fn run_daemon_until_shutdown_with_reconciler<F>(
     config: Config,
     executor: impl SessionExecutor + Send + Sync + Clone + 'static,
-    shutdown: &AtomicBool,
+    shutdown: Arc<AtomicBool>,
     reconcile_startup: F,
 ) -> Result<(), DaemonError>
 where
@@ -204,6 +205,7 @@ where
     runtime.bind_listener()?;
     let executor = Arc::new(executor);
     let mut handlers = Vec::new();
+    let scheduler_handle = spawn_scheduler_thread(&config, Arc::clone(&shutdown))?;
     tracing::info!(
         event = "agentd.daemon_started",
         socket_path = %config.daemon().socket_path().display(),
@@ -235,8 +237,9 @@ where
         }
     };
 
-    finish_daemon_loop(|| runtime.begin_shutdown(), handlers, loop_result)
-        .map_err(DaemonError::Io)?;
+    let finish_result = finish_daemon_loop(|| runtime.begin_shutdown(), handlers, loop_result);
+    join_scheduler_thread(scheduler_handle);
+    finish_result.map_err(DaemonError::Io)?;
     tracing::info!(event = "agentd.daemon_stopped", "agentd daemon stopped");
     Ok(())
 }
@@ -883,7 +886,7 @@ source = "AGENTD_GITHUB_TOKEN"
             run_daemon_until_shutdown_with_reconciler(
                 daemon_config,
                 FixedOutcomeExecutor,
-                daemon_shutdown.as_ref(),
+                daemon_shutdown,
                 move || {
                     daemon_id_tx
                         .send(expected_daemon_instance_id)
@@ -936,7 +939,7 @@ source = "AGENTD_GITHUB_TOKEN"
         let error = run_daemon_until_shutdown_with_reconciler(
             config.clone(),
             FixedOutcomeExecutor,
-            &AtomicBool::new(false),
+            Arc::new(AtomicBool::new(false)),
             || Err(RunnerError::InvalidBaseImage),
         )
         .expect_err("startup reconciliation failure should abort daemon startup");

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -238,10 +238,15 @@ where
     };
 
     let finish_result = finish_daemon_loop(|| runtime.begin_shutdown(), handlers, loop_result);
-    join_scheduler_thread(scheduler_handle);
+    stop_scheduler_thread(shutdown.as_ref(), scheduler_handle);
     finish_result.map_err(DaemonError::Io)?;
     tracing::info!(event = "agentd.daemon_stopped", "agentd daemon stopped");
     Ok(())
+}
+
+fn stop_scheduler_thread(shutdown: &AtomicBool, handle: Option<JoinHandle<()>>) {
+    shutdown.store(true, Ordering::Release);
+    join_scheduler_thread(handle);
 }
 
 fn finish_daemon_loop<F>(
@@ -943,6 +948,42 @@ source = "AGENTD_GITHUB_TOKEN"
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(error.to_string(), "accept failed");
+    }
+
+    #[test]
+    fn stopping_scheduler_thread_sets_shutdown_before_joining() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let scheduler_shutdown = Arc::clone(&shutdown);
+        let scheduler = thread::spawn(move || {
+            while !scheduler_shutdown.load(std::sync::atomic::Ordering::Acquire) {
+                thread::sleep(Duration::from_millis(10));
+            }
+        });
+        let (done_tx, done_rx) = mpsc::channel();
+        let join_shutdown = Arc::clone(&shutdown);
+        let joiner = thread::spawn(move || {
+            super::stop_scheduler_thread(join_shutdown.as_ref(), Some(scheduler));
+            done_tx
+                .send(())
+                .expect("scheduler stop should report completion");
+        });
+
+        let finished_quickly = done_rx.recv_timeout(Duration::from_millis(100)).is_ok();
+        if !finished_quickly {
+            shutdown.store(true, std::sync::atomic::Ordering::Release);
+        }
+        joiner
+            .join()
+            .expect("scheduler stopper should join cleanly");
+
+        assert!(
+            finished_quickly,
+            "stopping the scheduler should set shutdown before joining"
+        );
+        assert!(
+            shutdown.load(std::sync::atomic::Ordering::Acquire),
+            "stopping the scheduler should leave shutdown asserted"
+        );
     }
 
     #[test]

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -354,11 +354,41 @@ pub fn request_run(
     }
 }
 
+pub(crate) fn request_run_without_waiting(
+    config: &DaemonConfig,
+    request: &RunRequest,
+) -> Result<(), ClientError> {
+    send_request_without_response(
+        config.socket_path(),
+        &RequestMessage::Run {
+            profile: request.profile.clone(),
+            repo_url: request.repo_url.clone(),
+            work_unit: request.work_unit.clone(),
+        },
+    )
+}
+
 fn send_request(
     socket_path: &Path,
     request: &RequestMessage,
 ) -> Result<ResponseMessage, ClientError> {
-    let mut stream = UnixStream::connect(socket_path).map_err(|error| {
+    let mut stream = connect_to_daemon(socket_path)?;
+    write_request(&mut stream, request)?;
+
+    read_response(stream)
+}
+
+fn send_request_without_response(
+    socket_path: &Path,
+    request: &RequestMessage,
+) -> Result<(), ClientError> {
+    let mut stream = connect_to_daemon(socket_path)?;
+    write_request(&mut stream, request)?;
+    Ok(())
+}
+
+fn connect_to_daemon(socket_path: &Path) -> Result<UnixStream, ClientError> {
+    UnixStream::connect(socket_path).map_err(|error| {
         if matches!(
             error.kind(),
             io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
@@ -369,12 +399,19 @@ fn send_request(
         } else {
             ClientError::Io(error)
         }
-    })?;
+    })
+}
+
+fn write_request(stream: &mut UnixStream, request: &RequestMessage) -> Result<(), ClientError> {
     let payload = serde_json::to_vec(request)?;
     stream.write_all(&payload)?;
     stream.write_all(b"\n")?;
     stream.flush()?;
 
+    Ok(())
+}
+
+fn read_response(stream: UnixStream) -> Result<ResponseMessage, ClientError> {
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
     let bytes_read = reader.read_line(&mut line)?;
@@ -461,9 +498,28 @@ fn handle_connection_inner(
 fn write_response(stream: &mut UnixStream, response: &ResponseMessage) -> Result<(), io::Error> {
     let payload = serde_json::to_vec(response)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    stream.write_all(&payload)?;
-    stream.write_all(b"\n")?;
-    stream.flush()
+    write_response_part(stream, &payload)?;
+    write_response_part(stream, b"\n")?;
+    match stream.flush() {
+        Ok(()) => Ok(()),
+        Err(error) if peer_disconnected_during_response(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_response_part(stream: &mut UnixStream, bytes: &[u8]) -> Result<(), io::Error> {
+    match stream.write_all(bytes) {
+        Ok(()) => Ok(()),
+        Err(error) if peer_disconnected_during_response(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn peer_disconnected_during_response(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset
+    )
 }
 
 fn dispatch_error_message(error: &DispatchError) -> String {
@@ -660,8 +716,8 @@ fn read_pid(pid_file: &Path) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DaemonError, finish_daemon_loop, reap_finished_handlers,
-        run_daemon_until_shutdown_with_reconciler,
+        DaemonError, ResponseMessage, finish_daemon_loop, reap_finished_handlers,
+        run_daemon_until_shutdown_with_reconciler, write_response,
     };
     use crate::config::Config;
     use crate::dispatch::SessionExecutor;
@@ -678,7 +734,10 @@ mod tests {
     use std::sync::mpsc::Sender;
     use std::thread;
     use std::time::{Duration, Instant};
-    use std::{os::unix::fs::FileTypeExt, os::unix::net::UnixListener};
+    use std::{
+        os::unix::fs::FileTypeExt,
+        os::unix::net::{UnixListener, UnixStream},
+    };
 
     #[derive(Clone)]
     struct FixedOutcomeExecutor;
@@ -787,6 +846,25 @@ source = "AGENTD_GITHUB_TOKEN"
         assert!(
             handlers.is_empty(),
             "finished panicked handlers should be reaped"
+        );
+    }
+
+    #[test]
+    fn response_writes_ignore_a_peer_that_already_disconnected() {
+        let (mut daemon_stream, client_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        drop(client_stream);
+
+        let result = write_response(
+            &mut daemon_stream,
+            &ResponseMessage::Error {
+                message: "ignored disconnect".to_string(),
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "closed peer during response write should be treated as normal completion"
         );
     }
 

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod daemon;
 pub mod dispatch;
 pub mod logging;
+mod scheduler;
 
 pub use daemon::{ClientError, DaemonError, request_run, run_daemon_until_shutdown};
 pub use dispatch::{

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -17,6 +17,7 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
 enum RunCommandError {
     Failed { exit_code: i32 },
     TimedOut,
+    MissingRepo { profile: String },
 }
 
 impl fmt::Display for RunCommandError {
@@ -24,6 +25,10 @@ impl fmt::Display for RunCommandError {
         match self {
             Self::Failed { exit_code } => write!(f, "session failed (exit code {exit_code})"),
             Self::TimedOut => write!(f, "session timed out"),
+            Self::MissingRepo { profile } => write!(
+                f,
+                "profile '{profile}' requires a repo argument or configured profile repo"
+            ),
         }
     }
 }
@@ -46,7 +51,7 @@ enum Command {
     /// Trigger a manual session through the running daemon.
     Run {
         profile: String,
-        repo: String,
+        repo: Option<String>,
         #[arg(long)]
         work_unit: Option<String>,
     },
@@ -76,7 +81,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             profile,
             repo,
             work_unit,
-        }) => run_client(DaemonConfig::load(&cli.config)?, profile, repo, work_unit),
+        }) => run_client(&cli.config, profile, repo, work_unit),
     }
 }
 
@@ -85,7 +90,7 @@ fn run_daemon(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     register_termination_handlers(shutdown.clone())?;
 
     let executor = RunnerSessionExecutor;
-    run_daemon_until_shutdown(config, executor, shutdown.as_ref())?;
+    run_daemon_until_shutdown(config, executor, shutdown)?;
     Ok(())
 }
 
@@ -99,13 +104,15 @@ fn register_termination_handlers(shutdown: Arc<AtomicBool>) -> Result<(), std::i
 }
 
 fn run_client(
-    config: DaemonConfig,
+    config_path: &std::path::Path,
     profile: String,
-    repo: String,
+    repo: Option<String>,
     work_unit: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let repo = resolve_run_repo(config_path, &profile, repo)?;
+    let daemon_config = DaemonConfig::load(config_path)?;
     let outcome = request_run(
-        &config,
+        &daemon_config,
         &RunRequest {
             profile,
             repo_url: repo,
@@ -123,6 +130,27 @@ fn run_client(
         }
         agentd_runner::SessionOutcome::TimedOut => Err(Box::new(RunCommandError::TimedOut)),
     }
+}
+
+fn resolve_run_repo(
+    config_path: &std::path::Path,
+    profile: &str,
+    repo: Option<String>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if let Some(repo) = repo {
+        return Ok(repo);
+    }
+
+    let config = Config::load(config_path)?;
+    config
+        .profile(profile)
+        .and_then(|profile| profile.repo())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            Box::new(RunCommandError::MissingRepo {
+                profile: profile.to_string(),
+            }) as Box<dyn std::error::Error>
+        })
 }
 
 #[cfg(test)]

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -17,6 +17,7 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
 enum RunCommandError {
     Failed { exit_code: i32 },
     TimedOut,
+    UnknownProfile { profile: String },
     MissingRepo { profile: String },
 }
 
@@ -25,6 +26,7 @@ impl fmt::Display for RunCommandError {
         match self {
             Self::Failed { exit_code } => write!(f, "session failed (exit code {exit_code})"),
             Self::TimedOut => write!(f, "session timed out"),
+            Self::UnknownProfile { profile } => write!(f, "unknown profile '{profile}'"),
             Self::MissingRepo { profile } => write!(
                 f,
                 "profile '{profile}' requires a repo argument or configured profile repo"
@@ -142,15 +144,17 @@ fn resolve_run_repo(
     }
 
     let config = Config::load(config_path)?;
-    config
-        .profile(profile)
-        .and_then(|profile| profile.repo())
-        .map(str::to_owned)
-        .ok_or_else(|| {
-            Box::new(RunCommandError::MissingRepo {
-                profile: profile.to_string(),
-            }) as Box<dyn std::error::Error>
-        })
+    let profile = config.profile(profile).ok_or_else(|| {
+        Box::new(RunCommandError::UnknownProfile {
+            profile: profile.to_string(),
+        }) as Box<dyn std::error::Error>
+    })?;
+
+    profile.repo().map(str::to_owned).ok_or_else(|| {
+        Box::new(RunCommandError::MissingRepo {
+            profile: profile.name().to_string(),
+        }) as Box<dyn std::error::Error>
+    })
 }
 
 #[cfg(test)]

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -1,0 +1,255 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::thread::{self, JoinHandle};
+
+use agentd_scheduler::{
+    Clock, DispatchError, Dispatcher, ScheduledProfile, ScheduledRunRequest, Scheduler,
+    SystemClock, run_until_shutdown,
+};
+
+use crate::RunRequest;
+use crate::config::{Config, DaemonConfig};
+use crate::daemon::request_run;
+
+pub(crate) fn spawn_scheduler_thread(
+    config: &Config,
+    shutdown: Arc<AtomicBool>,
+) -> std::io::Result<Option<JoinHandle<()>>> {
+    let scheduled_profiles = scheduled_profiles_from_config(config);
+    if scheduled_profiles.is_empty() {
+        return Ok(None);
+    }
+
+    let daemon_config = config.daemon().clone();
+    thread::Builder::new()
+        .name("agentd-scheduler".to_string())
+        .spawn(move || {
+            let clock = SystemClock;
+            let mut scheduler = Scheduler::new(scheduled_profiles, clock.now())
+                .expect("config validation should guarantee valid schedules");
+            let dispatcher = SocketDispatcher { daemon_config };
+            run_until_shutdown(&mut scheduler, &dispatcher, &clock, shutdown.as_ref());
+        })
+        .map(Some)
+}
+
+pub(crate) fn join_scheduler_thread(handle: Option<JoinHandle<()>>) {
+    let Some(handle) = handle else {
+        return;
+    };
+
+    if handle.join().is_err() {
+        tracing::error!(
+            event = "agentd.scheduler_panicked",
+            "scheduler thread panicked"
+        );
+    }
+}
+
+fn scheduled_profiles_from_config(config: &Config) -> Vec<ScheduledProfile> {
+    config
+        .profiles()
+        .iter()
+        .filter_map(|profile| {
+            let schedule = profile.schedule()?;
+            let repo = profile
+                .repo()
+                .expect("config validation should guarantee scheduled profiles declare repo");
+            Some(
+                ScheduledProfile::new(profile.name().to_string(), repo.to_string(), schedule)
+                    .expect("config validation should guarantee valid schedules"),
+            )
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct SocketDispatcher {
+    daemon_config: DaemonConfig,
+}
+
+impl Dispatcher for SocketDispatcher {
+    fn dispatch(&self, request: ScheduledRunRequest) -> Result<(), DispatchError> {
+        let daemon_config = self.daemon_config.clone();
+        thread::Builder::new()
+            .name(format!("agentd-scheduled-dispatch-{}", request.profile))
+            .spawn(move || {
+                if let Err(error) = request_run(
+                    &daemon_config,
+                    &RunRequest {
+                        profile: request.profile.clone(),
+                        repo_url: request.repo_url.clone(),
+                        work_unit: None,
+                    },
+                ) {
+                    tracing::warn!(
+                        event = "agentd.scheduled_run_dispatch_failed",
+                        profile = request.profile,
+                        error = %error,
+                        "scheduled run dispatch failed"
+                    );
+                }
+            })
+            .map(|_| ())
+            .map_err(|error| DispatchError::new(error.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use std::sync::atomic::Ordering;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    use crate::{SessionExecutor, run_daemon_until_shutdown};
+    use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+
+    #[derive(Clone)]
+    struct RecordingExecutor {
+        invocations: Arc<Mutex<Vec<SessionInvocation>>>,
+    }
+
+    impl RecordingExecutor {
+        fn new() -> (Self, Arc<Mutex<Vec<SessionInvocation>>>) {
+            let invocations = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    invocations: Arc::clone(&invocations),
+                },
+                invocations,
+            )
+        }
+    }
+
+    impl SessionExecutor for RecordingExecutor {
+        fn run_session(
+            &self,
+            _spec: SessionSpec,
+            invocation: SessionInvocation,
+        ) -> Result<SessionOutcome, RunnerError> {
+            self.invocations
+                .lock()
+                .expect("invocations should lock")
+                .push(invocation);
+            Ok(SessionOutcome::Succeeded)
+        }
+    }
+
+    fn wait_for_path(path: &std::path::Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if path.exists() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        panic!("timed out waiting for {}", path.display());
+    }
+
+    #[test]
+    fn scheduled_profiles_ignore_profiles_without_schedule() {
+        let config = Config::from_str(
+            r#"
+[daemon]
+socket_path = "/tmp/agentd.sock"
+pid_file = "/tmp/agentd.pid"
+
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/site.git"
+schedule = "*/15 * * * *"
+
+command = ["site-builder", "exec"]
+
+[[profiles]]
+name = "code-reviewer"
+base_image = "ghcr.io/example/code-reviewer:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/review.git"
+
+command = ["code-reviewer", "exec"]
+"#,
+        )
+        .expect("config should parse");
+
+        let scheduled_profiles = scheduled_profiles_from_config(&config);
+
+        assert_eq!(scheduled_profiles.len(), 1);
+    }
+
+    #[test]
+    fn socket_dispatcher_sends_runs_through_the_daemon_socket() {
+        let runtime_dir = std::env::temp_dir().join(format!(
+            "agentd-scheduler-dispatch-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+        let config = Config::from_str(&format!(
+            r#"
+[daemon]
+socket_path = "{socket_path}"
+pid_file = "{pid_file}"
+
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/site.git"
+
+command = ["site-builder", "exec"]
+"#,
+            socket_path = runtime_dir.join("agentd.sock").display(),
+            pid_file = runtime_dir.join("agentd.pid").display(),
+        ))
+        .expect("config should parse");
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let daemon_config = config.clone();
+        let daemon_shutdown = Arc::clone(&shutdown);
+        let (executor, invocations) = RecordingExecutor::new();
+        let handle = thread::spawn(move || {
+            run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown)
+        });
+        wait_for_path(config.daemon().socket_path());
+
+        let dispatcher = SocketDispatcher {
+            daemon_config: config.daemon().clone(),
+        };
+        dispatcher
+            .dispatch(ScheduledRunRequest {
+                profile: "site-builder".to_string(),
+                repo_url: "https://example.com/site.git".to_string(),
+            })
+            .expect("dispatch should spawn a socket client");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !invocations
+                .lock()
+                .expect("invocations should lock")
+                .is_empty()
+            {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        let invocations = invocations.lock().expect("invocations should lock");
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].repo_url, "https://example.com/site.git");
+
+        shutdown.store(true, Ordering::Release);
+        handle
+            .join()
+            .expect("daemon thread should join")
+            .expect("daemon should exit cleanly");
+    }
+}

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -9,7 +9,7 @@ use agentd_scheduler::{
 
 use crate::RunRequest;
 use crate::config::{Config, DaemonConfig};
-use crate::daemon::request_run;
+use crate::daemon::request_run_without_waiting;
 
 pub(crate) fn spawn_scheduler_thread(
     config: &Config,
@@ -74,7 +74,7 @@ impl Dispatcher for SocketDispatcher {
         thread::Builder::new()
             .name(format!("agentd-scheduled-dispatch-{}", request.profile))
             .spawn(move || {
-                if let Err(error) = request_run(
+                if let Err(error) = request_run_without_waiting(
                     &daemon_config,
                     &RunRequest {
                         profile: request.profile.clone(),
@@ -98,6 +98,8 @@ impl Dispatcher for SocketDispatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{BufRead, BufReader, ErrorKind};
+    use std::os::unix::net::UnixListener;
     use std::str::FromStr;
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
@@ -149,6 +151,19 @@ mod tests {
         panic!("timed out waiting for {}", path.display());
     }
 
+    fn unique_runtime_dir(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "agentd-scheduler-test-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&path).expect("runtime dir should be created");
+        path
+    }
+
     #[test]
     fn scheduled_profiles_ignore_profiles_without_schedule() {
         let config = Config::from_str(
@@ -184,15 +199,7 @@ command = ["code-reviewer", "exec"]
 
     #[test]
     fn socket_dispatcher_sends_runs_through_the_daemon_socket() {
-        let runtime_dir = std::env::temp_dir().join(format!(
-            "agentd-scheduler-dispatch-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time should be after epoch")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+        let runtime_dir = unique_runtime_dir("dispatch");
         let config = Config::from_str(&format!(
             r#"
 [daemon]
@@ -251,5 +258,71 @@ command = ["site-builder", "exec"]
             .join()
             .expect("daemon thread should join")
             .expect("daemon should exit cleanly");
+    }
+
+    #[test]
+    fn socket_dispatcher_closes_the_socket_after_writing_the_run_request() {
+        let runtime_dir = unique_runtime_dir("fire-and-forget");
+        let socket_path = runtime_dir.join("agentd.sock");
+        let listener = UnixListener::bind(&socket_path).expect("listener should bind");
+        let config = Config::from_str(&format!(
+            r#"
+[daemon]
+socket_path = "{socket_path}"
+pid_file = "{pid_file}"
+
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/site.git"
+
+command = ["site-builder", "exec"]
+"#,
+            socket_path = socket_path.display(),
+            pid_file = runtime_dir.join("agentd.pid").display(),
+        ))
+        .expect("config should parse");
+        let dispatcher = SocketDispatcher {
+            daemon_config: config.daemon().clone(),
+        };
+
+        dispatcher
+            .dispatch(ScheduledRunRequest {
+                profile: "site-builder".to_string(),
+                repo_url: "https://example.com/site.git".to_string(),
+            })
+            .expect("dispatch should spawn a socket client");
+
+        let (stream, _) = listener.accept().expect("dispatcher should connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("stream timeout should be configured");
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        let bytes_read = reader
+            .read_line(&mut line)
+            .expect("dispatcher should write one json line");
+        assert!(bytes_read > 0, "expected a run request payload");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&line).expect("request should be valid json"),
+            serde_json::json!({
+                "type": "run",
+                "profile": "site-builder",
+                "repo_url": "https://example.com/site.git",
+                "work_unit": null,
+            })
+        );
+
+        line.clear();
+        let eof = reader.read_line(&mut line);
+        match eof {
+            Ok(0) => {}
+            Ok(bytes_read) => panic!("expected EOF after the request line, got {bytes_read} bytes"),
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                panic!("dispatcher kept the socket open instead of closing after the write")
+            }
+            Err(error) => panic!("expected EOF after the request line, got {error}"),
+        }
     }
 }

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -1,14 +1,17 @@
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use agentd::config::Config;
 use agentd::{SessionExecutor, run_daemon_until_shutdown};
 use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+
+type DaemonHandle = thread::JoinHandle<Result<(), agentd::DaemonError>>;
+type RecordedInvocations = Arc<Mutex<Vec<SessionInvocation>>>;
 
 #[derive(Clone)]
 struct FixedOutcomeExecutor {
@@ -21,6 +24,39 @@ impl SessionExecutor for FixedOutcomeExecutor {
         _spec: SessionSpec,
         _invocation: SessionInvocation,
     ) -> Result<SessionOutcome, RunnerError> {
+        Ok(self.outcome.clone())
+    }
+}
+
+#[derive(Clone)]
+struct RecordingInvocationExecutor {
+    outcome: SessionOutcome,
+    invocations: Arc<Mutex<Vec<SessionInvocation>>>,
+}
+
+impl RecordingInvocationExecutor {
+    fn new(outcome: SessionOutcome) -> (Self, Arc<Mutex<Vec<SessionInvocation>>>) {
+        let invocations = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                outcome,
+                invocations: Arc::clone(&invocations),
+            },
+            invocations,
+        )
+    }
+}
+
+impl SessionExecutor for RecordingInvocationExecutor {
+    fn run_session(
+        &self,
+        _spec: SessionSpec,
+        invocation: SessionInvocation,
+    ) -> Result<SessionOutcome, RunnerError> {
+        self.invocations
+            .lock()
+            .expect("recorded invocations should lock")
+            .push(invocation);
         Ok(self.outcome.clone())
     }
 }
@@ -59,6 +95,27 @@ command = ["site-builder", "exec"]
 "#,
         socket_path = socket_path.display(),
         pid_file = pid_file.display()
+    )
+}
+
+fn daemon_test_config_with_default_repo(socket_path: &Path, pid_file: &Path, repo: &str) -> String {
+    format!(
+        r#"
+[daemon]
+socket_path = "{socket_path}"
+pid_file = "{pid_file}"
+
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "{repo}"
+
+command = ["site-builder", "exec"]
+"#,
+        socket_path = socket_path.display(),
+        pid_file = pid_file.display(),
+        repo = repo
     )
 }
 
@@ -109,21 +166,31 @@ fn terminate(child: &mut Child) -> io::Result<()> {
 fn start_test_daemon(
     config_path: &Path,
     outcome: SessionOutcome,
-) -> (
-    Arc<AtomicBool>,
-    thread::JoinHandle<Result<(), agentd::DaemonError>>,
-    Config,
-) {
+) -> (Arc<AtomicBool>, DaemonHandle, Config) {
     let config = Config::load(config_path).expect("test config should load");
     let shutdown = Arc::new(AtomicBool::new(false));
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let executor = FixedOutcomeExecutor { outcome };
-    let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown.as_ref())
-    });
+    let handle =
+        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
     wait_for_path(config.daemon().socket_path());
     (shutdown, handle, config)
+}
+
+fn start_recording_test_daemon(
+    config_path: &Path,
+    outcome: SessionOutcome,
+) -> (Arc<AtomicBool>, DaemonHandle, Config, RecordedInvocations) {
+    let config = Config::load(config_path).expect("test config should load");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (executor, invocations) = RecordingInvocationExecutor::new(outcome);
+    let handle =
+        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    wait_for_path(config.daemon().socket_path());
+    (shutdown, handle, config, invocations)
 }
 
 #[test]
@@ -213,6 +280,149 @@ fn binary_run_command_reports_clear_error_when_daemon_is_not_running() {
     assert!(
         stderr.contains("agentd is not running"),
         "expected daemon-not-running error, got: {stderr}"
+    );
+}
+
+#[test]
+fn binary_run_command_uses_profile_default_repo_when_repo_argument_is_omitted() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-default-repo-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let default_repo = "https://example.com/default.git";
+    let config_path = write_temp_config(
+        "client-command-default-repo",
+        &daemon_test_config_with_default_repo(&socket_path, &pid_file, default_repo),
+    );
+
+    let (shutdown, handle, _config, invocations) =
+        start_recording_test_daemon(&config_path, SessionOutcome::Succeeded);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should succeed with a profile default repo: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        invocations.lock().expect("invocations should lock")[0].repo_url,
+        default_repo
+    );
+}
+
+#[test]
+fn binary_run_command_prefers_explicit_repo_over_profile_default_repo() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-explicit-repo-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-explicit-repo",
+        &daemon_test_config_with_default_repo(
+            &socket_path,
+            &pid_file,
+            "https://example.com/default.git",
+        ),
+    );
+    let explicit_repo = "https://example.com/override.git";
+
+    let (shutdown, handle, _config, invocations) =
+        start_recording_test_daemon(&config_path, SessionOutcome::Succeeded);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            explicit_repo,
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should succeed with an explicit repo override: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        invocations.lock().expect("invocations should lock")[0].repo_url,
+        explicit_repo
+    );
+}
+
+#[test]
+fn binary_run_command_reports_clear_error_when_repo_is_missing_from_cli_and_profile() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-missing-repo-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-missing-repo",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        !output.status.success(),
+        "run command should fail when no repo is available"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert!(
+        stderr.contains("requires a repo argument or configured profile repo"),
+        "expected missing-repo error, got: {stderr}"
     );
 }
 

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -427,6 +427,50 @@ fn binary_run_command_reports_clear_error_when_repo_is_missing_from_cli_and_prof
 }
 
 #[test]
+fn binary_run_command_reports_unknown_profile_when_repo_argument_is_omitted() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-unknown-profile-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-unknown-profile",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "unknown-profile",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        !output.status.success(),
+        "run command should fail for an unknown profile"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert!(
+        stderr.contains("unknown profile 'unknown-profile'"),
+        "expected unknown-profile error, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("requires a repo argument or configured profile repo"),
+        "unknown-profile failure should not be reported as missing repo: {stderr}"
+    );
+}
+
+#[test]
 fn binary_run_command_exits_non_zero_and_reports_failed_sessions_on_stderr() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-failed-{}-{}",

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -97,6 +97,11 @@ fn parses_example_config_into_static_profile_settings() {
     );
     assert_eq!(site_builder.methodology_dir(), Path::new("../groundwork"));
     assert_eq!(
+        site_builder.repo(),
+        Some("https://github.com/pentaxis93/agentd.git")
+    );
+    assert_eq!(site_builder.schedule(), Some("*/15 * * * *"));
+    assert_eq!(
         site_builder.repo_token_source(),
         Some("SITE_BUILDER_REPO_TOKEN")
     );
@@ -119,6 +124,11 @@ fn parses_example_config_into_static_profile_settings() {
         "ghcr.io/example/code-reviewer:latest"
     );
     assert_eq!(code_reviewer.methodology_dir(), Path::new("../groundwork"));
+    assert_eq!(
+        code_reviewer.repo(),
+        Some("https://github.com/pentaxis93/agentd.git")
+    );
+    assert_eq!(code_reviewer.schedule(), None);
     assert_eq!(
         code_reviewer.repo_token_source(),
         Some("CODE_REVIEWER_REPO_TOKEN")
@@ -500,6 +510,51 @@ command = ["site-builder", "exec"]
 }
 
 #[test]
+fn parses_profile_repo_as_optional_default_clone_url() {
+    let config = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/agentd.git"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse repo");
+
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
+
+    assert_eq!(profile.repo(), Some("https://example.com/agentd.git"));
+}
+
+#[test]
+fn parses_profile_schedule_as_optional_cron_expression() {
+    let config = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/agentd.git"
+schedule = "*/15 * * * *"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse schedule");
+
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
+
+    assert_eq!(profile.schedule(), Some("*/15 * * * *"));
+}
+
+#[test]
 fn normalizes_empty_repo_token_source_to_none() {
     let config = Config::from_str(
         r#"
@@ -519,6 +574,73 @@ command = ["site-builder", "exec"]
         .expect("profile should exist");
 
     assert_eq!(profile.repo_token_source(), None);
+}
+
+#[test]
+fn rejects_schedule_without_repo() {
+    let error = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+schedule = "*/15 * * * *"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect_err("scheduled profiles without repos should be rejected");
+
+    match error {
+        ConfigError::ScheduleRequiresRepo { profile } => assert_eq!(profile, "site-builder"),
+        other => panic!("expected schedule-requires-repo error, got {other}"),
+    }
+}
+
+#[test]
+fn rejects_invalid_profile_repo_url() {
+    let error = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "/srv/test-repo.git"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect_err("invalid profile repos should be rejected");
+
+    match error {
+        ConfigError::InvalidRepo { profile, .. } => assert_eq!(profile, "site-builder"),
+        other => panic!("expected invalid repo error, got {other}"),
+    }
+}
+
+#[test]
+fn rejects_invalid_profile_schedule() {
+    let error = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+repo = "https://example.com/agentd.git"
+schedule = "* * *"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect_err("invalid profile schedules should be rejected");
+
+    match error {
+        ConfigError::InvalidSchedule { profile, schedule } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(schedule, "* * *");
+        }
+        other => panic!("expected invalid schedule error, got {other}"),
+    }
 }
 
 #[test]

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -184,9 +184,8 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     let executor = FixedOutcomeExecutor {
         outcome: SessionOutcome::Failed { exit_code: 23 },
     };
-    let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown.as_ref())
-    });
+    let handle =
+        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
     wait_for_path(config.daemon().socket_path());
 
     let outcome = request_run(
@@ -250,9 +249,8 @@ fn starting_second_daemon_instance_fails_with_existing_pid() {
     let executor = FixedOutcomeExecutor {
         outcome: SessionOutcome::Succeeded,
     };
-    let first_handle = thread::spawn(move || {
-        run_daemon_until_shutdown(first_config, executor, first_shutdown.as_ref())
-    });
+    let first_handle =
+        thread::spawn(move || run_daemon_until_shutdown(first_config, executor, first_shutdown));
     wait_for_path(config.daemon().socket_path());
 
     let second_result = run_daemon_until_shutdown(
@@ -260,7 +258,7 @@ fn starting_second_daemon_instance_fails_with_existing_pid() {
         FixedOutcomeExecutor {
             outcome: SessionOutcome::Succeeded,
         },
-        &AtomicBool::new(false),
+        Arc::new(AtomicBool::new(false)),
     );
 
     match second_result.expect_err("second daemon should fail to start") {
@@ -296,9 +294,8 @@ fn daemon_shutdown_removes_pid_file_and_socket() {
     let executor = FixedOutcomeExecutor {
         outcome: SessionOutcome::Succeeded,
     };
-    let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown.as_ref())
-    });
+    let handle =
+        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
     wait_for_path(config.daemon().socket_path());
     wait_for_path(config.daemon().pid_file());
 
@@ -340,7 +337,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown.as_ref())
+        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -431,7 +428,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
         BlockingFirstRunExecutor::new(SessionOutcome::Succeeded, SessionOutcome::Succeeded);
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown.as_ref())
+        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -492,7 +489,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
         BlockingFirstRunExecutor::new(SessionOutcome::Succeeded, SessionOutcome::Succeeded);
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown.as_ref())
+        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -586,7 +583,7 @@ source = "AGENTD_GITHUB_TOKEN"
             FixedOutcomeExecutor {
                 outcome: SessionOutcome::Succeeded,
             },
-            daemon_shutdown.as_ref(),
+            daemon_shutdown,
         )
     });
     wait_for_path(config.daemon().socket_path());
@@ -631,7 +628,7 @@ fn daemon_startup_refuses_to_delete_a_non_socket_socket_path() {
         FixedOutcomeExecutor {
             outcome: SessionOutcome::Succeeded,
         },
-        &AtomicBool::new(false),
+        Arc::new(AtomicBool::new(false)),
     )
     .expect_err("daemon startup should fail for a non-socket socket_path");
 
@@ -672,7 +669,7 @@ command = ["site-builder", "exec"]
         FixedOutcomeExecutor {
             outcome: SessionOutcome::Succeeded,
         },
-        &AtomicBool::new(false),
+        Arc::new(AtomicBool::new(false)),
     )
     .expect_err("relative daemon paths should abort startup");
 

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -1,5 +1,5 @@
 # Static profile registry for agentd.
-# Session-specific inputs such as repo and work unit come from the CLI at run time.
+# A profile can carry its own default repo and optional schedule.
 
 [[profiles]]
 # Stable operator-facing profile name used for lookup and container identity.
@@ -8,6 +8,11 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
+# Default repository URL cloned for manual runs when `agentd run` omits a repo,
+# and for each scheduled run of this profile.
+repo = "https://github.com/pentaxis93/agentd.git"
+# Optional five-field cron expression in daemon-local time.
+schedule = "*/15 * * * *"
 # Static session command executed from the cloned repository. This profile is
 # tightly bound to one codebase, so the session repo is the app it builds.
 command = [
@@ -40,6 +45,7 @@ source = "AGENTD_GITHUB_TOKEN"
 name = "code-reviewer"
 base_image = "ghcr.io/example/code-reviewer:latest"
 methodology_dir = "../groundwork"
+repo = "https://github.com/pentaxis93/agentd.git"
 command = [
   "/bin/sh",
   "-lc",


### PR DESCRIPTION
## Summary

- add profile-level `repo` defaults and optional cron `schedule` fields with config-time validation
- implement `agentd-scheduler` as a real cron scheduler that dispatches through the daemon's Unix socket
- let `agentd run` omit the repo when the selected profile already declares one, while keeping explicit CLI repo override behavior
- restore daemon shutdown and CLI diagnostics regressions found during review before landing the scheduler work

## Changes

- extend profile config parsing, validation, and docs for `repo` and `schedule`, including rejection of scheduled profiles without a default repo
- add scheduler runtime types and timing logic in `agentd-scheduler`, then wire daemon startup and shutdown to own a socket-backed scheduler thread
- tighten daemon shutdown so hard accept-loop failures assert shared shutdown before joining the scheduler thread
- preserve distinct CLI error reporting for unknown profiles versus known profiles that lack a configured default repo
- add CLI, config, and socket-interface coverage for default repo resolution, overlapping schedules, no-backfill behavior, and scheduled dispatch through the daemon intake path

## Issue(s)

Refs #50
Blocked by #72
Refs #24

## Test plan

- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
