### PR TITLE
fix: interpret session outcomes per commons convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.grok/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,9 @@ The daemon's Unix socket is the single intake for all session triggers. Manual
 CLI invocation connects to that socket as a client. Scheduling policy also
 connects to that socket as a client when it decides work should start. The
 daemon accepts those run requests uniformly and dispatches them into session
-execution.
+execution. In `v0.1.x` this socket protocol is internal and unversioned:
+daemon and CLI must be the same build, and replacing the binary requires a
+daemon restart before new CLI invocations are supported.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
 
 ## [0.1.0] — 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ and binds a Unix socket for operator control. Default paths:
 `/run/agentd/agentd.sock` and `/run/agentd/agentd.pid`. On SIGINT or SIGTERM,
 the daemon stops accepting connections and drains in-flight sessions; a second
 signal exits immediately.
+The Unix socket protocol is internal to `agentd` in `v0.1.x`: daemon and CLI must be the same build, and operators must restart the daemon after replacing the binary before using `agentd run` again.
 
 Trigger a session through the running daemon:
 

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -437,10 +437,7 @@ where
 }
 
 fn container_status_to_outcome(status: ExitStatus) -> SessionOutcome {
-    match status.code().unwrap_or(1) {
-        0 => SessionOutcome::Succeeded,
-        exit_code => SessionOutcome::Failed { exit_code },
-    }
+    SessionOutcome::from_exit_code(status.code().unwrap_or(1))
 }
 
 fn inspect_terminal_container_outcome(container_name: &str) -> Option<SessionOutcome> {
@@ -470,10 +467,7 @@ fn parse_container_state(output: &str) -> Option<(&str, i32)> {
 }
 
 fn exit_code_to_outcome(exit_code: i32) -> SessionOutcome {
-    match exit_code {
-        0 => SessionOutcome::Succeeded,
-        exit_code => SessionOutcome::Failed { exit_code },
-    }
+    SessionOutcome::from_exit_code(exit_code)
 }
 
 fn inspect_container_status(container_name: &str) -> Result<String, RunnerError> {

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -15,6 +15,8 @@ use crate::types::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
 use std::collections::VecDeque;
 use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -437,6 +439,14 @@ where
 }
 
 fn container_status_to_outcome(status: ExitStatus) -> SessionOutcome {
+    #[cfg(unix)]
+    if let Some(signal) = status.signal() {
+        return SessionOutcome::TerminatedBySignal {
+            exit_code: 128 + signal,
+            signal,
+        };
+    }
+
     SessionOutcome::from_exit_code(status.code().unwrap_or(1))
 }
 

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -456,6 +456,32 @@ fn attached_start_classifies_signal_exit_as_signal_termination() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn attached_start_classifies_real_process_signals_as_signal_termination() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let outcome = classify_attached_start_result(
+        vec![
+            "start".to_string(),
+            "--attach".to_string(),
+            "container".to_string(),
+        ],
+        "container",
+        ExitStatusExt::from_raw(2),
+        String::new(),
+    )
+    .expect("real signal terminations should be preserved as semantic outcomes");
+
+    assert_eq!(
+        outcome,
+        SessionOutcome::TerminatedBySignal {
+            exit_code: 130,
+            signal: 2,
+        }
+    );
+}
+
 #[test]
 fn attached_start_classifies_zero_exit_as_success() {
     let outcome = classify_attached_start_result(

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -392,11 +392,11 @@ fn attached_start_preserves_exit_code_125_when_inspection_reports_terminal_exit(
         ],
         exit_status(125),
         String::new(),
-        || Some(SessionOutcome::Failed { exit_code: 125 }),
+        || Some(SessionOutcome::GenericFailure { exit_code: 125 }),
     )
     .expect("inspected terminal exit code should win over podman attach status");
 
-    assert_eq!(outcome, SessionOutcome::Failed { exit_code: 125 });
+    assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 125 });
 }
 
 #[test]
@@ -413,7 +413,47 @@ fn attached_start_classifies_nonzero_exit_as_session_failure() {
     )
     .expect("nonzero exit codes should remain session outcomes");
 
-    assert_eq!(outcome, SessionOutcome::Failed { exit_code: 23 });
+    assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 23 });
+}
+
+#[test]
+fn attached_start_classifies_blocked_exit_as_blocked() {
+    let outcome = classify_attached_start_result(
+        vec![
+            "start".to_string(),
+            "--attach".to_string(),
+            "container".to_string(),
+        ],
+        "container",
+        exit_status(3),
+        String::new(),
+    )
+    .expect("blocked exits should be preserved as semantic outcomes");
+
+    assert_eq!(outcome, SessionOutcome::Blocked { exit_code: 3 });
+}
+
+#[test]
+fn attached_start_classifies_signal_exit_as_signal_termination() {
+    let outcome = classify_attached_start_result(
+        vec![
+            "start".to_string(),
+            "--attach".to_string(),
+            "container".to_string(),
+        ],
+        "container",
+        exit_status(130),
+        String::new(),
+    )
+    .expect("signal-derived exits should be preserved as semantic outcomes");
+
+    assert_eq!(
+        outcome,
+        SessionOutcome::TerminatedBySignal {
+            exit_code: 130,
+            signal: 2,
+        }
+    );
 }
 
 #[test]
@@ -430,7 +470,7 @@ fn attached_start_classifies_zero_exit_as_success() {
     )
     .expect("successful attached starts should remain successful session outcomes");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
 }
 
 #[test]
@@ -537,7 +577,7 @@ fn fake_podman_scenario_records_create_arguments_for_a_successful_session() {
 
     assert_eq!(
         outcome.expect("session should succeed with fake podman"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
     assert!(fixture.create_args().contains("--name"));
 }
@@ -562,7 +602,7 @@ fn run_session_does_not_pass_resolved_environment_values_via_podman_create_argum
 
     assert_eq!(
         outcome.expect("session should succeed with fake podman"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
 
     let create_args = fixture.create_args();
@@ -600,7 +640,7 @@ fn run_session_does_not_pass_repo_token_via_podman_create_arguments() {
 
     assert_eq!(
         outcome.expect("session should succeed with repo token"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
 
     let create_args = fixture.create_args();
@@ -646,7 +686,7 @@ fn run_session_injects_empty_environment_values_via_direct_env_args() {
 
     assert_eq!(
         outcome.expect("session should succeed with mixed empty and non-empty environment"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
 
     let create_args = fixture.create_args();
@@ -686,7 +726,7 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
 
     assert_eq!(
         outcome.expect("session should succeed with fake podman"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
 
     let create_args = fixture.create_args();
@@ -761,7 +801,7 @@ fn run_session_releases_session_secrets_after_container_reaches_running_state() 
 
     assert_eq!(
         outcome.expect("session should succeed with fake podman"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
     assert!(fixture.secret_commands().contains("create"));
     assert!(fixture.secret_commands().contains("rm"));
@@ -809,7 +849,7 @@ fn run_session_continues_when_secret_release_fails_after_container_reaches_runni
 
     assert_eq!(
         outcome.expect("session should still succeed when secret release fails"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
     assert_eq!(
         fixture
@@ -1124,7 +1164,7 @@ fn fake_podman_scenario_allows_create_stdout_without_breaking_success() {
 
     assert_eq!(
         outcome.expect("session should still succeed"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
 }
 

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -49,11 +49,11 @@ use validation::{validate_invocation, validate_spec};
 /// and runs an ephemeral podman container, then cleans up all resources
 /// regardless of outcome.
 ///
-/// Returns [`SessionOutcome::Succeeded`] when the container exits 0,
-/// [`SessionOutcome::Failed`] for non-zero exits, or
+/// Returns a semantic [`SessionOutcome`] interpreted from the container exit
+/// code according to the shared commons contract, or
 /// [`SessionOutcome::TimedOut`] when the optional timeout fires. Returns
 /// [`RunnerError`] for validation failures, I/O errors, or podman command
-/// failures.
+/// failures before a terminal session outcome can be established.
 pub fn run_session(
     spec: SessionSpec,
     invocation: SessionInvocation,
@@ -208,14 +208,15 @@ mod tests {
             });
             assert_eq!(
                 outcome.expect("session should succeed"),
-                SessionOutcome::Succeeded
+                SessionOutcome::Success { exit_code: 0 }
             );
         });
 
         assert_eq!(events.len(), 3);
         assert_eq!(events[0]["fields"]["event"], "runner.session_started");
         assert_eq!(events[1]["fields"]["event"], "runner.session_outcome");
-        assert_eq!(events[1]["fields"]["outcome"], "succeeded");
+        assert_eq!(events[1]["fields"]["outcome"], "success");
+        assert_eq!(events[1]["fields"]["exit_code"], 0);
         assert_eq!(events[2]["fields"]["event"], "runner.session_teardown");
         assert_eq!(events[2]["fields"]["result"], "ok");
     }

--- a/crates/agentd-runner/src/lifecycle.rs
+++ b/crates/agentd-runner/src/lifecycle.rs
@@ -79,27 +79,32 @@ pub(crate) fn log_session_outcome(
     outcome: &SessionOutcome,
 ) {
     match outcome {
-        SessionOutcome::Succeeded => tracing::info!(
-            event = "runner.session_outcome",
-            session_id = session_id,
-            container_name = container_name,
-            outcome = "succeeded",
-            "runner session completed"
-        ),
-        SessionOutcome::Failed { exit_code } => tracing::info!(
-            event = "runner.session_outcome",
-            session_id = session_id,
-            container_name = container_name,
-            outcome = "failed",
-            exit_code = *exit_code,
-            "runner session completed"
-        ),
         SessionOutcome::TimedOut => tracing::warn!(
             event = "runner.session_outcome",
             session_id = session_id,
             container_name = container_name,
-            outcome = "timed_out",
+            outcome = outcome.label(),
             "runner session timed out"
+        ),
+        SessionOutcome::Success { .. }
+        | SessionOutcome::Blocked { .. }
+        | SessionOutcome::NothingReady { .. } => tracing::info!(
+            event = "runner.session_outcome",
+            session_id = session_id,
+            container_name = container_name,
+            outcome = outcome.label(),
+            exit_code = outcome.exit_code(),
+            signal = outcome.signal(),
+            "runner session completed"
+        ),
+        _ => tracing::warn!(
+            event = "runner.session_outcome",
+            session_id = session_id,
+            container_name = container_name,
+            outcome = outcome.label(),
+            exit_code = outcome.exit_code(),
+            signal = outcome.signal(),
+            "runner session completed"
         ),
     }
 }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -121,7 +121,7 @@ impl SessionOutcome {
             6 => Self::InfrastructureFailure { exit_code },
             126 => Self::CommandNotExecutable { exit_code },
             127 => Self::CommandNotFound { exit_code },
-            128.. => Self::TerminatedBySignal {
+            129.. => Self::TerminatedBySignal {
                 exit_code,
                 signal: exit_code - 128,
             },
@@ -177,6 +177,30 @@ impl SessionOutcome {
             self,
             Self::Success { .. } | Self::Blocked { .. } | Self::NothingReady { .. }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionOutcome;
+
+    #[test]
+    fn exit_code_128_is_generic_failure() {
+        assert_eq!(
+            SessionOutcome::from_exit_code(128),
+            SessionOutcome::GenericFailure { exit_code: 128 }
+        );
+    }
+
+    #[test]
+    fn signal_derived_exit_codes_above_128_remain_signal_terminations() {
+        assert_eq!(
+            SessionOutcome::from_exit_code(130),
+            SessionOutcome::TerminatedBySignal {
+                exit_code: 130,
+                signal: 2,
+            }
+        );
     }
 }
 

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -85,11 +85,99 @@ pub struct SessionInvocation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionOutcome {
     /// The container process exited with code 0.
-    Succeeded,
-    /// The container process exited with a non-zero code.
-    Failed { exit_code: i32 },
+    Success { exit_code: i32 },
+    /// The session failed without a more specific semantic classification.
+    GenericFailure { exit_code: i32 },
+    /// The caller invoked the runtime incorrectly.
+    UsageError { exit_code: i32 },
+    /// Actionable work exists, but execution is blocked on prerequisites.
+    Blocked { exit_code: i32 },
+    /// No actionable work is currently available.
+    NothingReady { exit_code: i32 },
+    /// Work was attempted but required completion checks failed.
+    WorkFailed { exit_code: i32 },
+    /// The runtime or environment failed independently of the work item.
+    InfrastructureFailure { exit_code: i32 },
+    /// The configured command was found but could not be executed.
+    CommandNotExecutable { exit_code: i32 },
+    /// The configured command was not found.
+    CommandNotFound { exit_code: i32 },
+    /// The process terminated from signal `signal`, preserving `128 + signal`.
+    TerminatedBySignal { exit_code: i32, signal: i32 },
     /// The session exceeded its timeout and was force-removed.
     TimedOut,
+}
+
+impl SessionOutcome {
+    /// Interpret a process exit code according to the shared commons contract.
+    pub fn from_exit_code(exit_code: i32) -> Self {
+        match exit_code {
+            0 => Self::Success { exit_code },
+            1 => Self::GenericFailure { exit_code },
+            2 => Self::UsageError { exit_code },
+            3 => Self::Blocked { exit_code },
+            4 => Self::NothingReady { exit_code },
+            5 => Self::WorkFailed { exit_code },
+            6 => Self::InfrastructureFailure { exit_code },
+            126 => Self::CommandNotExecutable { exit_code },
+            127 => Self::CommandNotFound { exit_code },
+            128.. => Self::TerminatedBySignal {
+                exit_code,
+                signal: exit_code - 128,
+            },
+            _ => Self::GenericFailure { exit_code },
+        }
+    }
+
+    /// Canonical snake_case semantic label for this outcome.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Success { .. } => "success",
+            Self::GenericFailure { .. } => "generic_failure",
+            Self::UsageError { .. } => "usage_error",
+            Self::Blocked { .. } => "blocked",
+            Self::NothingReady { .. } => "nothing_ready",
+            Self::WorkFailed { .. } => "work_failed",
+            Self::InfrastructureFailure { .. } => "infrastructure_failure",
+            Self::CommandNotExecutable { .. } => "command_not_executable",
+            Self::CommandNotFound { .. } => "command_not_found",
+            Self::TerminatedBySignal { .. } => "terminated_by_signal",
+            Self::TimedOut => "timed_out",
+        }
+    }
+
+    /// Raw process exit code when this outcome came from process termination.
+    pub fn exit_code(&self) -> Option<i32> {
+        match self {
+            Self::Success { exit_code }
+            | Self::GenericFailure { exit_code }
+            | Self::UsageError { exit_code }
+            | Self::Blocked { exit_code }
+            | Self::NothingReady { exit_code }
+            | Self::WorkFailed { exit_code }
+            | Self::InfrastructureFailure { exit_code }
+            | Self::CommandNotExecutable { exit_code }
+            | Self::CommandNotFound { exit_code } => Some(*exit_code),
+            Self::TerminatedBySignal { exit_code, .. } => Some(*exit_code),
+            Self::TimedOut => None,
+        }
+    }
+
+    /// Signal number when this outcome represents signal-derived termination.
+    pub fn signal(&self) -> Option<i32> {
+        match self {
+            Self::TerminatedBySignal { signal, .. } => Some(*signal),
+            _ => None,
+        }
+    }
+
+    /// Whether the CLI should treat this terminal outcome as process success.
+    pub fn is_cli_success(&self) -> bool {
+        matches!(
+            self,
+            Self::Success { .. } | Self::Blocked { .. } | Self::NothingReady { .. }
+        )
+    }
 }
 
 /// Summary of what startup reconciliation removed before the daemon accepted

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -59,7 +59,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
     )
     .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -107,7 +107,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
     )
     .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -145,7 +145,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
     )
     .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -191,7 +191,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
     )
     .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Failed { exit_code: 23 });
+    assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 23 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -237,7 +237,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
     )
     .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Failed { exit_code: 125 });
+    assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 125 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -284,7 +284,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
     )
     .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -383,7 +383,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
         .expect("session thread should complete")
         .expect("session should run");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -139,16 +139,38 @@ enum ResponseMessage {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 enum OutcomeMessage {
-    Succeeded,
-    Failed { exit_code: i32 },
+    Success { exit_code: i32 },
+    GenericFailure { exit_code: i32 },
+    UsageError { exit_code: i32 },
+    Blocked { exit_code: i32 },
+    NothingReady { exit_code: i32 },
+    WorkFailed { exit_code: i32 },
+    InfrastructureFailure { exit_code: i32 },
+    CommandNotExecutable { exit_code: i32 },
+    CommandNotFound { exit_code: i32 },
+    TerminatedBySignal { exit_code: i32, signal: i32 },
     TimedOut,
 }
 
 impl From<SessionOutcome> for OutcomeMessage {
     fn from(outcome: SessionOutcome) -> Self {
         match outcome {
-            SessionOutcome::Succeeded => Self::Succeeded,
-            SessionOutcome::Failed { exit_code } => Self::Failed { exit_code },
+            SessionOutcome::Success { exit_code } => Self::Success { exit_code },
+            SessionOutcome::GenericFailure { exit_code } => Self::GenericFailure { exit_code },
+            SessionOutcome::UsageError { exit_code } => Self::UsageError { exit_code },
+            SessionOutcome::Blocked { exit_code } => Self::Blocked { exit_code },
+            SessionOutcome::NothingReady { exit_code } => Self::NothingReady { exit_code },
+            SessionOutcome::WorkFailed { exit_code } => Self::WorkFailed { exit_code },
+            SessionOutcome::InfrastructureFailure { exit_code } => {
+                Self::InfrastructureFailure { exit_code }
+            }
+            SessionOutcome::CommandNotExecutable { exit_code } => {
+                Self::CommandNotExecutable { exit_code }
+            }
+            SessionOutcome::CommandNotFound { exit_code } => Self::CommandNotFound { exit_code },
+            SessionOutcome::TerminatedBySignal { exit_code, signal } => {
+                Self::TerminatedBySignal { exit_code, signal }
+            }
             SessionOutcome::TimedOut => Self::TimedOut,
         }
     }
@@ -157,10 +179,59 @@ impl From<SessionOutcome> for OutcomeMessage {
 impl From<OutcomeMessage> for SessionOutcome {
     fn from(outcome: OutcomeMessage) -> Self {
         match outcome {
-            OutcomeMessage::Succeeded => Self::Succeeded,
-            OutcomeMessage::Failed { exit_code } => Self::Failed { exit_code },
+            OutcomeMessage::Success { exit_code } => Self::Success { exit_code },
+            OutcomeMessage::GenericFailure { exit_code } => Self::GenericFailure { exit_code },
+            OutcomeMessage::UsageError { exit_code } => Self::UsageError { exit_code },
+            OutcomeMessage::Blocked { exit_code } => Self::Blocked { exit_code },
+            OutcomeMessage::NothingReady { exit_code } => Self::NothingReady { exit_code },
+            OutcomeMessage::WorkFailed { exit_code } => Self::WorkFailed { exit_code },
+            OutcomeMessage::InfrastructureFailure { exit_code } => {
+                Self::InfrastructureFailure { exit_code }
+            }
+            OutcomeMessage::CommandNotExecutable { exit_code } => {
+                Self::CommandNotExecutable { exit_code }
+            }
+            OutcomeMessage::CommandNotFound { exit_code } => Self::CommandNotFound { exit_code },
+            OutcomeMessage::TerminatedBySignal { exit_code, signal } => {
+                Self::TerminatedBySignal { exit_code, signal }
+            }
             OutcomeMessage::TimedOut => Self::TimedOut,
         }
+    }
+}
+
+fn log_manual_run_completed(profile: &str, work_unit: Option<&str>, outcome: &SessionOutcome) {
+    match outcome {
+        SessionOutcome::TimedOut => tracing::warn!(
+            event = "agentd.manual_run_completed",
+            profile = profile,
+            work_unit = work_unit.unwrap_or(""),
+            work_unit_present = work_unit.is_some(),
+            outcome = outcome.label(),
+            "manual run completed"
+        ),
+        SessionOutcome::Success { .. }
+        | SessionOutcome::Blocked { .. }
+        | SessionOutcome::NothingReady { .. } => tracing::info!(
+            event = "agentd.manual_run_completed",
+            profile = profile,
+            work_unit = work_unit.unwrap_or(""),
+            work_unit_present = work_unit.is_some(),
+            outcome = outcome.label(),
+            exit_code = outcome.exit_code(),
+            signal = outcome.signal(),
+            "manual run completed"
+        ),
+        _ => tracing::warn!(
+            event = "agentd.manual_run_completed",
+            profile = profile,
+            work_unit = work_unit.unwrap_or(""),
+            work_unit_present = work_unit.is_some(),
+            outcome = outcome.label(),
+            exit_code = outcome.exit_code(),
+            signal = outcome.signal(),
+            "manual run completed"
+        ),
     }
 }
 
@@ -482,15 +553,18 @@ fn handle_connection_inner(
         } => match dispatch_run(
             config,
             &RunRequest {
-                profile,
+                profile: profile.clone(),
                 repo_url,
-                work_unit,
+                work_unit: work_unit.clone(),
             },
             executor,
         ) {
-            Ok(outcome) => ResponseMessage::SessionOutcome {
-                outcome: outcome.into(),
-            },
+            Ok(outcome) => {
+                log_manual_run_completed(&profile, work_unit.as_deref(), &outcome);
+                ResponseMessage::SessionOutcome {
+                    outcome: outcome.into(),
+                }
+            }
             Err(error) => {
                 tracing::warn!(
                     event = "agentd.manual_run_rejected",
@@ -751,6 +825,24 @@ mod tests {
         os::unix::net::{UnixListener, UnixStream},
     };
 
+    #[test]
+    fn response_message_deserializes_blocked_outcome_payloads() {
+        let response: ResponseMessage = serde_json::from_str(
+            r#"{"type":"session_outcome","outcome":{"status":"blocked","exit_code":3}}"#,
+        )
+        .expect("blocked outcome payload should deserialize");
+
+        match response {
+            ResponseMessage::SessionOutcome { outcome } => {
+                assert_eq!(
+                    SessionOutcome::from(outcome),
+                    SessionOutcome::Blocked { exit_code: 3 }
+                );
+            }
+            other => panic!("expected session outcome response, got {other:?}"),
+        }
+    }
+
     #[derive(Clone)]
     struct FixedOutcomeExecutor;
 
@@ -760,7 +852,7 @@ mod tests {
             _spec: SessionSpec,
             _invocation: SessionInvocation,
         ) -> Result<SessionOutcome, RunnerError> {
-            Ok(SessionOutcome::Succeeded)
+            Ok(SessionOutcome::Success { exit_code: 0 })
         }
     }
 

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -15,8 +15,7 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
 
 #[derive(Debug)]
 enum RunCommandError {
-    Failed { exit_code: i32 },
-    TimedOut,
+    Outcome(agentd_runner::SessionOutcome),
     UnknownProfile { profile: String },
     MissingRepo { profile: String },
 }
@@ -24,8 +23,21 @@ enum RunCommandError {
 impl fmt::Display for RunCommandError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Failed { exit_code } => write!(f, "session failed (exit code {exit_code})"),
-            Self::TimedOut => write!(f, "session timed out"),
+            Self::Outcome(outcome) => match outcome {
+                agentd_runner::SessionOutcome::TimedOut => write!(f, "session timed out"),
+                agentd_runner::SessionOutcome::TerminatedBySignal { exit_code, signal } => write!(
+                    f,
+                    "session {} (exit code {exit_code}, signal {signal})",
+                    outcome.label()
+                ),
+                _ => {
+                    if let Some(exit_code) = outcome.exit_code() {
+                        write!(f, "session {} (exit code {exit_code})", outcome.label())
+                    } else {
+                        write!(f, "session {}", outcome.label())
+                    }
+                }
+            },
             Self::UnknownProfile { profile } => write!(f, "unknown profile '{profile}'"),
             Self::MissingRepo { profile } => write!(
                 f,
@@ -122,15 +134,11 @@ fn run_client(
         },
     )?;
 
-    match outcome {
-        agentd_runner::SessionOutcome::Succeeded => {
-            println!("session succeeded");
-            Ok(())
-        }
-        agentd_runner::SessionOutcome::Failed { exit_code } => {
-            Err(Box::new(RunCommandError::Failed { exit_code }))
-        }
-        agentd_runner::SessionOutcome::TimedOut => Err(Box::new(RunCommandError::TimedOut)),
+    if outcome.is_cli_success() {
+        println!("session {}", outcome.label());
+        Ok(())
+    } else {
+        Err(Box::new(RunCommandError::Outcome(outcome)))
     }
 }
 

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -135,7 +135,7 @@ mod tests {
                 .lock()
                 .expect("invocations should lock")
                 .push(invocation);
-            Ok(SessionOutcome::Succeeded)
+            Ok(SessionOutcome::Success { exit_code: 0 })
         }
     }
 

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -303,7 +303,7 @@ fn binary_run_command_uses_profile_default_repo_when_repo_argument_is_omitted() 
     );
 
     let (shutdown, handle, _config, invocations) =
-        start_recording_test_daemon(&config_path, SessionOutcome::Succeeded);
+        start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
 
     let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
         .args([
@@ -356,7 +356,7 @@ fn binary_run_command_prefers_explicit_repo_over_profile_default_repo() {
     let explicit_repo = "https://example.com/override.git";
 
     let (shutdown, handle, _config, invocations) =
-        start_recording_test_daemon(&config_path, SessionOutcome::Succeeded);
+        start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
 
     let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
         .args([
@@ -491,8 +491,10 @@ fn binary_run_command_exits_non_zero_and_reports_failed_sessions_on_stderr() {
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
     }
-    let (shutdown, handle, _config) =
-        start_test_daemon(&config_path, SessionOutcome::Failed { exit_code: 23 });
+    let (shutdown, handle, _config) = start_test_daemon(
+        &config_path,
+        SessionOutcome::GenericFailure { exit_code: 23 },
+    );
 
     let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
         .args([
@@ -527,7 +529,7 @@ fn binary_run_command_exits_non_zero_and_reports_failed_sessions_on_stderr() {
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
     assert!(
-        stderr.contains("session failed (exit code 23)"),
+        stderr.contains("session generic_failure (exit code 23)"),
         "expected failed-session error on stderr, got: {stderr}"
     );
 }
@@ -588,6 +590,116 @@ fn binary_run_command_exits_non_zero_and_reports_timed_out_sessions_on_stderr() 
 }
 
 #[test]
+fn binary_run_command_exits_zero_and_reports_blocked_sessions_on_stdout() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-blocked-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-blocked",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+
+    let (shutdown, handle, _config) =
+        start_test_daemon(&config_path, SessionOutcome::Blocked { exit_code: 3 });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should treat blocked as a normal terminal state: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session blocked\n"
+    );
+    assert!(
+        String::from_utf8(output.stderr)
+            .expect("stderr should be valid UTF-8")
+            .is_empty(),
+        "blocked run should not print an error-style stderr message"
+    );
+}
+
+#[test]
+fn binary_run_command_exits_zero_and_reports_nothing_ready_sessions_on_stdout() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-nothing-ready-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-nothing-ready",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+
+    let (shutdown, handle, _config) =
+        start_test_daemon(&config_path, SessionOutcome::NothingReady { exit_code: 4 });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should treat nothing_ready as a normal terminal state: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session nothing_ready\n"
+    );
+    assert!(
+        String::from_utf8(output.stderr)
+            .expect("stderr should be valid UTF-8")
+            .is_empty(),
+        "nothing_ready run should not print an error-style stderr message"
+    );
+}
+
+#[test]
 fn binary_run_command_succeeds_when_profile_registry_becomes_invalid_after_daemon_start() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-invalid-registry-{}-{}",
@@ -605,7 +717,8 @@ fn binary_run_command_succeeds_when_profile_registry_becomes_invalid_after_daemo
         &daemon_test_config(&socket_path, &pid_file),
     );
 
-    let (shutdown, handle, _config) = start_test_daemon(&config_path, SessionOutcome::Succeeded);
+    let (shutdown, handle, _config) =
+        start_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
     std::fs::write(
         &config_path,
         format!(
@@ -651,6 +764,6 @@ command = ["site-builder", "exec"]
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session succeeded\n"
+        "session success\n"
     );
 }

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -590,6 +590,67 @@ fn binary_run_command_exits_non_zero_and_reports_timed_out_sessions_on_stderr() 
 }
 
 #[test]
+fn binary_run_command_exits_non_zero_and_reports_signal_terminated_sessions_on_stderr() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-signaled-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-signaled",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+
+    let (shutdown, handle, _config) = start_test_daemon(
+        &config_path,
+        SessionOutcome::TerminatedBySignal {
+            exit_code: 130,
+            signal: 2,
+        },
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        !output.status.success(),
+        "run command should fail when the daemon reports a signal-terminated session"
+    );
+    assert!(
+        String::from_utf8(output.stdout)
+            .expect("stdout should be valid UTF-8")
+            .is_empty(),
+        "signal-terminated run should not print a success-style stdout message"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert!(
+        stderr.contains("session terminated_by_signal (exit code 130, signal 2)"),
+        "expected signal-terminated session error on stderr, got: {stderr}"
+    );
+}
+
+#[test]
 fn binary_run_command_exits_zero_and_reports_blocked_sessions_on_stdout() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-blocked-{}-{}",

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -182,7 +182,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let executor = FixedOutcomeExecutor {
-        outcome: SessionOutcome::Failed { exit_code: 23 },
+        outcome: SessionOutcome::GenericFailure { exit_code: 23 },
     };
     let handle =
         thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
@@ -198,7 +198,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     )
     .expect("client request should succeed");
 
-    assert_eq!(outcome, SessionOutcome::Failed { exit_code: 23 });
+    assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 23 });
 
     shutdown.store(true, Ordering::Release);
     handle
@@ -247,7 +247,7 @@ fn starting_second_daemon_instance_fails_with_existing_pid() {
     let first_config = config.clone();
     let first_shutdown = shutdown.clone();
     let executor = FixedOutcomeExecutor {
-        outcome: SessionOutcome::Succeeded,
+        outcome: SessionOutcome::Success { exit_code: 0 },
     };
     let first_handle =
         thread::spawn(move || run_daemon_until_shutdown(first_config, executor, first_shutdown));
@@ -256,7 +256,7 @@ fn starting_second_daemon_instance_fails_with_existing_pid() {
     let second_result = run_daemon_until_shutdown(
         config.clone(),
         FixedOutcomeExecutor {
-            outcome: SessionOutcome::Succeeded,
+            outcome: SessionOutcome::Success { exit_code: 0 },
         },
         Arc::new(AtomicBool::new(false)),
     );
@@ -292,7 +292,7 @@ fn daemon_shutdown_removes_pid_file_and_socket() {
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let executor = FixedOutcomeExecutor {
-        outcome: SessionOutcome::Succeeded,
+        outcome: SessionOutcome::Success { exit_code: 0 },
     };
     let handle =
         thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
@@ -332,8 +332,8 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let executor = BlockingFirstRunExecutor::new(
-        SessionOutcome::Succeeded,
-        SessionOutcome::Failed { exit_code: 23 },
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::GenericFailure { exit_code: 23 },
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
@@ -374,7 +374,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         Ok(result) => {
             assert_eq!(
                 result.expect("second client request should succeed"),
-                SessionOutcome::Failed { exit_code: 23 }
+                SessionOutcome::GenericFailure { exit_code: 23 }
             );
             true
         }
@@ -390,7 +390,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
             .join()
             .expect("first request thread should join")
             .expect("first client request should succeed"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
     second_request
         .join()
@@ -424,8 +424,10 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
     let shutdown = Arc::new(AtomicBool::new(false));
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
-    let executor =
-        BlockingFirstRunExecutor::new(SessionOutcome::Succeeded, SessionOutcome::Succeeded);
+    let executor = BlockingFirstRunExecutor::new(
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::Success { exit_code: 0 },
+    );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
@@ -465,7 +467,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
             .join()
             .expect("client request thread should join")
             .expect("client request should eventually succeed"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
@@ -485,8 +487,10 @@ fn daemon_shutdown_stops_accepting_new_runs() {
     let shutdown = Arc::new(AtomicBool::new(false));
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
-    let executor =
-        BlockingFirstRunExecutor::new(SessionOutcome::Succeeded, SessionOutcome::Succeeded);
+    let executor = BlockingFirstRunExecutor::new(
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::Success { exit_code: 0 },
+    );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
@@ -529,7 +533,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
             .join()
             .expect("first request thread should join")
             .expect("first client request should succeed"),
-        SessionOutcome::Succeeded
+        SessionOutcome::Success { exit_code: 0 }
     );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
@@ -581,7 +585,7 @@ source = "AGENTD_GITHUB_TOKEN"
         run_daemon_until_shutdown(
             daemon_config,
             FixedOutcomeExecutor {
-                outcome: SessionOutcome::Succeeded,
+                outcome: SessionOutcome::Success { exit_code: 0 },
             },
             daemon_shutdown,
         )
@@ -626,7 +630,7 @@ fn daemon_startup_refuses_to_delete_a_non_socket_socket_path() {
     let error = run_daemon_until_shutdown(
         config.clone(),
         FixedOutcomeExecutor {
-            outcome: SessionOutcome::Succeeded,
+            outcome: SessionOutcome::Success { exit_code: 0 },
         },
         Arc::new(AtomicBool::new(false)),
     )
@@ -667,7 +671,7 @@ command = ["site-builder", "exec"]
     let error = run_daemon_until_shutdown(
         config,
         FixedOutcomeExecutor {
-            outcome: SessionOutcome::Succeeded,
+            outcome: SessionOutcome::Success { exit_code: 0 },
         },
         Arc::new(AtomicBool::new(false)),
     )

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -87,11 +87,11 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: Some("task-42".to_string()),
     };
-    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
     let outcome = dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
 
-    assert_eq!(outcome, SessionOutcome::Succeeded);
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
 
     let state = state.lock().expect("recording state should lock");
     let spec = state
@@ -150,7 +150,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_missing() {
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
-    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
     dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
 
@@ -182,7 +182,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
-    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
     dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
 
@@ -215,7 +215,8 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
-    let (executor, _state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
+    let (executor, _state) =
+        RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
     let error = dispatch_run(&config, &request, &executor)
         .expect_err("missing runtime credential sources should fail dispatch");
@@ -260,7 +261,8 @@ command = ["site-builder", "exec"]
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
     };
-    let (executor, _state) = RecordingExecutor::succeeding(SessionOutcome::Succeeded);
+    let (executor, _state) =
+        RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
     let error =
         dispatch_run(&config, &request, &executor).expect_err("relative daemon paths should fail");

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -97,3 +97,26 @@ fn architecture_describes_uniform_socket_intake_for_session_triggers() {
         "architecture should not describe the scheduler as handing work directly to the runner"
     );
 }
+
+#[test]
+fn workspace_docs_declare_same_build_socket_policy() {
+    let readme = read_workspace_file("README.md");
+    let architecture = read_workspace_file("ARCHITECTURE.md");
+
+    assert!(
+        readme.contains("must restart the daemon after replacing the binary"),
+        "README should declare the restart requirement after replacing the binary"
+    );
+    assert!(
+        readme.contains("daemon and CLI must be the same build"),
+        "README should declare the same-build daemon/CLI requirement"
+    );
+    assert!(
+        architecture.contains("internal and unversioned"),
+        "architecture should describe the socket protocol as internal and unversioned"
+    );
+    assert!(
+        architecture.contains("daemon and CLI must be the same build"),
+        "architecture should declare the same-build daemon/CLI requirement"
+    );
+}


### PR DESCRIPTION
## Summary

Align `agentd` and `agentd-runner` with the shared commons exit-code contract.

This replaces the old zero/non-zero outcome model with semantic session outcomes that preserve the raw exit code, updates daemon and runner reporting to emit the semantic labels, and makes `agentd run` treat `blocked` and `nothing_ready` as normal terminal states.

Closes #77.

## What Changed

- replaced the runner `SessionOutcome` succeeded/failed bucket with semantic outcomes for commons-defined exit codes plus reserved shell/signal meanings
- centralized exit-code interpretation so runner completion, daemon transport, and CLI output all use the same mapping
- updated daemon socket serialization and completion logging to carry semantic labels, raw exit codes, and signal numbers where applicable
- changed `agentd run` output so `success`, `blocked`, and `nothing_ready` print to stdout and exit 0, while failure-like outcomes remain stderr/non-zero
- added `.grok/` to `.gitignore`
- updated `CHANGELOG.md` for the new outcome semantics

## Root Cause

`agentd` treated every non-zero session exit code as a generic failure, so commons-defined normal terminal states like `blocked` and `nothing_ready` were misclassified and surfaced incorrectly to operators.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
