### PR TITLE
feat: support profile-declared bind mounts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,6 +140,7 @@ agentd runs sessions in ephemeral Podman containers so agents remain separated f
 | Mount or Injection | Purpose | Need Served |
 |---|---|---|
 | Read-only methodology directory | Expose the configured methodology manifest and protocol assets without allowing mutation | Context |
+| Profile-declared bind mounts | Expose host-managed state such as subscription auth or persistent artifact storage with per-mount read-only vs read-write policy | Context, Credentials |
 | Credentials | Authenticate to external systems without baking secrets into images | Credentials |
 | Home workspace at `/home/{username}` with repo at `/home/{username}/repo` | Give the session a writable standard Linux home and a clean project workspace that starts fresh each run | Mission, Tool Availability, Identity |
 
@@ -147,9 +148,17 @@ From inside the environment, an agent should see:
 - identity-related environment variables
 - `$HOME` set to `/home/{username}`
 - a read-only methodology mount rooted at `manifest.toml`
+- any additional bind mounts declared by the selected profile
 - a fresh writable repository checkout at `/home/{username}/repo`
 - any runtime-managed state the configured session command creates inside the repo or home directory
 - the tools and runtime configuration needed for its assigned work
+
+Additional bind mounts are declared in profile configuration as `source`,
+`target`, and `read_only`. agentd validates absolute container targets and
+unique target paths, then stages canonical host sources through runner-managed
+symlinks before calling Podman so host paths containing commas remain mountable.
+Subscription auth is the first read-only consumer of this mechanism; persistent
+audit storage in `#76` builds on the same path with read-write mounts.
 
 ## 6. Credential Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,11 +154,13 @@ From inside the environment, an agent should see:
 - the tools and runtime configuration needed for its assigned work
 
 Additional bind mounts are declared in profile configuration as `source`,
-`target`, and `read_only`. agentd validates absolute container targets and
-unique target paths, then stages canonical host sources through runner-managed
-symlinks before calling Podman so host paths containing commas remain mountable.
-Subscription auth is the first read-only consumer of this mechanism; persistent
-audit storage in `#76` builds on the same path with read-write mounts.
+`target`, and `read_only`. agentd validates absolute container targets plus a
+per-profile disjointness invariant: target paths must be unique and no target
+may be a path-component prefix of another. It then stages canonical host
+sources through runner-managed symlinks before calling Podman so host paths
+containing commas remain mountable. Subscription auth is the first read-only
+consumer of this mechanism; persistent audit storage in `#76` builds on the
+same path with read-write mounts.
 
 ## 6. Credential Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,8 +122,8 @@ The runner prepares the execution environment:
 2. Sets identity inside the container, including `PROFILE_NAME` and a unique container name derived from the profile.
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
-5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `git`, `useradd`, or `gosu` are not supported.
-6. Transfers ownership of `/home/{username}/repo` to that user, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
+5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, or `gosu` are not supported.
+6. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
 
 ### Phase 3: Execution (`agentd-runner`)
 
@@ -160,7 +160,9 @@ may be a path-component prefix of another. It then stages canonical host
 sources through runner-managed symlinks before calling Podman so host paths
 containing commas remain mountable. Subscription auth is the first read-only
 consumer of this mechanism; persistent audit storage in `#76` builds on the
-same path with read-write mounts.
+same path with read-write mounts. Additional mounts are not relabelled; on
+SELinux-enabled hosts, operators must pre-label those host paths with a
+container-compatible context.
 
 ## 6. Credential Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ The runner prepares the execution environment:
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
 5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `git`, `useradd`, or `gosu` are not supported.
-6. Recursively transfers ownership of `/home/{username}` to that user, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready.
+6. Transfers ownership of `/home/{username}/repo` to that user, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
 
 ### Phase 3: Execution (`agentd-runner`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
 - Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
+- Profile-declared bind mounts now reject overlapping container targets within the same profile, so nested targets fail validation before startup instead of reaching the container setup script.
 
 ## [0.1.0] — 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
+- Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
 
 ## [0.1.0] — 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 #[[profiles.mounts]]
 # Additional host bind mounts are declared explicitly per profile.
 # `source` must be an absolute host path and must already exist.
-# `target` must be an absolute path inside the container.
+# `target` must be an absolute path inside the container and must not
+# duplicate or overlap another mount target in the same profile.
 # `read_only = true` is appropriate for host-managed auth directories.
 #source = "/home/core/.claude"
 #target = "/home/site-builder/.claude"

--- a/README.md
+++ b/README.md
@@ -127,11 +127,14 @@ Credential `source` fields name environment variables in the daemon's process
 environment — export them before starting the daemon. Additional `mounts`
 entries are bind mounts: `source` must be an absolute existing host path,
 `target` must be an absolute container path, targets must be unique within the
-profile, and the methodology mount remains reserved at `/agentd/methodology`.
-The base image must provide `/bin/sh`, `git`, `useradd`, `gosu`, and whatever
-binaries the configured session command uses. When a profile declares
-`schedule`, it must also declare `repo`. Schedules are evaluated in
-daemon-local time and missed fires are not backfilled after downtime.
+profile, and runner-managed targets are reserved: `/agentd/methodology`,
+`/home/{profile}`, and `/home/{profile}/repo` plus its descendants. Other
+targets under `/home/{profile}` remain supported, including read-only auth
+mounts such as `/home/site-builder/.claude`. The base image must provide
+`/bin/sh`, `git`, `useradd`, `gosu`, and whatever binaries the configured
+session command uses. When a profile declares `schedule`, it must also declare
+`repo`. Schedules are evaluated in daemon-local time and missed fires are not
+backfilled after downtime.
 
 ## Running a Session
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ visibility.
 Profiles may now declare a default repository and an optional cron schedule.
 Manual runs still flow through `agentd run`, and scheduled runs dispatch
 through the same daemon socket intake without introducing a separate job type.
+Profiles may also declare additional bind mounts for host-managed state such as
+subscription auth directories or persistent audit storage.
 
 ## Configuration
 
 A profile is a named environment specification: base image, methodology
-directory, optional default repo, optional cron schedule, credentials, and
-runtime command. Define profiles in a TOML config file — start from
+directory, optional additional bind mounts, optional default repo, optional
+cron schedule, credentials, and runtime command. Define profiles in a TOML
+config file — start from
 [`examples/agentd.toml`](examples/agentd.toml):
 
 ```toml
@@ -76,6 +79,15 @@ exec runa run
 # repository authentication. This value does not flow into the agent runtime.
 repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 
+#[[profiles.mounts]]
+# Additional host bind mounts are declared explicitly per profile.
+# `source` must be an absolute host path and must already exist.
+# `target` must be an absolute path inside the container.
+# `read_only = true` is appropriate for host-managed auth directories.
+#source = "/home/core/.claude"
+#target = "/home/site-builder/.claude"
+#read_only = true
+
 [[profiles.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"
@@ -112,11 +124,14 @@ source = "AGENTD_GITHUB_TOKEN"
 ```
 
 Credential `source` fields name environment variables in the daemon's process
-environment — export them before starting the daemon. The base image must
-provide `/bin/sh`, `git`, `useradd`, `gosu`, and whatever binaries the
-configured session command uses. When a profile declares `schedule`, it must
-also declare `repo`. Schedules are evaluated in daemon-local time and missed
-fires are not backfilled after downtime.
+environment — export them before starting the daemon. Additional `mounts`
+entries are bind mounts: `source` must be an absolute existing host path,
+`target` must be an absolute container path, targets must be unique within the
+profile, and the methodology mount remains reserved at `/agentd/methodology`.
+The base image must provide `/bin/sh`, `git`, `useradd`, `gosu`, and whatever
+binaries the configured session command uses. When a profile declares
+`schedule`, it must also declare `repo`. Schedules are evaluated in
+daemon-local time and missed fires are not backfilled after downtime.
 
 ## Running a Session
 
@@ -158,6 +173,7 @@ the container, the agent sees:
 - An unprivileged user with `$HOME` at `/home/site-builder`
 - A fresh clone of the repository at `/home/site-builder/repo`
 - Read-only methodology mount at `/agentd/methodology`
+- Any operator-declared additional bind mounts, read-only or read-write per profile
 - Credentials injected as environment variables
 - `AGENTD_WORK_UNIT` when the invocation includes one
 - The configured session command executing from the repo directory

--- a/README.md
+++ b/README.md
@@ -131,11 +131,13 @@ entries are bind mounts: `source` must be an absolute existing host path,
 profile, and runner-managed targets are reserved: `/agentd/methodology`,
 `/home/{profile}`, and `/home/{profile}/repo` plus its descendants. Other
 targets under `/home/{profile}` remain supported, including read-only auth
-mounts such as `/home/site-builder/.claude`. The base image must provide
-`/bin/sh`, `git`, `useradd`, `gosu`, and whatever binaries the configured
-session command uses. When a profile declares `schedule`, it must also declare
-`repo`. Schedules are evaluated in daemon-local time and missed fires are not
-backfilled after downtime.
+mounts such as `/home/site-builder/.claude`. Additional mounts are not
+relabelled; on SELinux-enabled hosts, operators must ensure each host path
+already has a container-compatible label. The base image must provide
+`/bin/sh`, `find`, `git`, `useradd`, `gosu`, and whatever binaries the
+configured session command uses. When a profile declares `schedule`, it must
+also declare `repo`. Schedules are evaluated in daemon-local time and missed
+fires are not backfilled after downtime.
 
 ## Running a Session
 

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -11,6 +11,7 @@
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::podman::{run_podman_command, run_podman_command_until};
 use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
+use crate::session_paths::{session_home_dir, session_repo_dir};
 use crate::types::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
 use std::collections::VecDeque;
@@ -23,7 +24,6 @@ use std::time::{Duration, Instant};
 
 const ATTACHED_STDERR_TAIL_LIMIT: usize = 64 * 1024;
 const ATTACHED_STDERR_TRUNCATION_NOTICE: &str = "[stderr truncated to last 65536 bytes]\n";
-const HOME_ROOT_DIR: &str = "/home";
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
 const PODMAN_INFRASTRUCTURE_ERROR_EXIT_CODE: i32 = 125;
 
@@ -135,20 +135,25 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 
 // Generates the shell script passed as the container entrypoint via
 // `/bin/sh -lc`. The script runs as root (UID 0) to perform privileged setup:
-// creating the profile's unix user, cloning the repository, and transferring
-// home directory ownership. It then drops privileges permanently via `gosu`
+// creating the profile's unix user, ensuring the home directory itself is
+// owned by that user, cloning the repository, and transferring repository
+// ownership. It then drops privileges permanently via `gosu`
 // and `exec`s the configured session command as the unprivileged profile user
 // from the cloned repository. `set -eu` at the top ensures any setup failure
 // aborts immediately rather than continuing with a broken workspace.
 fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) -> String {
     let username = &spec.profile_name;
-    let home_dir = format!("{HOME_ROOT_DIR}/{username}");
-    let repo_dir = format!("{home_dir}/repo");
+    let home_dir = session_home_dir(username).display().to_string();
+    let repo_dir = session_repo_dir(username).display().to_string();
     let user_group = format!("{username}:{username}");
     let mut script = String::from("set -eu\nuseradd --create-home --home-dir ");
     script.push_str(&shell_quote(&home_dir));
     script.push_str(" --shell /bin/sh --user-group ");
     script.push_str(&shell_quote(username));
+    script.push_str("\nchown ");
+    script.push_str(&shell_quote(&user_group));
+    script.push(' ');
+    script.push_str(&shell_quote(&home_dir));
     script.push_str("\nrm -rf ");
     script.push_str(&shell_quote(&repo_dir));
     script.push('\n');
@@ -158,7 +163,7 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     script.push_str("\nchown -R ");
     script.push_str(&shell_quote(&user_group));
     script.push(' ');
-    script.push_str(&shell_quote(&home_dir));
+    script.push_str(&shell_quote(&repo_dir));
     script.push_str("\nexport HOME=");
     script.push_str(&shell_quote(&home_dir));
     if let Some(work_unit) = &invocation.work_unit {

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -225,6 +225,17 @@ fn build_create_container_args(
             METHODOLOGY_MOUNT_PATH
         ),
     ];
+
+    for mount in &resources.additional_mounts {
+        args.push("--mount".to_string());
+        args.push(format!(
+            "type=bind,src={},target={},ro={},relabel=shared",
+            mount.source.display(),
+            mount.target.display(),
+            mount.read_only
+        ));
+    }
+
     let mut secret_bindings = resources.environment_secret_bindings.iter();
 
     for variable in &spec.environment {

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -14,10 +14,11 @@ use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
 use crate::session_paths::{session_home_dir, session_repo_dir};
 use crate::types::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -143,7 +144,8 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 // aborts immediately rather than continuing with a broken workspace.
 fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) -> String {
     let username = &spec.profile_name;
-    let home_dir = session_home_dir(username).display().to_string();
+    let home_dir_path = session_home_dir(username);
+    let home_dir = home_dir_path.display().to_string();
     let repo_dir = session_repo_dir(username).display().to_string();
     let user_group = format!("{username}:{username}");
     let mut script = String::from("set -eu\nuseradd --create-home --home-dir ");
@@ -154,6 +156,18 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     script.push_str(&shell_quote(&user_group));
     script.push(' ');
     script.push_str(&shell_quote(&home_dir));
+    let mut seen_home_mount_parents = HashSet::new();
+    for mount in &spec.mounts {
+        for intermediate_parent in intermediate_home_mount_parents(&home_dir_path, &mount.target) {
+            if !seen_home_mount_parents.insert(intermediate_parent.clone()) {
+                continue;
+            }
+            script.push_str("\nchown ");
+            script.push_str(&shell_quote(&user_group));
+            script.push(' ');
+            script.push_str(&shell_quote(&intermediate_parent.display().to_string()));
+        }
+    }
     script.push_str("\nrm -rf ");
     script.push_str(&shell_quote(&repo_dir));
     script.push('\n');
@@ -178,6 +192,24 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     script.push_str(&shell_join(&spec.command));
 
     script
+}
+
+fn intermediate_home_mount_parents(home_dir: &Path, mount_target: &Path) -> Vec<PathBuf> {
+    let Ok(relative_target) = mount_target.strip_prefix(home_dir) else {
+        return Vec::new();
+    };
+    if relative_target.as_os_str().is_empty() {
+        return Vec::new();
+    }
+
+    let mut parents = relative_target
+        .ancestors()
+        .skip(1)
+        .take_while(|parent| !parent.as_os_str().is_empty())
+        .map(|parent| home_dir.join(parent))
+        .collect::<Vec<_>>();
+    parents.reverse();
+    parents
 }
 
 fn build_clone_command(invocation: &SessionInvocation, repo_dir: &str) -> String {

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -12,13 +12,13 @@ use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::podman::{run_podman_command, run_podman_command_until};
 use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
 use crate::session_paths::{session_home_dir, session_repo_dir};
-use crate::types::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use crate::types::{BindMount, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -136,9 +136,10 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 
 // Generates the shell script passed as the container entrypoint via
 // `/bin/sh -lc`. The script runs as root (UID 0) to perform privileged setup:
-// creating the profile's unix user, ensuring the home directory itself is
-// owned by that user, cloning the repository, and transferring repository
-// ownership. It then drops privileges permanently via `gosu`
+// creating the profile's unix user, recursively re-owning pre-existing home
+// content while preserving host-backed mount targets, cloning the repository,
+// and transferring repository ownership. It then drops privileges permanently
+// via `gosu`
 // and `exec`s the configured session command as the unprivileged profile user
 // from the cloned repository. `set -eu` at the top ensures any setup failure
 // aborts immediately rather than continuing with a broken workspace.
@@ -146,28 +147,20 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     let username = &spec.profile_name;
     let home_dir_path = session_home_dir(username);
     let home_dir = home_dir_path.display().to_string();
-    let repo_dir = session_repo_dir(username).display().to_string();
+    let repo_dir_path = session_repo_dir(username);
+    let repo_dir = repo_dir_path.display().to_string();
     let user_group = format!("{username}:{username}");
     let mut script = String::from("set -eu\nuseradd --create-home --home-dir ");
     script.push_str(&shell_quote(&home_dir));
     script.push_str(" --shell /bin/sh --user-group ");
     script.push_str(&shell_quote(username));
-    script.push_str("\nchown ");
-    script.push_str(&shell_quote(&user_group));
-    script.push(' ');
-    script.push_str(&shell_quote(&home_dir));
-    let mut seen_home_mount_parents = HashSet::new();
-    for mount in &spec.mounts {
-        for intermediate_parent in intermediate_home_mount_parents(&home_dir_path, &mount.target) {
-            if !seen_home_mount_parents.insert(intermediate_parent.clone()) {
-                continue;
-            }
-            script.push_str("\nchown ");
-            script.push_str(&shell_quote(&user_group));
-            script.push(' ');
-            script.push_str(&shell_quote(&intermediate_parent.display().to_string()));
-        }
-    }
+    script.push('\n');
+    script.push_str(&build_home_ownership_command(
+        &home_dir_path,
+        &repo_dir_path,
+        &spec.mounts,
+        &user_group,
+    ));
     script.push_str("\nrm -rf ");
     script.push_str(&shell_quote(&repo_dir));
     script.push('\n');
@@ -194,22 +187,44 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     script
 }
 
-fn intermediate_home_mount_parents(home_dir: &Path, mount_target: &Path) -> Vec<PathBuf> {
-    let Ok(relative_target) = mount_target.strip_prefix(home_dir) else {
-        return Vec::new();
-    };
+fn build_home_ownership_command(
+    home_dir: &Path,
+    repo_dir: &Path,
+    mounts: &[BindMount],
+    user_group: &str,
+) -> String {
+    let mut prune_targets = mounts
+        .iter()
+        .filter_map(|mount| home_descendant_mount_target(home_dir, &mount.target))
+        .collect::<Vec<_>>();
+    prune_targets.push(repo_dir.display().to_string());
+
+    let mut command = String::from("find ");
+    command.push_str(&shell_quote(&home_dir.display().to_string()));
+    // `find -path`, `-prune`, `-o`, and `-exec ... +` are POSIX. `-mindepth`
+    // is a widely available extension that we rely on as part of the base
+    // image contract so the home directory entry itself is re-owned.
+    command.push_str(" -mindepth 0 \\( ");
+    for (index, prune_target) in prune_targets.iter().enumerate() {
+        if index > 0 {
+            command.push_str(" -o ");
+        }
+        command.push_str("-path ");
+        command.push_str(&shell_quote(prune_target));
+    }
+    command.push_str(" \\) -prune -o -exec chown ");
+    command.push_str(&shell_quote(user_group));
+    command.push_str(" {} +");
+    command
+}
+
+fn home_descendant_mount_target(home_dir: &Path, mount_target: &Path) -> Option<String> {
+    let relative_target = mount_target.strip_prefix(home_dir).ok()?;
     if relative_target.as_os_str().is_empty() {
-        return Vec::new();
+        return None;
     }
 
-    let mut parents = relative_target
-        .ancestors()
-        .skip(1)
-        .take_while(|parent| !parent.as_os_str().is_empty())
-        .map(|parent| home_dir.join(parent))
-        .collect::<Vec<_>>();
-    parents.reverse();
-    parents
+    Some(mount_target.display().to_string())
 }
 
 fn build_clone_command(invocation: &SessionInvocation, repo_dir: &str) -> String {
@@ -266,7 +281,7 @@ fn build_create_container_args(
     for mount in &resources.additional_mounts {
         args.push("--mount".to_string());
         args.push(format!(
-            "type=bind,src={},target={},ro={},relabel=shared",
+            "type=bind,src={},target={},ro={}",
             mount.source.display(),
             mount.target.display(),
             mount.read_only

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -155,9 +155,19 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
     assert!(mount_values[1].contains("src=/tmp/staging/mount-0"));
     assert!(mount_values[1].contains("target=/home/site-builder/.claude"));
     assert!(mount_values[1].contains("ro=true"));
+    assert!(
+        !mount_values[1].contains("relabel="),
+        "operator-declared mounts should not mutate host SELinux labels: {}",
+        mount_values[1]
+    );
     assert!(mount_values[2].contains("src=/tmp/staging/mount-1"));
     assert!(mount_values[2].contains("target=/home/site-builder/.runa"));
     assert!(mount_values[2].contains("ro=false"));
+    assert!(
+        !mount_values[2].contains("relabel="),
+        "operator-declared mounts should not mutate host SELinux labels: {}",
+        mount_values[2]
+    );
 }
 
 #[test]
@@ -207,12 +217,15 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
     );
 
     assert!(script.contains("useradd --create-home --home-dir '/home/myprofile' --shell /bin/sh --user-group 'myprofile'"));
-    assert!(script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
+    assert!(script.contains(
+        "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
+    ));
     assert!(script.contains(
         "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/myprofile/repo'"
     ));
     assert!(script.contains("\ncd '/home/myprofile/repo'\n"));
     assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile/repo'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(!script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
     assert!(script.contains("\nexport AGENTD_WORK_UNIT='task-42'\n"));
@@ -223,7 +236,7 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
 }
 
 #[test]
-fn build_container_script_chowns_intermediate_home_mount_parents_without_touching_targets() {
+fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_targets() {
     let script = build_container_script(
         &crate::SessionSpec {
             profile_name: "myprofile".to_string(),
@@ -235,12 +248,12 @@ fn build_container_script_chowns_intermediate_home_mount_parents_without_touchin
                 },
                 crate::BindMount {
                     source: PathBuf::from("/srv/claude-config"),
-                    target: PathBuf::from("/home/myprofile/.config/claude"),
+                    target: PathBuf::from("/home/myprofile/.config/claude workspace"),
                     read_only: false,
                 },
                 crate::BindMount {
                     source: PathBuf::from("/srv/git-config"),
-                    target: PathBuf::from("/home/myprofile/.config/git"),
+                    target: PathBuf::from("/home/myprofile/.config/git (session)"),
                     read_only: false,
                 },
                 crate::BindMount {
@@ -264,23 +277,58 @@ fn build_container_script_chowns_intermediate_home_mount_parents_without_touchin
         },
     );
 
-    let config_parent_chown = "\nchown 'myprofile:myprofile' '/home/myprofile/.config'\n";
     assert!(
-        script.contains(config_parent_chown),
-        "nested home mounts should chown their intermediate parent: {script}"
+        script.contains(
+            "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/.claude' -o -path '/home/myprofile/.config/claude workspace' -o -path '/home/myprofile/.config/git (session)' -o -path '/home/myprofile/a/b/c' -o -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
+        ),
+        "home ownership should be repaired with one find traversal that prunes mounts and the repo: {script}"
     );
     assert_eq!(
-        script.matches(config_parent_chown).count(),
+        script.matches("-path '/home/myprofile/repo'").count(),
         1,
-        "shared intermediate parents should be emitted once"
+        "the repo prune should be emitted exactly once"
     );
-    assert!(script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/a'\n"));
-    assert!(script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/a/b'\n"));
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.claude'\n"));
+    assert!(
+        !script.contains("-path '/var/lib/shared'"),
+        "mounts outside HOME should not be part of the HOME ownership traversal: {script}"
+    );
+}
+
+#[test]
+fn build_container_script_does_not_emit_intermediate_home_chown_commands() {
+    let script = build_container_script(
+        &crate::SessionSpec {
+            profile_name: "myprofile".to_string(),
+            mounts: vec![
+                crate::BindMount {
+                    source: PathBuf::from("/srv/claude"),
+                    target: PathBuf::from("/home/myprofile/.config/claude"),
+                    read_only: true,
+                },
+                crate::BindMount {
+                    source: PathBuf::from("/srv/git-config"),
+                    target: PathBuf::from("/home/myprofile/.config/git"),
+                    read_only: false,
+                },
+            ],
+            ..test_session_spec()
+        },
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    );
+
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config'\n"));
     assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config/claude'\n"));
     assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config/git'\n"));
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/a/b/c'\n"));
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/var/lib/shared'\n"));
+    assert!(
+        script.contains("\nfind '/home/myprofile' -mindepth 0 "),
+        "the find traversal should replace standalone home ownership chown lines: {script}"
+    );
 }
 
 #[test]

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -223,6 +223,67 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
 }
 
 #[test]
+fn build_container_script_chowns_intermediate_home_mount_parents_without_touching_targets() {
+    let script = build_container_script(
+        &crate::SessionSpec {
+            profile_name: "myprofile".to_string(),
+            mounts: vec![
+                crate::BindMount {
+                    source: PathBuf::from("/srv/claude"),
+                    target: PathBuf::from("/home/myprofile/.claude"),
+                    read_only: true,
+                },
+                crate::BindMount {
+                    source: PathBuf::from("/srv/claude-config"),
+                    target: PathBuf::from("/home/myprofile/.config/claude"),
+                    read_only: false,
+                },
+                crate::BindMount {
+                    source: PathBuf::from("/srv/git-config"),
+                    target: PathBuf::from("/home/myprofile/.config/git"),
+                    read_only: false,
+                },
+                crate::BindMount {
+                    source: PathBuf::from("/srv/deep-tree"),
+                    target: PathBuf::from("/home/myprofile/a/b/c"),
+                    read_only: false,
+                },
+                crate::BindMount {
+                    source: PathBuf::from("/srv/outside-home"),
+                    target: PathBuf::from("/var/lib/shared"),
+                    read_only: false,
+                },
+            ],
+            ..test_session_spec()
+        },
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    );
+
+    let config_parent_chown = "\nchown 'myprofile:myprofile' '/home/myprofile/.config'\n";
+    assert!(
+        script.contains(config_parent_chown),
+        "nested home mounts should chown their intermediate parent: {script}"
+    );
+    assert_eq!(
+        script.matches(config_parent_chown).count(),
+        1,
+        "shared intermediate parents should be emitted once"
+    );
+    assert!(script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/a'\n"));
+    assert!(script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/a/b'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.claude'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config/claude'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config/git'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/a/b/c'\n"));
+    assert!(!script.contains("\nchown 'myprofile:myprofile' '/var/lib/shared'\n"));
+}
+
+#[test]
 fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
     let script = build_container_script(
         &crate::SessionSpec {

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -207,11 +207,13 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
     );
 
     assert!(script.contains("useradd --create-home --home-dir '/home/myprofile' --shell /bin/sh --user-group 'myprofile'"));
+    assert!(script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(script.contains(
         "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/myprofile/repo'"
     ));
     assert!(script.contains("\ncd '/home/myprofile/repo'\n"));
-    assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
+    assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile/repo'\n"));
+    assert!(!script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
     assert!(script.contains("\nexport AGENTD_WORK_UNIT='task-42'\n"));
     assert!(script.contains("exec gosu 'myprofile:myprofile' 'site-builder' 'exec'"));

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
-use crate::resources::SessionResources;
+use crate::resources::{PreparedBindMount, SessionResources};
 use crate::test_support::{
     CommandBehavior, CommandOutcome, FakePodmanFixture, FakePodmanScenario, InspectBehavior,
     capture_tracing_events, exit_status, fake_podman_lock, test_session_spec,
@@ -21,6 +21,7 @@ fn create_container_args_include_shared_relabel_for_methodology_mount() {
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
         },
@@ -49,6 +50,7 @@ fn create_container_args_force_root_user_and_entrypoint_before_image_argument() 
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
         },
@@ -96,6 +98,7 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
         },
@@ -113,6 +116,48 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
         args.get(image_index + 2).map(String::as_str),
         Some(expected_script.as_str())
     );
+}
+
+#[test]
+fn create_container_args_include_configured_additional_mounts_after_methodology_mount() {
+    let args = build_create_container_args(
+        &SessionResources {
+            container_name: "agentd-agent-session".to_string(),
+            methodology_staging_dir: PathBuf::from("/tmp/staging"),
+            methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            additional_mounts: vec![
+                PreparedBindMount {
+                    source: PathBuf::from("/tmp/staging/mount-0"),
+                    target: PathBuf::from("/home/site-builder/.claude"),
+                    read_only: true,
+                },
+                PreparedBindMount {
+                    source: PathBuf::from("/tmp/staging/mount-1"),
+                    target: PathBuf::from("/home/site-builder/.runa"),
+                    read_only: false,
+                },
+            ],
+            environment_secret_bindings: Vec::new(),
+            repo_token_secret_binding: None,
+        },
+        &test_session_spec(),
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    );
+
+    let mount_values = argument_values(&args, "--mount");
+    assert_eq!(mount_values.len(), 3);
+    assert!(mount_values[0].contains("src=/tmp/staging/methodology"));
+    assert!(mount_values[1].contains("src=/tmp/staging/mount-0"));
+    assert!(mount_values[1].contains("target=/home/site-builder/.claude"));
+    assert!(mount_values[1].contains("ro=true"));
+    assert!(mount_values[2].contains("src=/tmp/staging/mount-1"));
+    assert!(mount_values[2].contains("target=/home/site-builder/.runa"));
+    assert!(mount_values[2].contains("ro=false"));
 }
 
 #[test]
@@ -1203,6 +1248,18 @@ fn argument_value(command_line: &str, flag: &str) -> Option<String> {
     }
 
     None
+}
+
+fn argument_values(args: &[String], flag: &str) -> Vec<String> {
+    args.windows(2)
+        .filter_map(|window| {
+            if window[0] == flag {
+                Some(window[1].clone())
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn mount_src_value(mount: &str) -> Option<String> {

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -1,8 +1,8 @@
 //! Session lifecycle management for agentd.
 //!
 //! Owns the four phases of a session: input validation, resource allocation
-//! (methodology staging, podman secrets), container execution (create, start
-//! in attached mode, supervise), and teardown (force-remove container, release
+//! (mount staging, podman secrets), container execution (create, start in
+//! attached mode, supervise), and teardown (force-remove container, release
 //! secrets, remove staging directory). The public entry point is
 //! [`run_session`], which accepts a [`SessionSpec`] and
 //! [`SessionInvocation`] and returns a [`SessionOutcome`] or
@@ -25,8 +25,9 @@ pub(crate) mod test_support;
 
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
-    EnvironmentNameValidationError, ProfileNameValidationError, ResolvedEnvironmentVariable,
-    RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    BindMount, EnvironmentNameValidationError, ProfileNameValidationError,
+    ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
+    StartupReconciliationReport,
 };
 pub use validation::{validate_environment_name, validate_profile_name, validate_repo_url};
 
@@ -44,7 +45,7 @@ use validation::{validate_invocation, validate_spec};
 
 /// Executes a single session from validation through teardown.
 ///
-/// Validates `spec` and `invocation`, allocates session resources (methodology
+/// Validates `spec` and `invocation`, allocates session resources (mount
 /// staging directory, podman secrets for non-empty environment values), creates
 /// and runs an ephemeral podman container, then cleans up all resources
 /// regardless of outcome.

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -26,12 +26,13 @@ pub(crate) mod test_support;
 
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
-    BindMount, EnvironmentNameValidationError, MountTargetValidationError,
+    BindMount, EnvironmentNameValidationError, MountOverlapError, MountTargetValidationError,
     ProfileNameValidationError, ResolvedEnvironmentVariable, RunnerError, SessionInvocation,
     SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
 pub use validation::{
-    validate_environment_name, validate_mount_target, validate_profile_name, validate_repo_url,
+    validate_environment_name, validate_mount_overlap, validate_mount_target,
+    validate_profile_name, validate_repo_url,
 };
 
 use container::{create_container, run_container_to_completion, run_container_with_timeout};

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -26,11 +26,13 @@ pub(crate) mod test_support;
 
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
-    BindMount, EnvironmentNameValidationError, ProfileNameValidationError,
-    ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
-    StartupReconciliationReport,
+    BindMount, EnvironmentNameValidationError, MountTargetValidationError,
+    ProfileNameValidationError, ResolvedEnvironmentVariable, RunnerError, SessionInvocation,
+    SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
-pub use validation::{validate_environment_name, validate_profile_name, validate_repo_url};
+pub use validation::{
+    validate_environment_name, validate_mount_target, validate_profile_name, validate_repo_url,
+};
 
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
 use lifecycle::{

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -17,6 +17,7 @@ mod naming;
 mod podman;
 mod reconcile;
 mod resources;
+mod session_paths;
 mod types;
 mod validation;
 

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -1,9 +1,9 @@
 //! Session resource allocation and cleanup.
 //!
-//! Resources (methodology staging directory, podman secrets) are allocated as
-//! a unit by [`prepare_session_resources`] and cleaned up as a unit after the
-//! session completes. Partial-failure cleanup during allocation ensures no
-//! leaked secrets or stale directories when resource creation fails midway.
+//! Resources (staged mount sources, podman secrets) are allocated as a unit by
+//! [`prepare_session_resources`] and cleaned up as a unit after the session
+//! completes. Partial-failure cleanup during allocation ensures no leaked
+//! secrets or stale staging directories when resource creation fails midway.
 
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::naming::{SESSION_ID_LEN, format_secret_name};
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const METHODOLOGY_STAGE_LINK_NAME: &str = "methodology";
+const ADDITIONAL_MOUNT_STAGE_PREFIX: &str = "mount-";
 const SESSION_STAGE_PREFIX: &str = "agentd-session-stage-";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,10 +25,18 @@ pub(crate) struct SecretBinding {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedBindMount {
+    pub(crate) source: PathBuf,
+    pub(crate) target: PathBuf,
+    pub(crate) read_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SessionResources {
     pub(crate) container_name: String,
     pub(crate) methodology_staging_dir: PathBuf,
     pub(crate) methodology_mount_source: PathBuf,
+    pub(crate) additional_mounts: Vec<PreparedBindMount>,
     pub(crate) environment_secret_bindings: Vec<SecretBinding>,
     pub(crate) repo_token_secret_binding: Option<SecretBinding>,
 }
@@ -62,10 +71,18 @@ pub(crate) fn prepare_session_resources(
     let methodology_staging_dir =
         create_methodology_staging_dir(&spec.methodology_dir, session_id)?;
     let methodology_mount_source = methodology_staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
+    let additional_mounts = match create_additional_mounts(&spec.mounts, &methodology_staging_dir) {
+        Ok(mounts) => mounts,
+        Err(error) => {
+            let _ = fs::remove_dir_all(&methodology_staging_dir);
+            return Err(error);
+        }
+    };
     let mut resources = SessionResources {
         container_name: container_name.to_string(),
         methodology_staging_dir,
         methodology_mount_source,
+        additional_mounts,
         environment_secret_bindings: Vec::new(),
         repo_token_secret_binding: None,
     };
@@ -175,12 +192,40 @@ fn create_methodology_staging_dir(
     fs::create_dir_all(&staging_dir)?;
     let staged_link = staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
 
-    if let Err(error) = create_directory_symlink(&canonical_methodology_dir, &staged_link) {
+    if let Err(error) = create_path_symlink(&canonical_methodology_dir, &staged_link) {
         let _ = fs::remove_dir_all(&staging_dir);
         return Err(error);
     }
 
     Ok(staging_dir)
+}
+
+fn create_additional_mounts(
+    mounts: &[crate::BindMount],
+    staging_dir: &Path,
+) -> Result<Vec<PreparedBindMount>, RunnerError> {
+    let mut prepared_mounts = Vec::with_capacity(mounts.len());
+
+    for (index, mount) in mounts.iter().enumerate() {
+        let canonical_source = mount
+            .source
+            .canonicalize()
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::NotFound => RunnerError::MissingMountSource {
+                    path: mount.source.clone(),
+                },
+                _ => RunnerError::Io(error),
+            })?;
+        let staged_source = staging_dir.join(format!("{ADDITIONAL_MOUNT_STAGE_PREFIX}{index}"));
+        create_path_symlink(&canonical_source, &staged_source)?;
+        prepared_mounts.push(PreparedBindMount {
+            source: staged_source,
+            target: mount.target.clone(),
+            read_only: mount.read_only,
+        });
+    }
+
+    Ok(prepared_mounts)
 }
 
 // Returns a base directory for session staging that is safe for podman
@@ -223,13 +268,18 @@ fn create_podman_secret(secret_name: &str, value: &str) -> Result<(), RunnerErro
 }
 
 #[cfg(unix)]
-fn create_directory_symlink(source: &Path, destination: &Path) -> Result<(), RunnerError> {
+fn create_path_symlink(source: &Path, destination: &Path) -> Result<(), RunnerError> {
     std::os::unix::fs::symlink(source, destination).map_err(RunnerError::Io)
 }
 
 #[cfg(windows)]
-fn create_directory_symlink(source: &Path, destination: &Path) -> Result<(), RunnerError> {
-    std::os::windows::fs::symlink_dir(source, destination).map_err(RunnerError::Io)
+fn create_path_symlink(source: &Path, destination: &Path) -> Result<(), RunnerError> {
+    let metadata = source.metadata().map_err(RunnerError::Io)?;
+    if metadata.is_dir() {
+        std::os::windows::fs::symlink_dir(source, destination).map_err(RunnerError::Io)
+    } else {
+        std::os::windows::fs::symlink_file(source, destination).map_err(RunnerError::Io)
+    }
 }
 
 // Generates a 16-character hex string from 8 bytes of cryptographic randomness.
@@ -263,7 +313,8 @@ mod tests {
         CommandBehavior, CommandOutcome, FakePodmanFixture, FakePodmanScenario,
         capture_tracing_events, fake_podman_lock, test_session_spec,
     };
-    use crate::{ResolvedEnvironmentVariable, RunnerError, SessionInvocation};
+    use crate::{BindMount, ResolvedEnvironmentVariable, RunnerError, SessionInvocation};
+    use std::path::PathBuf;
 
     #[test]
     fn unique_suffix_with_encodes_eight_random_bytes_as_sixteen_lower_hex_characters() {
@@ -464,6 +515,51 @@ mod tests {
                 assert_eq!(stderr.trim(), "repo token secret create failed");
             }
             other => panic!("expected PodmanCommandFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prepare_session_resources_rejects_missing_additional_mount_sources() {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let missing_mount_source = std::env::temp_dir().join(format!(
+            "agentd-runner-missing-mount-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after the unix epoch")
+                .as_nanos()
+        ));
+        let session_id = format!("session-missing-mount-{}", std::process::id());
+
+        let result = prepare_session_resources(
+            "agentd-agent-session",
+            &crate::SessionSpec {
+                methodology_dir,
+                mounts: vec![BindMount {
+                    source: missing_mount_source.clone(),
+                    target: PathBuf::from("/mnt/readonly"),
+                    read_only: true,
+                }],
+                ..test_session_spec()
+            },
+            &SessionInvocation {
+                repo_url: "https://example.com/repo.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+            &session_id,
+        );
+
+        match result.expect_err("missing mount sources should be rejected") {
+            RunnerError::MissingMountSource { path } => {
+                assert_eq!(path, missing_mount_source);
+            }
+            other => panic!("expected MissingMountSource, got {other:?}"),
         }
     }
 }

--- a/crates/agentd-runner/src/session_paths.rs
+++ b/crates/agentd-runner/src/session_paths.rs
@@ -1,0 +1,12 @@
+use std::path::PathBuf;
+
+const HOME_ROOT_DIR: &str = "/home";
+const REPO_DIR_NAME: &str = "repo";
+
+pub(crate) fn session_home_dir(profile_name: &str) -> PathBuf {
+    PathBuf::from(HOME_ROOT_DIR).join(profile_name)
+}
+
+pub(crate) fn session_repo_dir(profile_name: &str) -> PathBuf {
+    session_home_dir(profile_name).join(REPO_DIR_NAME)
+}

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -17,6 +17,7 @@ pub(crate) fn test_session_spec() -> SessionSpec {
         profile_name: "site-builder".to_string(),
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
+        mounts: Vec::new(),
         command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),
     }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -6,7 +6,7 @@
 //! for the standalone validators are also defined here.
 
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::time::Duration;
 
@@ -50,8 +50,8 @@ pub struct SessionSpec {
 pub struct BindMount {
     /// Host-side source path to bind into the container.
     pub source: PathBuf,
-    /// Absolute in-container target path for the bind mount. Must not contain
-    /// `.` or `..` components or `,`.
+    /// Absolute in-container target path for the bind mount. Must satisfy
+    /// [`validate_mount_target`](crate::validate_mount_target).
     pub target: PathBuf,
     /// Whether the mount is read-only inside the container.
     pub read_only: bool,
@@ -254,6 +254,16 @@ pub enum ProfileNameValidationError {
     Reserved,
 }
 
+/// Error returned by [`validate_mount_target`](crate::validate_mount_target)
+/// when a bind-mount target violates runner rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountTargetValidationError {
+    /// The target is not absolute, contains `.` or `..`, or contains `,`.
+    Invalid { path: PathBuf },
+    /// The target collides with a runner-managed path.
+    Reserved { target: PathBuf },
+}
+
 /// Errors produced during session execution.
 ///
 /// Validation errors ([`InvalidProfileName`](Self::InvalidProfileName),
@@ -355,23 +365,11 @@ impl fmt::Display for RunnerError {
                     path.display()
                 )
             }
-            RunnerError::InvalidMountTarget { path } => {
-                write!(
-                    f,
-                    "mount target must be an absolute path without '.' or '..' components or ',': {}",
-                    path.display()
-                )
-            }
+            RunnerError::InvalidMountTarget { path } => mount_target_invalid_message(f, path),
             RunnerError::DuplicateMountTarget { target } => {
                 write!(f, "mount targets must be unique: {}", target.display())
             }
-            RunnerError::ReservedMountTarget { target } => {
-                write!(
-                    f,
-                    "mount target is reserved by the runner: {}",
-                    target.display()
-                )
-            }
+            RunnerError::ReservedMountTarget { target } => mount_target_reserved_message(f, target),
             RunnerError::Io(error) => write!(f, "{error}"),
             RunnerError::MissingMountSource { path } => {
                 write!(f, "mount source path does not exist: {}", path.display())
@@ -391,6 +389,17 @@ impl fmt::Display for RunnerError {
     }
 }
 
+impl fmt::Display for MountTargetValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MountTargetValidationError::Invalid { path } => mount_target_invalid_message(f, path),
+            MountTargetValidationError::Reserved { target } => {
+                mount_target_reserved_message(f, target)
+            }
+        }
+    }
+}
+
 impl std::error::Error for RunnerError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -400,10 +409,28 @@ impl std::error::Error for RunnerError {
     }
 }
 
+impl std::error::Error for MountTargetValidationError {}
+
 impl From<std::io::Error> for RunnerError {
     fn from(error: std::io::Error) -> Self {
         Self::Io(error)
     }
+}
+
+fn mount_target_invalid_message(f: &mut fmt::Formatter<'_>, path: &Path) -> fmt::Result {
+    write!(
+        f,
+        "mount target must be an absolute path without '.' or '..' components or ',': {}",
+        path.display()
+    )
+}
+
+fn mount_target_reserved_message(f: &mut fmt::Formatter<'_>, target: &Path) -> fmt::Result {
+    write!(
+        f,
+        "mount target is reserved by the runner: {}",
+        target.display()
+    )
 }
 
 fn exit_status_label(status: &ExitStatus) -> String {

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -50,7 +50,8 @@ pub struct SessionSpec {
 pub struct BindMount {
     /// Host-side source path to bind into the container.
     pub source: PathBuf,
-    /// Absolute in-container target path for the bind mount.
+    /// Absolute in-container target path for the bind mount. Must not contain
+    /// `.` or `..` components or `,`.
     pub target: PathBuf,
     /// Whether the mount is read-only inside the container.
     pub read_only: bool,
@@ -291,7 +292,8 @@ pub enum RunnerError {
     ReservedEnvironmentName { name: String },
     /// A configured bind mount source path is not absolute.
     InvalidMountSource { path: PathBuf },
-    /// A configured bind mount target path is not absolute.
+    /// A configured bind mount target path is not absolute, contains `.` or
+    /// `..` components, or contains `,`.
     InvalidMountTarget { path: PathBuf },
     /// Two configured bind mounts share the same target path.
     DuplicateMountTarget { target: PathBuf },
@@ -356,7 +358,7 @@ impl fmt::Display for RunnerError {
             RunnerError::InvalidMountTarget { path } => {
                 write!(
                     f,
-                    "mount target must be an absolute path: {}",
+                    "mount target must be an absolute path without '.' or '..' components or ',': {}",
                     path.display()
                 )
             }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -260,7 +260,8 @@ pub enum ProfileNameValidationError {
 /// when a bind-mount target violates runner rules.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MountTargetValidationError {
-    /// The target is not absolute, contains `.` or `..`, or contains `,`.
+    /// The target is not absolute, contains `.` or `..`, contains `,`, ends
+    /// with `/`, or includes `find -path` metacharacters.
     Invalid { path: PathBuf },
     /// The target collides with a runner-managed path.
     Reserved { target: PathBuf },
@@ -445,7 +446,7 @@ impl From<std::io::Error> for RunnerError {
 fn mount_target_invalid_message(f: &mut fmt::Formatter<'_>, path: &Path) -> fmt::Result {
     write!(
         f,
-        "mount target must be an absolute path without '.' or '..' components or ',': {}",
+        "mount target must be an absolute path without trailing '/', '.' or '..' components, ',', or find metacharacters ('*', '?', '[', ']', '\\\\'): {}",
         path.display()
     )
 }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -33,6 +33,8 @@ pub struct SessionSpec {
     /// Host-side path to the methodology directory. Mounted read-only into
     /// the container at `/agentd/methodology`. Must contain `manifest.toml`.
     pub methodology_dir: PathBuf,
+    /// Additional host bind mounts declared by the selected profile.
+    pub mounts: Vec<BindMount>,
     /// Command array executed directly from the cloned repository after
     /// workspace setup. Not a shell command unless the profile explicitly
     /// configures one (for example, `["/bin/sh", "-lc", "..."]`).
@@ -41,6 +43,17 @@ pub struct SessionSpec {
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
     pub environment: Vec<ResolvedEnvironmentVariable>,
+}
+
+/// A host bind mount declared by a session profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindMount {
+    /// Host-side source path to bind into the container.
+    pub source: PathBuf,
+    /// Absolute in-container target path for the bind mount.
+    pub target: PathBuf,
+    /// Whether the mount is read-only inside the container.
+    pub read_only: bool,
 }
 
 /// A name-value pair representing an environment variable whose value has
@@ -276,9 +289,19 @@ pub enum RunnerError {
     /// An environment variable name collides with a runner-managed name.
     /// Produced during spec validation.
     ReservedEnvironmentName { name: String },
+    /// A configured bind mount source path is not absolute.
+    InvalidMountSource { path: PathBuf },
+    /// A configured bind mount target path is not absolute.
+    InvalidMountTarget { path: PathBuf },
+    /// Two configured bind mounts share the same target path.
+    DuplicateMountTarget { target: PathBuf },
+    /// A configured bind mount target collides with a runner-managed mount.
+    ReservedMountTarget { target: PathBuf },
     /// Filesystem failure, process I/O failure, or invalid external command
     /// output received after a successful process exit.
     Io(std::io::Error),
+    /// A configured bind mount source path does not exist.
+    MissingMountSource { path: PathBuf },
     /// A podman CLI invocation returned a non-zero exit status. Captures the
     /// argument list, exit status, and stderr for diagnostics.
     PodmanCommandFailed {
@@ -323,7 +346,34 @@ impl fmt::Display for RunnerError {
                     "environment variable name is reserved by the runner: {name}"
                 )
             }
+            RunnerError::InvalidMountSource { path } => {
+                write!(
+                    f,
+                    "mount source must be an absolute path: {}",
+                    path.display()
+                )
+            }
+            RunnerError::InvalidMountTarget { path } => {
+                write!(
+                    f,
+                    "mount target must be an absolute path: {}",
+                    path.display()
+                )
+            }
+            RunnerError::DuplicateMountTarget { target } => {
+                write!(f, "mount targets must be unique: {}", target.display())
+            }
+            RunnerError::ReservedMountTarget { target } => {
+                write!(
+                    f,
+                    "mount target is reserved by the runner: {}",
+                    target.display()
+                )
+            }
             RunnerError::Io(error) => write!(f, "{error}"),
+            RunnerError::MissingMountSource { path } => {
+                write!(f, "mount source path does not exist: {}", path.display())
+            }
             RunnerError::PodmanCommandFailed {
                 args,
                 status,

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -51,7 +51,9 @@ pub struct BindMount {
     /// Host-side source path to bind into the container.
     pub source: PathBuf,
     /// Absolute in-container target path for the bind mount. Must satisfy
-    /// [`validate_mount_target`](crate::validate_mount_target).
+    /// [`validate_mount_target`](crate::validate_mount_target). When
+    /// validated as part of a mount list, targets must also be pairwise
+    /// non-overlapping via [`validate_mount_overlap`](crate::validate_mount_overlap).
     pub target: PathBuf,
     /// Whether the mount is read-only inside the container.
     pub read_only: bool,
@@ -264,6 +266,16 @@ pub enum MountTargetValidationError {
     Reserved { target: PathBuf },
 }
 
+/// Error returned by [`validate_mount_overlap`](crate::validate_mount_overlap)
+/// when two distinct bind-mount targets overlap by path components.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountOverlapError {
+    /// The first offending in-container mount target path.
+    pub first: PathBuf,
+    /// The second offending in-container mount target path.
+    pub second: PathBuf,
+}
+
 /// Errors produced during session execution.
 ///
 /// Validation errors ([`InvalidProfileName`](Self::InvalidProfileName),
@@ -307,6 +319,8 @@ pub enum RunnerError {
     InvalidMountTarget { path: PathBuf },
     /// Two configured bind mounts share the same target path.
     DuplicateMountTarget { target: PathBuf },
+    /// Two configured bind mounts target overlapping container paths.
+    OverlappingMountTargets { first: PathBuf, second: PathBuf },
     /// A configured bind mount target collides with a runner-managed mount.
     ReservedMountTarget { target: PathBuf },
     /// Filesystem failure, process I/O failure, or invalid external command
@@ -369,6 +383,9 @@ impl fmt::Display for RunnerError {
             RunnerError::DuplicateMountTarget { target } => {
                 write!(f, "mount targets must be unique: {}", target.display())
             }
+            RunnerError::OverlappingMountTargets { first, second } => {
+                mount_target_overlap_message(f, first, second)
+            }
             RunnerError::ReservedMountTarget { target } => mount_target_reserved_message(f, target),
             RunnerError::Io(error) => write!(f, "{error}"),
             RunnerError::MissingMountSource { path } => {
@@ -400,6 +417,12 @@ impl fmt::Display for MountTargetValidationError {
     }
 }
 
+impl fmt::Display for MountOverlapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mount_target_overlap_message(f, &self.first, &self.second)
+    }
+}
+
 impl std::error::Error for RunnerError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -410,6 +433,8 @@ impl std::error::Error for RunnerError {
 }
 
 impl std::error::Error for MountTargetValidationError {}
+
+impl std::error::Error for MountOverlapError {}
 
 impl From<std::io::Error> for RunnerError {
     fn from(error: std::io::Error) -> Self {
@@ -430,6 +455,19 @@ fn mount_target_reserved_message(f: &mut fmt::Formatter<'_>, target: &Path) -> f
         f,
         "mount target is reserved by the runner: {}",
         target.display()
+    )
+}
+
+fn mount_target_overlap_message(
+    f: &mut fmt::Formatter<'_>,
+    first: &Path,
+    second: &Path,
+) -> fmt::Result {
+    write!(
+        f,
+        "mount targets must not overlap: {} and {}",
+        first.display(),
+        second.display()
     )
 }
 

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -27,8 +27,8 @@ pub struct SessionSpec {
     /// [`validate_profile_name`](crate::validate_profile_name).
     pub profile_name: String,
     /// Container image reference. The image must provide `/bin/sh`, `git`,
-    /// and the setup/session binaries required by the configured profile
-    /// command in `PATH`, including `useradd` and `gosu`.
+    /// `find`, and the setup/session binaries required by the configured
+    /// profile command in `PATH`, including `useradd` and `gosu`.
     pub base_image: String,
     /// Host-side path to the methodology directory. Mounted read-only into
     /// the container at `/agentd/methodology`. Must contain `manifest.toml`.

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -1,15 +1,16 @@
 //! Input validation for session specs and invocations.
 //!
 //! All validation runs before any filesystem or podman interaction, so invalid
-//! inputs are rejected without side effects. The two public validators
-//! ([`validate_profile_name`] and [`validate_environment_name`]) are also used
-//! by the configuration layer in the `agentd` crate.
+//! inputs are rejected without side effects. The public validators
+//! ([`validate_profile_name`], [`validate_environment_name`], and
+//! [`validate_mount_target`]) are also used by the configuration layer in the
+//! `agentd` crate.
 
 use crate::naming::is_daemon_instance_id;
 use crate::session_paths::{session_home_dir, session_repo_dir};
 use crate::types::{
-    EnvironmentNameValidationError, ProfileNameValidationError, RunnerError, SessionInvocation,
-    SessionSpec,
+    EnvironmentNameValidationError, MountTargetValidationError, ProfileNameValidationError,
+    RunnerError, SessionInvocation, SessionSpec,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -43,22 +44,14 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
                 path: mount.source.clone(),
             });
         }
-        if !mount.target.is_absolute() {
-            return Err(RunnerError::InvalidMountTarget {
-                path: mount.target.clone(),
-            });
-        }
-        if has_relative_mount_target_component(&mount.target)
-            || mount_target_contains_comma(&mount.target)
-        {
-            return Err(RunnerError::InvalidMountTarget {
-                path: mount.target.clone(),
-            });
-        }
-        if is_reserved_mount_target(&mount.target, &spec.profile_name) {
-            return Err(RunnerError::ReservedMountTarget {
-                target: mount.target.clone(),
-            });
+        match validate_mount_target(&mount.target, &spec.profile_name) {
+            Ok(()) => {}
+            Err(MountTargetValidationError::Invalid { path }) => {
+                return Err(RunnerError::InvalidMountTarget { path });
+            }
+            Err(MountTargetValidationError::Reserved { target }) => {
+                return Err(RunnerError::ReservedMountTarget { target });
+            }
         }
         if !seen_mount_targets.insert(mount.target.clone()) {
             return Err(RunnerError::DuplicateMountTarget {
@@ -81,6 +74,32 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
                 });
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Validates an in-container bind-mount target against the runner contract.
+///
+/// Rejects targets that are not absolute, contain `.` or `..` components,
+/// contain `,`, or collide with runner-managed paths such as
+/// `/agentd/methodology`, `/home/{profile}`, or `/home/{profile}/repo`.
+pub fn validate_mount_target(
+    target: &Path,
+    profile_name: &str,
+) -> Result<(), MountTargetValidationError> {
+    if !target.is_absolute()
+        || has_relative_mount_target_component(target)
+        || mount_target_contains_comma(target)
+    {
+        return Err(MountTargetValidationError::Invalid {
+            path: target.to_path_buf(),
+        });
+    }
+    if is_reserved_mount_target(target, profile_name) {
+        return Err(MountTargetValidationError::Reserved {
+            target: target.to_path_buf(),
+        });
     }
 
     Ok(())

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -10,6 +10,8 @@ use crate::types::{
     EnvironmentNameValidationError, ProfileNameValidationError, RunnerError, SessionInvocation,
     SessionSpec,
 };
+use std::collections::HashSet;
+use std::path::PathBuf;
 
 const PROFILE_NAME_ENV: &str = "PROFILE_NAME";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
@@ -17,6 +19,7 @@ pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
 const RESERVED_PROFILE_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys", "man", "mail"];
 const SUPPORTED_REPO_URL_FORMS: &str = "https://, http://, or git://";
 const SUPPORTED_REPO_URL_PREFIXES: [&str; 3] = ["https://", "http://", "git://"];
+const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
 
 pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     if !is_daemon_instance_id(&spec.daemon_instance_id) {
@@ -30,6 +33,30 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     }
     if spec.command.is_empty() || spec.command.iter().any(|arg| arg.is_empty()) {
         return Err(RunnerError::InvalidCommand);
+    }
+
+    let mut seen_mount_targets = HashSet::new();
+    for mount in &spec.mounts {
+        if !mount.source.is_absolute() {
+            return Err(RunnerError::InvalidMountSource {
+                path: mount.source.clone(),
+            });
+        }
+        if !mount.target.is_absolute() {
+            return Err(RunnerError::InvalidMountTarget {
+                path: mount.target.clone(),
+            });
+        }
+        if mount.target == PathBuf::from(METHODOLOGY_MOUNT_PATH) {
+            return Err(RunnerError::ReservedMountTarget {
+                target: mount.target.clone(),
+            });
+        }
+        if !seen_mount_targets.insert(mount.target.clone()) {
+            return Err(RunnerError::DuplicateMountTarget {
+                target: mount.target.clone(),
+            });
+        }
     }
 
     for variable in &spec.environment {
@@ -212,7 +239,7 @@ fn is_valid_unix_username(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ResolvedEnvironmentVariable, test_support::test_session_spec};
+    use crate::{BindMount, ResolvedEnvironmentVariable, test_support::test_session_spec};
     use std::path::PathBuf;
 
     #[test]
@@ -303,6 +330,93 @@ mod tests {
                 matches!(error, RunnerError::InvalidBaseImage),
                 "expected InvalidBaseImage for {base_image:?}, got {error:?}"
             );
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_sources_that_are_not_absolute() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("relative/source"),
+                target: PathBuf::from("/home/site-builder/.claude"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("relative mount sources should be rejected");
+
+        match error {
+            RunnerError::InvalidMountSource { path } => {
+                assert_eq!(path, PathBuf::from("relative/source"));
+            }
+            other => panic!("expected InvalidMountSource, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_are_not_absolute() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from(".claude"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("relative mount targets should be rejected");
+
+        match error {
+            RunnerError::InvalidMountTarget { path } => {
+                assert_eq!(path, PathBuf::from(".claude"));
+            }
+            other => panic!("expected InvalidMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_duplicate_mount_targets() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![
+                BindMount {
+                    source: PathBuf::from("/home/core/.claude"),
+                    target: PathBuf::from("/home/site-builder/.claude"),
+                    read_only: true,
+                },
+                BindMount {
+                    source: PathBuf::from("/var/lib/tesserine/audit"),
+                    target: PathBuf::from("/home/site-builder/.claude"),
+                    read_only: false,
+                },
+            ],
+            ..test_session_spec()
+        })
+        .expect_err("duplicate mount targets should be rejected");
+
+        match error {
+            RunnerError::DuplicateMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/home/site-builder/.claude"));
+            }
+            other => panic!("expected DuplicateMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_collide_with_methodology_mount() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/agentd/methodology"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets must not collide with the methodology mount");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/agentd/methodology"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
         }
     }
 

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -231,13 +231,28 @@ fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     let repo_dir = session_repo_dir(profile_name);
     let methodology_dir = Path::new(METHODOLOGY_MOUNT_PATH);
 
-    if target == methodology_dir || target.starts_with(methodology_dir) || target == home_dir {
+    // Each rule states the invariant for one runner-owned path. Intentional
+    // overlap is part of the contract: targets like `/home` or `/` can
+    // legitimately collide with more than one runner-owned path, and a future
+    // refactor should preserve that instead of collapsing these checks.
+    //
+    // Target and runner-owned methodology path must be disjoint by path
+    // components: neither may be a prefix of the other.
+    if target.starts_with(methodology_dir) || methodology_dir.starts_with(target) {
         return true;
     }
 
-    // Compare by path components, not string prefix, so `/home/{profile}/repo-cache`
-    // remains valid while `/home/{profile}/repo/.git` is correctly reserved.
-    target.starts_with(&repo_dir)
+    // Target and runner-owned repo path must be disjoint by path components:
+    // neither may be a prefix of the other. This keeps `/home/{profile}/repo-cache`
+    // valid while reserving `/home/{profile}/repo`, its descendants, and its
+    // ancestors.
+    if target.starts_with(&repo_dir) || repo_dir.starts_with(target) {
+        return true;
+    }
+
+    // Home is narrower: the home root and its ancestors are reserved, while
+    // descendants such as `.claude` and `.runa` are the supported mount surface.
+    home_dir.starts_with(target)
 }
 
 fn has_relative_mount_target_component(target: &Path) -> bool {
@@ -475,6 +490,26 @@ mod tests {
     }
 
     #[test]
+    fn validate_spec_rejects_mount_targets_that_are_ancestors_of_methodology_mount() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/agentd"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets that are ancestors of the methodology mount should be reserved");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/agentd"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn validate_spec_rejects_mount_targets_that_collide_with_home_directory() {
         let error = validate_spec(&SessionSpec {
             mounts: vec![BindMount {
@@ -489,6 +524,26 @@ mod tests {
         match error {
             RunnerError::ReservedMountTarget { target } => {
                 assert_eq!(target, PathBuf::from("/home/site-builder"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_are_ancestors_of_home_directory() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets that are ancestors of the runner-managed home directory should be reserved");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/home"));
             }
             other => panic!("expected ReservedMountTarget, got {other:?}"),
         }
@@ -529,6 +584,28 @@ mod tests {
         match error {
             RunnerError::ReservedMountTarget { target } => {
                 assert_eq!(target, PathBuf::from("/home/site-builder/repo/.git"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_are_ancestors_of_all_runner_managed_paths() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err(
+            "mount targets that are ancestors of every runner-managed path should be reserved",
+        );
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/"));
             }
             other => panic!("expected ReservedMountTarget, got {other:?}"),
         }
@@ -602,6 +679,11 @@ mod tests {
                     source: PathBuf::from("/home/core/.claude"),
                     target: PathBuf::from("/home/site-builder/.claude"),
                     read_only: true,
+                },
+                BindMount {
+                    source: PathBuf::from("/var/lib/tesserine/session-runtime"),
+                    target: PathBuf::from("/home/site-builder/.runa"),
+                    read_only: false,
                 },
                 BindMount {
                     source: PathBuf::from("/var/lib/tesserine/repo-cache"),

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -6,12 +6,13 @@
 //! by the configuration layer in the `agentd` crate.
 
 use crate::naming::is_daemon_instance_id;
+use crate::session_paths::{session_home_dir, session_repo_dir};
 use crate::types::{
     EnvironmentNameValidationError, ProfileNameValidationError, RunnerError, SessionInvocation,
     SessionSpec,
 };
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::Path;
 
 const PROFILE_NAME_ENV: &str = "PROFILE_NAME";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
@@ -47,7 +48,7 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
                 path: mount.target.clone(),
             });
         }
-        if mount.target == PathBuf::from(METHODOLOGY_MOUNT_PATH) {
+        if is_reserved_mount_target(&mount.target, &spec.profile_name) {
             return Err(RunnerError::ReservedMountTarget {
                 target: mount.target.clone(),
             });
@@ -216,6 +217,19 @@ fn is_reserved_environment_name(name: &str) -> bool {
 
 fn is_reserved_profile_name(name: &str) -> bool {
     RESERVED_PROFILE_NAMES.contains(&name)
+}
+
+fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
+    let home_dir = session_home_dir(profile_name);
+    let repo_dir = session_repo_dir(profile_name);
+
+    if target == Path::new(METHODOLOGY_MOUNT_PATH) || target == home_dir {
+        return true;
+    }
+
+    // Compare by path components, not string prefix, so `/home/{profile}/repo-cache`
+    // remains valid while `/home/{profile}/repo/.git` is correctly reserved.
+    target.starts_with(&repo_dir)
 }
 
 fn is_valid_unix_username(name: &str) -> bool {
@@ -418,6 +432,86 @@ mod tests {
             }
             other => panic!("expected ReservedMountTarget, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_collide_with_home_directory() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home/site-builder"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets must not collide with the runner-managed home directory");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/home/site-builder"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_collide_with_repo_directory() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/var/lib/tesserine/repo-cache"),
+                target: PathBuf::from("/home/site-builder/repo"),
+                read_only: false,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets must not collide with the runner-managed repo directory");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/home/site-builder/repo"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_under_repo_directory() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/var/lib/tesserine/git"),
+                target: PathBuf::from("/home/site-builder/repo/.git"),
+                read_only: false,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets under the repo directory should be reserved");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/home/site-builder/repo/.git"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_accepts_mount_targets_under_home_outside_runner_managed_paths() {
+        validate_spec(&SessionSpec {
+            mounts: vec![
+                BindMount {
+                    source: PathBuf::from("/home/core/.claude"),
+                    target: PathBuf::from("/home/site-builder/.claude"),
+                    read_only: true,
+                },
+                BindMount {
+                    source: PathBuf::from("/var/lib/tesserine/repo-cache"),
+                    target: PathBuf::from("/home/site-builder/repo-cache"),
+                    read_only: false,
+                },
+            ],
+            ..test_session_spec()
+        })
+        .expect("mount targets under home outside runner-managed paths should be accepted");
     }
 
     #[test]

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -85,8 +85,9 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
 /// Validates an in-container bind-mount target against the runner contract.
 ///
 /// Rejects targets that are not absolute, contain `.` or `..` components,
-/// contain `,`, or collide with runner-managed paths such as
-/// `/agentd/methodology`, `/home/{profile}`, or `/home/{profile}/repo`.
+/// contain `,`, end with `/`, contain `find -path` metacharacters, or collide
+/// with runner-managed paths such as `/agentd/methodology`,
+/// `/home/{profile}`, or `/home/{profile}/repo`.
 pub fn validate_mount_target(
     target: &Path,
     profile_name: &str,
@@ -94,6 +95,8 @@ pub fn validate_mount_target(
     if !target.is_absolute()
         || has_relative_mount_target_component(target)
         || mount_target_contains_comma(target)
+        || mount_target_has_trailing_slash(target)
+        || mount_target_contains_find_metacharacters(target)
     {
         return Err(MountTargetValidationError::Invalid {
             path: target.to_path_buf(),
@@ -313,6 +316,18 @@ fn has_relative_mount_target_component(target: &Path) -> bool {
 
 fn mount_target_contains_comma(target: &Path) -> bool {
     target.as_os_str().to_string_lossy().contains(',')
+}
+
+fn mount_target_has_trailing_slash(target: &Path) -> bool {
+    target != Path::new("/") && target.as_os_str().to_string_lossy().ends_with('/')
+}
+
+fn mount_target_contains_find_metacharacters(target: &Path) -> bool {
+    target
+        .as_os_str()
+        .to_string_lossy()
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '[' | ']' | '\\'))
 }
 
 fn is_valid_unix_username(name: &str) -> bool {
@@ -720,6 +735,53 @@ mod tests {
     }
 
     #[test]
+    fn validate_spec_rejects_mount_targets_with_trailing_slashes() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home/site-builder/.claude/"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets with trailing slashes should be rejected");
+
+        match error {
+            RunnerError::InvalidMountTarget { path } => {
+                assert_eq!(path, PathBuf::from("/home/site-builder/.claude/"));
+            }
+            other => panic!("expected InvalidMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_containing_find_metacharacters() {
+        for target in [
+            "/home/site-builder/foo*bar",
+            "/home/site-builder/foo?bar",
+            "/home/site-builder/[x]",
+            r"/home/site-builder/foo\bar",
+        ] {
+            let error = validate_spec(&SessionSpec {
+                mounts: vec![BindMount {
+                    source: PathBuf::from("/home/core/.claude"),
+                    target: PathBuf::from(target),
+                    read_only: true,
+                }],
+                ..test_session_spec()
+            })
+            .expect_err("mount targets with find metacharacters should be rejected");
+
+            match error {
+                RunnerError::InvalidMountTarget { path } => {
+                    assert_eq!(path, PathBuf::from(target));
+                }
+                other => panic!("expected InvalidMountTarget, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn validate_spec_accepts_mount_targets_under_home_outside_runner_managed_paths() {
         validate_spec(&SessionSpec {
             mounts: vec![
@@ -742,6 +804,26 @@ mod tests {
             ..test_session_spec()
         })
         .expect("mount targets under home outside runner-managed paths should be accepted");
+    }
+
+    #[test]
+    fn validate_spec_accepts_mount_targets_without_trailing_slashes_or_find_metacharacters() {
+        validate_spec(&SessionSpec {
+            mounts: vec![
+                BindMount {
+                    source: PathBuf::from("/home/core/.claude"),
+                    target: PathBuf::from("/home/site-builder/.claude"),
+                    read_only: true,
+                },
+                BindMount {
+                    source: PathBuf::from("/home/core/.config/claude"),
+                    target: PathBuf::from("/home/site-builder/.config/claude"),
+                    read_only: true,
+                },
+            ],
+            ..test_session_spec()
+        })
+        .expect("mount targets without trailing slashes or find metacharacters should be accepted");
     }
 
     #[test]

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -48,6 +48,13 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
                 path: mount.target.clone(),
             });
         }
+        if has_relative_mount_target_component(&mount.target)
+            || mount_target_contains_comma(&mount.target)
+        {
+            return Err(RunnerError::InvalidMountTarget {
+                path: mount.target.clone(),
+            });
+        }
         if is_reserved_mount_target(&mount.target, &spec.profile_name) {
             return Err(RunnerError::ReservedMountTarget {
                 target: mount.target.clone(),
@@ -222,14 +229,27 @@ fn is_reserved_profile_name(name: &str) -> bool {
 fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     let home_dir = session_home_dir(profile_name);
     let repo_dir = session_repo_dir(profile_name);
+    let methodology_dir = Path::new(METHODOLOGY_MOUNT_PATH);
 
-    if target == Path::new(METHODOLOGY_MOUNT_PATH) || target == home_dir {
+    if target == methodology_dir || target.starts_with(methodology_dir) || target == home_dir {
         return true;
     }
 
     // Compare by path components, not string prefix, so `/home/{profile}/repo-cache`
     // remains valid while `/home/{profile}/repo/.git` is correctly reserved.
     target.starts_with(&repo_dir)
+}
+
+fn has_relative_mount_target_component(target: &Path) -> bool {
+    target
+        .as_os_str()
+        .to_string_lossy()
+        .split('/')
+        .any(|component| matches!(component, "." | ".."))
+}
+
+fn mount_target_contains_comma(target: &Path) -> bool {
+    target.as_os_str().to_string_lossy().contains(',')
 }
 
 fn is_valid_unix_username(name: &str) -> bool {
@@ -435,6 +455,26 @@ mod tests {
     }
 
     #[test]
+    fn validate_spec_rejects_mount_targets_under_methodology_mount() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/agentd/methodology/manifest.toml"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets under the methodology mount should be reserved");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/agentd/methodology/manifest.toml"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn validate_spec_rejects_mount_targets_that_collide_with_home_directory() {
         let error = validate_spec(&SessionSpec {
             mounts: vec![BindMount {
@@ -495,6 +535,66 @@ mod tests {
     }
 
     #[test]
+    fn validate_spec_rejects_mount_targets_with_parent_dir_components() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/var/lib/tesserine/git"),
+                target: PathBuf::from("/home/site-builder/x/../repo/.git"),
+                read_only: false,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets with '..' components should be rejected");
+
+        match error {
+            RunnerError::InvalidMountTarget { path } => {
+                assert_eq!(path, PathBuf::from("/home/site-builder/x/../repo/.git"));
+            }
+            other => panic!("expected InvalidMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_with_current_dir_components() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home/site-builder/./a"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets with '.' components should be rejected");
+
+        match error {
+            RunnerError::InvalidMountTarget { path } => {
+                assert_eq!(path, PathBuf::from("/home/site-builder/./a"));
+            }
+            other => panic!("expected InvalidMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_containing_commas() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home/site-builder/data,archive"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets containing commas should be rejected");
+
+        match error {
+            RunnerError::InvalidMountTarget { path } => {
+                assert_eq!(path, PathBuf::from("/home/site-builder/data,archive"));
+            }
+            other => panic!("expected InvalidMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn validate_spec_accepts_mount_targets_under_home_outside_runner_managed_paths() {
         validate_spec(&SessionSpec {
             mounts: vec![
@@ -512,6 +612,19 @@ mod tests {
             ..test_session_spec()
         })
         .expect("mount targets under home outside runner-managed paths should be accepted");
+    }
+
+    #[test]
+    fn validate_spec_accepts_mount_targets_with_methodology_prefix_outside_reserved_tree() {
+        validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/agentd/methodology-cache"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect("mount targets outside the methodology path components should be accepted");
     }
 
     #[test]

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -3,14 +3,14 @@
 //! All validation runs before any filesystem or podman interaction, so invalid
 //! inputs are rejected without side effects. The public validators
 //! ([`validate_profile_name`], [`validate_environment_name`], and
-//! [`validate_mount_target`]) are also used by the configuration layer in the
-//! `agentd` crate.
+//! [`validate_mount_target`], [`validate_mount_overlap`]) are also used by the
+//! configuration layer in the `agentd` crate.
 
 use crate::naming::is_daemon_instance_id;
 use crate::session_paths::{session_home_dir, session_repo_dir};
 use crate::types::{
-    EnvironmentNameValidationError, MountTargetValidationError, ProfileNameValidationError,
-    RunnerError, SessionInvocation, SessionSpec,
+    BindMount, EnvironmentNameValidationError, MountOverlapError, MountTargetValidationError,
+    ProfileNameValidationError, RunnerError, SessionInvocation, SessionSpec,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -59,6 +59,9 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
             });
         }
     }
+    if let Err(MountOverlapError { first, second }) = validate_mount_overlap(&spec.mounts) {
+        return Err(RunnerError::OverlappingMountTargets { first, second });
+    }
 
     for variable in &spec.environment {
         match validate_environment_name(&variable.name) {
@@ -100,6 +103,32 @@ pub fn validate_mount_target(
         return Err(MountTargetValidationError::Reserved {
             target: target.to_path_buf(),
         });
+    }
+
+    Ok(())
+}
+
+/// Validates that declared bind-mount targets are pairwise non-overlapping.
+///
+/// Rejects distinct targets when one is a component-aware prefix of the other,
+/// such as `/home/{profile}/.config` and `/home/{profile}/.config/claude`.
+pub fn validate_mount_overlap(mounts: &[BindMount]) -> Result<(), MountOverlapError> {
+    for (index, mount) in mounts.iter().enumerate() {
+        for other in mounts.iter().skip(index + 1) {
+            // Exact-equal targets are ignored here because this public validator
+            // must remain a standalone overlap check; duplicate detection lives
+            // elsewhere and preserves a more precise error message.
+            if mount.target == other.target {
+                continue;
+            }
+
+            if mount.target.starts_with(&other.target) || other.target.starts_with(&mount.target) {
+                return Err(MountOverlapError {
+                    first: mount.target.clone(),
+                    second: other.target.clone(),
+                });
+            }
+        }
     }
 
     Ok(())
@@ -726,6 +755,118 @@ mod tests {
             ..test_session_spec()
         })
         .expect("mount targets outside the methodology path components should be accepted");
+    }
+
+    #[test]
+    fn validate_mount_overlap_rejects_nested_mount_targets() {
+        let error = validate_mount_overlap(&[
+            BindMount {
+                source: PathBuf::from("/home/core/.config"),
+                target: PathBuf::from("/home/site-builder/.config"),
+                read_only: true,
+            },
+            BindMount {
+                source: PathBuf::from("/home/core/.config/claude"),
+                target: PathBuf::from("/home/site-builder/.config/claude"),
+                read_only: true,
+            },
+        ])
+        .expect_err("nested mount targets should be rejected");
+
+        assert_eq!(
+            error,
+            MountOverlapError {
+                first: PathBuf::from("/home/site-builder/.config"),
+                second: PathBuf::from("/home/site-builder/.config/claude"),
+            }
+        );
+    }
+
+    #[test]
+    fn validate_mount_overlap_rejects_nested_mount_targets_in_reverse_order() {
+        let error = validate_mount_overlap(&[
+            BindMount {
+                source: PathBuf::from("/home/core/.config/claude"),
+                target: PathBuf::from("/home/site-builder/.config/claude"),
+                read_only: true,
+            },
+            BindMount {
+                source: PathBuf::from("/home/core/.config"),
+                target: PathBuf::from("/home/site-builder/.config"),
+                read_only: true,
+            },
+        ])
+        .expect_err("nested mount targets should be rejected regardless of order");
+
+        assert_eq!(
+            error,
+            MountOverlapError {
+                first: PathBuf::from("/home/site-builder/.config/claude"),
+                second: PathBuf::from("/home/site-builder/.config"),
+            }
+        );
+    }
+
+    #[test]
+    fn validate_mount_overlap_accepts_disjoint_sibling_targets() {
+        validate_mount_overlap(&[
+            BindMount {
+                source: PathBuf::from("/home/core/.config"),
+                target: PathBuf::from("/home/site-builder/.config"),
+                read_only: true,
+            },
+            BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home/site-builder/.claude"),
+                read_only: true,
+            },
+        ])
+        .expect("disjoint sibling targets should be accepted");
+    }
+
+    #[test]
+    fn validate_mount_overlap_accepts_component_distinct_targets() {
+        validate_mount_overlap(&[
+            BindMount {
+                source: PathBuf::from("/home/core/.config-alt"),
+                target: PathBuf::from("/home/site-builder/.config-alt"),
+                read_only: true,
+            },
+            BindMount {
+                source: PathBuf::from("/home/core/.config"),
+                target: PathBuf::from("/home/site-builder/.config"),
+                read_only: true,
+            },
+        ])
+        .expect("component-distinct targets should be accepted");
+    }
+
+    #[test]
+    fn validate_spec_rejects_overlapping_mount_targets() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![
+                BindMount {
+                    source: PathBuf::from("/home/core/.config"),
+                    target: PathBuf::from("/home/site-builder/.config"),
+                    read_only: true,
+                },
+                BindMount {
+                    source: PathBuf::from("/home/core/.config/claude"),
+                    target: PathBuf::from("/home/site-builder/.config/claude"),
+                    read_only: true,
+                },
+            ],
+            ..test_session_spec()
+        })
+        .expect_err("overlapping mount targets should be rejected");
+
+        match error {
+            RunnerError::OverlappingMountTargets { first, second } => {
+                assert_eq!(first, PathBuf::from("/home/site-builder/.config"));
+                assert_eq!(second, PathBuf::from("/home/site-builder/.config/claude"));
+            }
+            other => panic!("expected OverlappingMountTargets, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -313,6 +315,11 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
     fs::create_dir_all(&host_mount).expect("read-only host mount should be created");
     fs::write(host_mount.join("auth.json"), "{\"token\":\"test\"}\n")
         .expect("read-only host fixture file should be written");
+    fs::write(
+        host_mount.join("sentinel.txt"),
+        "host data should remain untouched\n",
+    )
+    .expect("read-only host sentinel file should be written");
 
     let outcome = run_session(
         SessionSpec {
@@ -322,7 +329,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
             methodology_dir: fixture.methodology_dir(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
-                target: PathBuf::from("/mnt/readonly"),
+                target: PathBuf::from("/home/readonly-mount-run/.claude"),
                 read_only: true,
             }],
             command: vec!["site-builder".to_string(), "exec".to_string()],
@@ -345,6 +352,16 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
         !host_mount.join("write-should-fail").exists(),
         "read-only mount should not permit in-container writes"
     );
+    assert_eq!(
+        fs::read_to_string(host_mount.join("auth.json"))
+            .expect("read-only host auth fixture should remain readable"),
+        "{\"token\":\"test\"}\n"
+    );
+    assert_eq!(
+        fs::read_to_string(host_mount.join("sentinel.txt"))
+            .expect("read-only host sentinel should remain readable"),
+        "host data should remain untouched\n"
+    );
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -362,6 +379,11 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
     let image = fixture.build_image();
     let host_mount = fixture.root.join("host-readwrite");
     fs::create_dir_all(&host_mount).expect("read-write host mount should be created");
+    fs::write(host_mount.join("sentinel.txt"), "host sentinel\n")
+        .expect("read-write host sentinel should be written");
+    #[cfg(unix)]
+    let sentinel_metadata_before =
+        fs::metadata(host_mount.join("sentinel.txt")).expect("sentinel metadata should exist");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -378,7 +400,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             methodology_dir: fixture.methodology_dir(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
-                target: PathBuf::from("/mnt/readwrite"),
+                target: PathBuf::from("/home/readwrite-mount-run/.runa"),
                 read_only: false,
             }],
             command: vec!["site-builder".to_string(), "exec".to_string()],
@@ -402,6 +424,26 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             .expect("read-write mount should persist host-visible writes"),
         "persisted from container\n"
     );
+    assert_eq!(
+        fs::read_to_string(host_mount.join("sentinel.txt"))
+            .expect("read-write host sentinel should remain readable"),
+        "host sentinel\n"
+    );
+    #[cfg(unix)]
+    {
+        let sentinel_metadata_after =
+            fs::metadata(host_mount.join("sentinel.txt")).expect("sentinel metadata should exist");
+        assert_eq!(
+            sentinel_metadata_after.uid(),
+            sentinel_metadata_before.uid(),
+            "runner setup must not re-own host-backed files under home mounts"
+        );
+        assert_eq!(
+            sentinel_metadata_after.gid(),
+            sentinel_metadata_before.gid(),
+            "runner setup must not re-own host-backed files under home mounts"
+        );
+    }
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -1000,8 +1042,8 @@ case "$command_name" in
         fi
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "verify-read-only-mount" ]; then
-            [ -f /mnt/readonly/auth.json ]
-            if touch /mnt/readonly/write-should-fail 2>/dev/null; then
+            [ -f "${HOME}/.claude/auth.json" ]
+            if touch "${HOME}/.claude/write-should-fail" 2>/dev/null; then
                 echo "read-only mount unexpectedly allowed writes" >&2
                 exit 91
             fi
@@ -1009,7 +1051,7 @@ case "$command_name" in
         fi
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-read-write-mount" ]; then
-            printf 'persisted from container\n' > /mnt/readwrite/session-artifact.txt
+            printf 'persisted from container\n' > "${HOME}/.runa/session-artifact.txt"
             exit 0
         fi
 

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -506,6 +506,45 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
 }
 
 #[test]
+fn preserves_session_user_access_to_preexisting_home_content() {
+    if skip_if_podman_unavailable("preserves_session_user_access_to_preexisting_home_content") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("preexisting-home-run");
+    let image = fixture.build_image_with_preexisting_home_file();
+
+    let outcome = run_session(
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "preexisting-home-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "write-preexisting-home-file".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
 fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
     if skip_if_podman_unavailable("times_out_when_a_timeout_is_provided_and_cleans_up_container") {
         return;
@@ -661,11 +700,26 @@ impl SessionFixture {
         self.build_image_with_agentd_work_unit_line(None)
     }
 
+    fn build_image_with_preexisting_home_file(&self) -> String {
+        self.build_image_with_customizations(
+            None,
+            "RUN mkdir -p /home/preexisting-home-run \\\n    && printf 'root owned fixture\\n' > /home/preexisting-home-run/.preexisting\n",
+        )
+    }
+
     fn build_image_with_agentd_work_unit(&self, work_unit: &str) -> String {
         self.build_image_with_agentd_work_unit_line(Some(work_unit))
     }
 
     fn build_image_with_agentd_work_unit_line(&self, work_unit: Option<&str>) -> String {
+        self.build_image_with_customizations(work_unit, "")
+    }
+
+    fn build_image_with_customizations(
+        &self,
+        work_unit: Option<&str>,
+        extra_containerfile_lines: &str,
+    ) -> String {
         let context_dir = self.root.join("image-context");
         fs::create_dir_all(&context_dir).expect("image context should be created");
 
@@ -673,12 +727,15 @@ impl SessionFixture {
             .expect("site-builder stub should be written");
         fs::write(context_dir.join("entrypoint.sh"), ENTRYPOINT_SH)
             .expect("entrypoint script should be written");
-        let containerfile = work_unit
+        let mut containerfile = work_unit
             .map(|work_unit| CONTAINERFILE.replace(
                 "FROM docker.io/library/debian:bookworm-slim\n",
                 &format!("FROM docker.io/library/debian:bookworm-slim\nENV AGENTD_WORK_UNIT={work_unit}\n"),
             ))
             .unwrap_or_else(|| CONTAINERFILE.to_string());
+        if !extra_containerfile_lines.is_empty() {
+            containerfile.push_str(extra_containerfile_lines);
+        }
         fs::write(context_dir.join("Containerfile"), containerfile)
             .expect("containerfile should be written");
 
@@ -926,7 +983,7 @@ const CONTAINERFILE: &str = r#"
 FROM docker.io/library/debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git gosu passwd \
+    && apt-get install -y --no-install-recommends findutils git gosu passwd \
     && rm -rf /var/lib/apt/lists/*
 COPY site-builder /usr/local/bin/site-builder
 COPY entrypoint.sh /entrypoint.sh
@@ -1119,6 +1176,14 @@ case "$command_name" in
             mkdir -p "${HOME}/.config/git"
             printf 'sibling write succeeded\n' > "${HOME}/.config/git/config"
             printf 'persisted from nested mount\n' > "${HOME}/.config/claude/nested-artifact.txt"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-preexisting-home-file" ]; then
+            [ -f "${HOME}/.preexisting" ]
+            [ "$(cat "${HOME}/.preexisting")" = "root owned fixture" ]
+            printf 'session write succeeded\n' > "${HOME}/.preexisting"
+            [ "$(cat "${HOME}/.preexisting")" = "session write succeeded" ]
             exit 0
         fi
 

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -449,6 +449,63 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
 }
 
 #[test]
+fn preserves_writable_home_for_nested_additional_mount_parents() {
+    if skip_if_podman_unavailable("preserves_writable_home_for_nested_additional_mount_parents") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("nested-home-mount-run");
+    let image = fixture.build_image();
+    let host_mount = fixture.root.join("host-nested-claude");
+    fs::create_dir_all(&host_mount).expect("nested host mount should be created");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
+            .expect("nested host mount should permit container writes");
+    }
+
+    let outcome = run_session(
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "nested-home-mount-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            mounts: vec![BindMount {
+                source: host_mount.clone(),
+                target: PathBuf::from("/home/nested-home-mount-run/.config/claude"),
+                read_only: false,
+            }],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "write-nested-home-mount".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    assert_eq!(
+        fs::read_to_string(host_mount.join("nested-artifact.txt"))
+            .expect("nested home mount should persist host-visible writes"),
+        "persisted from nested mount\n"
+    );
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
 fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
     if skip_if_podman_unavailable("times_out_when_a_timeout_is_provided_and_cleans_up_container") {
         return;
@@ -1052,6 +1109,16 @@ case "$command_name" in
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-read-write-mount" ]; then
             printf 'persisted from container\n' > "${HOME}/.runa/session-artifact.txt"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-nested-home-mount" ]; then
+            # The mkdir/write below is the regression probe: if setup leaves
+            # $HOME/.config owned by root, creating the sibling git config
+            # fails and we never reach the mounted-target sentinel write.
+            mkdir -p "${HOME}/.config/git"
+            printf 'sibling write succeeded\n' > "${HOME}/.config/git/config"
+            printf 'persisted from nested mount\n' > "${HOME}/.config/claude/nested-artifact.txt"
             exit 0
         fi
 

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -10,7 +10,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use agentd_runner::{
-    ResolvedEnvironmentVariable, SessionInvocation, SessionOutcome, SessionSpec, run_session,
+    BindMount, ResolvedEnvironmentVariable, SessionInvocation, SessionOutcome, SessionSpec,
+    run_session,
 };
 
 const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
@@ -33,6 +34,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             profile_name: "success-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec![
                 "site-builder".to_string(),
                 "exec".to_string(),
@@ -82,6 +84,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             profile_name: "mixed-env-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
@@ -130,6 +133,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             profile_name: "unset-work-unit-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
@@ -170,6 +174,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             profile_name: "failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
@@ -216,6 +221,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             profile_name: "failure-run-125".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
@@ -263,6 +269,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             profile_name: "comma-methodology-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
@@ -290,6 +297,116 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
 }
 
 #[test]
+fn validates_read_only_additional_mounts_from_paths_containing_commas() {
+    if skip_if_podman_unavailable(
+        "validates_read_only_additional_mounts_from_paths_containing_commas",
+    ) {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("readonly-mount-run");
+    let image = fixture.build_image();
+    let host_mount = fixture.root.join("host,readonly");
+    fs::create_dir_all(&host_mount).expect("read-only host mount should be created");
+    fs::write(host_mount.join("auth.json"), "{\"token\":\"test\"}\n")
+        .expect("read-only host fixture file should be written");
+
+    let outcome = run_session(
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "readonly-mount-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            mounts: vec![BindMount {
+                source: host_mount.clone(),
+                target: PathBuf::from("/mnt/readonly"),
+                read_only: true,
+            }],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "verify-read-only-mount".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    assert!(
+        !host_mount.join("write-should-fail").exists(),
+        "read-only mount should not permit in-container writes"
+    );
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn preserves_host_writes_through_read_write_additional_mounts() {
+    if skip_if_podman_unavailable("preserves_host_writes_through_read_write_additional_mounts") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("readwrite-mount-run");
+    let image = fixture.build_image();
+    let host_mount = fixture.root.join("host-readwrite");
+    fs::create_dir_all(&host_mount).expect("read-write host mount should be created");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
+            .expect("read-write host mount should permit container writes");
+    }
+
+    let outcome = run_session(
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "readwrite-mount-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            mounts: vec![BindMount {
+                source: host_mount.clone(),
+                target: PathBuf::from("/mnt/readwrite"),
+                read_only: false,
+            }],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "write-read-write-mount".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    assert_eq!(
+        fs::read_to_string(host_mount.join("session-artifact.txt"))
+            .expect("read-write mount should persist host-visible writes"),
+        "persisted from container\n"
+    );
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
 fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
     if skip_if_podman_unavailable("times_out_when_a_timeout_is_provided_and_cleans_up_container") {
         return;
@@ -307,6 +424,7 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             profile_name: "timeout-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
@@ -354,6 +472,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 profile_name: "running-secret-run".to_string(),
                 base_image: image,
                 methodology_dir,
+                mounts: Vec::new(),
                 command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![
                     ResolvedEnvironmentVariable {
@@ -877,6 +996,20 @@ case "$command_name" in
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "success-without-work-unit" ]; then
             [ "${AGENTD_WORK_UNIT+set}" != "set" ]
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "verify-read-only-mount" ]; then
+            [ -f /mnt/readonly/auth.json ]
+            if touch /mnt/readonly/write-should-fail 2>/dev/null; then
+                echo "read-only mount unexpectedly allowed writes" >&2
+                exit 91
+            fi
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-read-write-mount" ]; then
+            printf 'persisted from container\n' > /mnt/readwrite/session-artifact.txt
             exit 0
         fi
 

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -16,7 +16,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use agentd_runner::{
-    BindMount, RunnerError, validate_environment_name, validate_profile_name, validate_repo_url,
+    BindMount, MountTargetValidationError, RunnerError, validate_environment_name,
+    validate_mount_target, validate_profile_name, validate_repo_url,
 };
 use croner::parser::{CronParser, Seconds, Year};
 use serde::Deserialize;
@@ -173,10 +174,10 @@ impl Config {
                 }
 
                 let target = PathBuf::from(&raw_mount.target);
-                if !target.is_absolute() {
-                    return Err(ConfigError::MountTargetMustBeAbsolute {
+                if let Err(error) = validate_mount_target(&target, &raw_profile.name) {
+                    return Err(ConfigError::InvalidMountTarget {
                         profile: raw_profile.name.clone(),
-                        target,
+                        error,
                     });
                 }
 
@@ -505,8 +506,11 @@ pub enum ConfigError {
     ScheduleRequiresRepo { profile: String },
     /// A configured mount source is not an absolute path.
     MountSourceMustBeAbsolute { profile: String, source: PathBuf },
-    /// A configured mount target is not an absolute path.
-    MountTargetMustBeAbsolute { profile: String, target: PathBuf },
+    /// A configured mount target violates the runner's target rules.
+    InvalidMountTarget {
+        profile: String,
+        error: MountTargetValidationError,
+    },
     /// Two configured mounts in one profile share the same target path.
     DuplicateMountTarget { profile: String, target: PathBuf },
 }
@@ -606,11 +610,10 @@ impl fmt::Display for ConfigError {
                     source.display()
                 )
             }
-            ConfigError::MountTargetMustBeAbsolute { profile, target } => {
+            ConfigError::InvalidMountTarget { profile, error } => {
                 write!(
                     f,
-                    "profile '{profile}' defines mount target that must be absolute: {}",
-                    target.display()
+                    "profile '{profile}' defines invalid mount target: {error}"
                 )
             }
             ConfigError::DuplicateMountTarget { profile, target } => {

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 
 use agentd_runner::{
     BindMount, MountTargetValidationError, RunnerError, validate_environment_name,
-    validate_mount_target, validate_profile_name, validate_repo_url,
+    validate_mount_overlap, validate_mount_target, validate_profile_name, validate_repo_url,
 };
 use croner::parser::{CronParser, Seconds, Year};
 use serde::Deserialize;
@@ -192,6 +192,17 @@ impl Config {
                     source,
                     target,
                     read_only: raw_mount.read_only,
+                });
+            }
+            let runner_mounts = mounts
+                .iter()
+                .map(ProfileMountConfig::to_runner_mount)
+                .collect::<Vec<_>>();
+            if let Err(error) = validate_mount_overlap(&runner_mounts) {
+                return Err(ConfigError::OverlappingMountTargets {
+                    profile: raw_profile.name.clone(),
+                    first: error.first,
+                    second: error.second,
                 });
             }
 
@@ -513,6 +524,12 @@ pub enum ConfigError {
     },
     /// Two configured mounts in one profile share the same target path.
     DuplicateMountTarget { profile: String, target: PathBuf },
+    /// Two configured mounts in one profile overlap by path components.
+    OverlappingMountTargets {
+        profile: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
 }
 
 impl fmt::Display for ConfigError {
@@ -621,6 +638,18 @@ impl fmt::Display for ConfigError {
                     f,
                     "profile '{profile}' defines duplicate mount target: {}",
                     target.display()
+                )
+            }
+            ConfigError::OverlappingMountTargets {
+                profile,
+                first,
+                second,
+            } => {
+                write!(
+                    f,
+                    "profile '{profile}' defines overlapping mount targets: {} and {}",
+                    first.display(),
+                    second.display()
                 )
             }
         }

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use agentd_runner::{
-    RunnerError, validate_environment_name, validate_profile_name, validate_repo_url,
+    BindMount, RunnerError, validate_environment_name, validate_profile_name, validate_repo_url,
 };
 use croner::parser::{CronParser, Seconds, Year};
 use serde::Deserialize;
@@ -148,6 +148,52 @@ impl Config {
                 command.push(element);
             }
 
+            let mut seen_mount_targets = HashSet::new();
+            let mut mounts = Vec::with_capacity(raw_profile.mounts.len());
+            for raw_mount in raw_profile.mounts {
+                validate_lookup_key(
+                    "mounts.source",
+                    &raw_mount.source,
+                    Some(raw_profile.name.as_str()),
+                    None,
+                )?;
+                validate_lookup_key(
+                    "mounts.target",
+                    &raw_mount.target,
+                    Some(raw_profile.name.as_str()),
+                    None,
+                )?;
+
+                let source = PathBuf::from(&raw_mount.source);
+                if !source.is_absolute() {
+                    return Err(ConfigError::MountSourceMustBeAbsolute {
+                        profile: raw_profile.name.clone(),
+                        source,
+                    });
+                }
+
+                let target = PathBuf::from(&raw_mount.target);
+                if !target.is_absolute() {
+                    return Err(ConfigError::MountTargetMustBeAbsolute {
+                        profile: raw_profile.name.clone(),
+                        target,
+                    });
+                }
+
+                if !seen_mount_targets.insert(target.clone()) {
+                    return Err(ConfigError::DuplicateMountTarget {
+                        profile: raw_profile.name.clone(),
+                        target,
+                    });
+                }
+
+                mounts.push(ProfileMountConfig {
+                    source,
+                    target,
+                    read_only: raw_mount.read_only,
+                });
+            }
+
             let mut seen_credentials = HashSet::new();
             let mut credentials = Vec::with_capacity(raw_profile.credentials.len());
             for raw_credential in raw_profile.credentials {
@@ -194,6 +240,7 @@ impl Config {
                 name: raw_profile.name,
                 base_image: raw_profile.base_image,
                 methodology_dir,
+                mounts,
                 repo,
                 schedule,
                 repo_token_source,
@@ -228,6 +275,7 @@ pub struct ProfileConfig {
     name: String,
     base_image: String,
     methodology_dir: PathBuf,
+    mounts: Vec<ProfileMountConfig>,
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
@@ -251,6 +299,11 @@ impl ProfileConfig {
     /// constructed via the [`FromStr`] impl.
     pub fn methodology_dir(&self) -> &Path {
         &self.methodology_dir
+    }
+
+    /// Additional bind mounts declared for this profile.
+    pub fn mounts(&self) -> &[ProfileMountConfig] {
+        &self.mounts
     }
 
     /// Optional default repository URL for sessions launched from this profile.
@@ -279,6 +332,39 @@ impl ProfileConfig {
     /// Static session command executed from the cloned repository.
     pub fn command(&self) -> &[String] {
         &self.command
+    }
+}
+
+/// A validated profile-declared bind mount.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileMountConfig {
+    source: PathBuf,
+    target: PathBuf,
+    read_only: bool,
+}
+
+impl ProfileMountConfig {
+    /// Host-side source path for this mount.
+    pub fn source(&self) -> &Path {
+        &self.source
+    }
+
+    /// Absolute in-container target path for this mount.
+    pub fn target(&self) -> &Path {
+        &self.target
+    }
+
+    /// Whether the mount is read-only inside the container.
+    pub fn read_only(&self) -> bool {
+        self.read_only
+    }
+
+    pub(crate) fn to_runner_mount(&self) -> BindMount {
+        BindMount {
+            source: self.source.clone(),
+            target: self.target.clone(),
+            read_only: self.read_only,
+        }
     }
 }
 
@@ -417,6 +503,12 @@ pub enum ConfigError {
     InvalidSchedule { profile: String, schedule: String },
     /// A scheduled profile must declare a default repo for autonomous runs.
     ScheduleRequiresRepo { profile: String },
+    /// A configured mount source is not an absolute path.
+    MountSourceMustBeAbsolute { profile: String, source: PathBuf },
+    /// A configured mount target is not an absolute path.
+    MountTargetMustBeAbsolute { profile: String, target: PathBuf },
+    /// Two configured mounts in one profile share the same target path.
+    DuplicateMountTarget { profile: String, target: PathBuf },
 }
 
 impl fmt::Display for ConfigError {
@@ -507,6 +599,27 @@ impl fmt::Display for ConfigError {
                     "profile '{profile}' defines schedule but no repo; scheduled profiles must define a repo"
                 )
             }
+            ConfigError::MountSourceMustBeAbsolute { profile, source } => {
+                write!(
+                    f,
+                    "profile '{profile}' defines mount source that must be absolute: {}",
+                    source.display()
+                )
+            }
+            ConfigError::MountTargetMustBeAbsolute { profile, target } => {
+                write!(
+                    f,
+                    "profile '{profile}' defines mount target that must be absolute: {}",
+                    target.display()
+                )
+            }
+            ConfigError::DuplicateMountTarget { profile, target } => {
+                write!(
+                    f,
+                    "profile '{profile}' defines duplicate mount target: {}",
+                    target.display()
+                )
+            }
         }
     }
 }
@@ -576,11 +689,21 @@ struct RawProfileConfig {
     base_image: String,
     methodology_dir: String,
     command: Vec<String>,
+    #[serde(default)]
+    mounts: Vec<RawMountConfig>,
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
     #[serde(default)]
     credentials: Vec<RawCredentialConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawMountConfig {
+    source: String,
+    target: String,
+    read_only: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -138,6 +138,11 @@ pub fn dispatch_run(
                 profile_name: profile.name().to_string(),
                 base_image: profile.base_image().to_string(),
                 methodology_dir: profile.methodology_dir().to_path_buf(),
+                mounts: profile
+                    .mounts()
+                    .iter()
+                    .map(|mount| mount.to_runner_mount())
+                    .collect(),
                 command: profile.command().to_vec(),
                 environment,
             },

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -117,6 +117,7 @@ fn parses_example_config_into_static_profile_settings() {
         site_builder.credentials()[0].source(),
         "AGENTD_GITHUB_TOKEN"
     );
+    assert!(site_builder.mounts().is_empty());
 
     assert_eq!(code_reviewer.name(), "code-reviewer");
     assert_eq!(
@@ -145,6 +146,7 @@ fn parses_example_config_into_static_profile_settings() {
         code_reviewer.credentials()[0].source(),
         "AGENTD_GITHUB_TOKEN"
     );
+    assert!(code_reviewer.mounts().is_empty());
 }
 
 #[test]
@@ -552,6 +554,144 @@ command = ["site-builder", "exec"]
         .expect("profile should exist");
 
     assert_eq!(profile.schedule(), Some("*/15 * * * *"));
+}
+
+#[test]
+fn parses_profile_mounts_as_operator_declared_bind_mounts() {
+    let config = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.claude"
+target = "/home/site-builder/.claude"
+read_only = true
+
+[[profiles.mounts]]
+source = "/var/lib/tesserine/audit"
+target = "/home/site-builder/.runa"
+read_only = false
+"#,
+    )
+    .expect("config should parse declared mounts");
+
+    let profile = config
+        .profile("site-builder")
+        .expect("profile should exist");
+
+    assert_eq!(profile.mounts().len(), 2);
+    assert_eq!(
+        profile.mounts()[0].source(),
+        Path::new("/home/core/.claude")
+    );
+    assert_eq!(
+        profile.mounts()[0].target(),
+        Path::new("/home/site-builder/.claude")
+    );
+    assert!(profile.mounts()[0].read_only());
+    assert_eq!(
+        profile.mounts()[1].source(),
+        Path::new("/var/lib/tesserine/audit")
+    );
+    assert_eq!(
+        profile.mounts()[1].target(),
+        Path::new("/home/site-builder/.runa")
+    );
+    assert!(!profile.mounts()[1].read_only());
+}
+
+#[test]
+fn rejects_profile_mount_sources_that_are_not_absolute() {
+    let error = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "../claude"
+target = "/home/site-builder/.claude"
+read_only = true
+"#,
+    )
+    .expect_err("relative mount sources should be rejected");
+
+    match error {
+        ConfigError::MountSourceMustBeAbsolute { profile, source } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(source, Path::new("../claude"));
+        }
+        other => panic!("expected absolute mount source error, got {other}"),
+    }
+}
+
+#[test]
+fn rejects_profile_mount_targets_that_are_not_absolute() {
+    let error = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.claude"
+target = ".claude"
+read_only = true
+"#,
+    )
+    .expect_err("relative mount targets should be rejected");
+
+    match error {
+        ConfigError::MountTargetMustBeAbsolute { profile, target } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(target, Path::new(".claude"));
+        }
+        other => panic!("expected absolute mount target error, got {other}"),
+    }
+}
+
+#[test]
+fn rejects_duplicate_profile_mount_targets() {
+    let error = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.claude"
+target = "/home/site-builder/.claude"
+read_only = true
+
+[[profiles.mounts]]
+source = "/var/lib/tesserine/audit"
+target = "/home/site-builder/.claude"
+read_only = false
+"#,
+    )
+    .expect_err("duplicate mount targets should be rejected");
+
+    match error {
+        ConfigError::DuplicateMountTarget { profile, target } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(target, Path::new("/home/site-builder/.claude"));
+        }
+        other => panic!("expected duplicate mount target error, got {other}"),
+    }
 }
 
 #[test]

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -76,6 +76,7 @@ fn assert_invalid_mount_target_parse_error(
     target: &str,
     expected_error: MountTargetValidationError,
 ) {
+    let target = target.replace('\\', "\\\\").replace('"', "\\\"");
     let error = Config::from_str(&format!(
         r#"
 [[profiles]]
@@ -774,6 +775,73 @@ fn rejects_profile_mount_targets_containing_commas() {
         MountTargetValidationError::Invalid {
             path: PathBuf::from("/home/site-builder/data,archive"),
         },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_with_trailing_slashes() {
+    assert_invalid_mount_target_parse_error(
+        "/home/site-builder/.claude/",
+        MountTargetValidationError::Invalid {
+            path: PathBuf::from("/home/site-builder/.claude/"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_containing_find_metacharacters() {
+    for target in [
+        "/home/site-builder/foo*bar",
+        "/home/site-builder/foo?bar",
+        "/home/site-builder/[x]",
+        r"/home/site-builder/foo\bar",
+    ] {
+        assert_invalid_mount_target_parse_error(
+            target,
+            MountTargetValidationError::Invalid {
+                path: PathBuf::from(target),
+            },
+        );
+    }
+}
+
+#[test]
+fn load_rejects_profile_mount_targets_with_trailing_slashes() {
+    let path = write_temp_config(
+        "invalid-mount-target-trailing-slash",
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.claude"
+target = "/home/site-builder/.claude/"
+read_only = true
+"#,
+    );
+
+    let error = Config::load(&path).expect_err("trailing-slash mount targets should be rejected");
+
+    match &error {
+        ConfigError::InvalidMountTarget { profile, error } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(
+                error,
+                &MountTargetValidationError::Invalid {
+                    path: PathBuf::from("/home/site-builder/.claude/"),
+                }
+            );
+        }
+        other => panic!("expected invalid mount target error, got {other}"),
+    }
+
+    assert_eq!(
+        error.to_string(),
+        "profile 'site-builder' defines invalid mount target: mount target must be an absolute path without trailing '/', '.' or '..' components, ',', or find metacharacters ('*', '?', '[', ']', '\\\\'): /home/site-builder/.claude/"
     );
 }
 

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -708,6 +708,46 @@ read_only = false
 }
 
 #[test]
+fn load_rejects_overlapping_profile_mount_targets() {
+    let path = write_temp_config(
+        "overlapping-mount-targets",
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.config"
+target = "/home/site-builder/.config"
+read_only = true
+
+[[profiles.mounts]]
+source = "/home/core/.config/claude"
+target = "/home/site-builder/.config/claude"
+read_only = true
+"#,
+    );
+
+    let error = Config::load(&path).expect_err("overlapping mount targets should be rejected");
+
+    match error {
+        ConfigError::OverlappingMountTargets {
+            profile,
+            first,
+            second,
+        } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(first, Path::new("/home/site-builder/.config"));
+            assert_eq!(second, Path::new("/home/site-builder/.config/claude"));
+        }
+        other => panic!("expected overlapping mount target error, got {other}"),
+    }
+}
+
+#[test]
 fn rejects_profile_mount_targets_with_parent_dir_components() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder/x/../repo/.git",

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use agentd::config::{Config, ConfigError, DaemonConfig};
+use agentd_runner::MountTargetValidationError;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -69,6 +70,36 @@ fn write_temp_config_under(base_dir: &Path, name: &str, contents: &str) -> PathB
     let path = dir.join("agentd.toml");
     std::fs::write(&path, contents).expect("temp config should be written");
     path
+}
+
+fn assert_invalid_mount_target_parse_error(
+    target: &str,
+    expected_error: MountTargetValidationError,
+) {
+    let error = Config::from_str(&format!(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.claude"
+target = "{target}"
+read_only = true
+"#
+    ))
+    .expect_err("runner-invalid mount targets should be rejected during config parse");
+
+    match error {
+        ConfigError::InvalidMountTarget { profile, error } => {
+            assert_eq!(profile, "site-builder");
+            assert_eq!(error, expected_error);
+        }
+        other => panic!("expected invalid mount target error, got {other}"),
+    }
 }
 
 #[test]
@@ -635,30 +666,12 @@ read_only = true
 
 #[test]
 fn rejects_profile_mount_targets_that_are_not_absolute() {
-    let error = Config::from_str(
-        r#"
-[[profiles]]
-name = "site-builder"
-base_image = "ghcr.io/example/site-builder:latest"
-methodology_dir = "../groundwork"
-
-command = ["site-builder", "exec"]
-
-[[profiles.mounts]]
-source = "/home/core/.claude"
-target = ".claude"
-read_only = true
-"#,
-    )
-    .expect_err("relative mount targets should be rejected");
-
-    match error {
-        ConfigError::MountTargetMustBeAbsolute { profile, target } => {
-            assert_eq!(profile, "site-builder");
-            assert_eq!(target, Path::new(".claude"));
-        }
-        other => panic!("expected absolute mount target error, got {other}"),
-    }
+    assert_invalid_mount_target_parse_error(
+        ".claude",
+        MountTargetValidationError::Invalid {
+            path: PathBuf::from(".claude"),
+        },
+    );
 }
 
 #[test]
@@ -692,6 +705,76 @@ read_only = false
         }
         other => panic!("expected duplicate mount target error, got {other}"),
     }
+}
+
+#[test]
+fn rejects_profile_mount_targets_with_parent_dir_components() {
+    assert_invalid_mount_target_parse_error(
+        "/home/site-builder/x/../repo/.git",
+        MountTargetValidationError::Invalid {
+            path: PathBuf::from("/home/site-builder/x/../repo/.git"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_with_current_dir_components() {
+    assert_invalid_mount_target_parse_error(
+        "/home/site-builder/./a",
+        MountTargetValidationError::Invalid {
+            path: PathBuf::from("/home/site-builder/./a"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_containing_commas() {
+    assert_invalid_mount_target_parse_error(
+        "/home/site-builder/data,archive",
+        MountTargetValidationError::Invalid {
+            path: PathBuf::from("/home/site-builder/data,archive"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_that_are_ancestors_of_methodology_mount() {
+    assert_invalid_mount_target_parse_error(
+        "/agentd",
+        MountTargetValidationError::Reserved {
+            target: PathBuf::from("/agentd"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_that_collide_with_methodology_mount() {
+    assert_invalid_mount_target_parse_error(
+        "/agentd/methodology",
+        MountTargetValidationError::Reserved {
+            target: PathBuf::from("/agentd/methodology"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_that_collide_with_home_directory() {
+    assert_invalid_mount_target_parse_error(
+        "/home/site-builder",
+        MountTargetValidationError::Reserved {
+            target: PathBuf::from("/home/site-builder"),
+        },
+    );
+}
+
+#[test]
+fn rejects_profile_mount_targets_that_collide_with_repo_directory() {
+    assert_invalid_mount_target_parse_error(
+        "/home/site-builder/repo",
+        MountTargetValidationError::Reserved {
+            target: PathBuf::from("/home/site-builder/repo"),
+        },
+    );
 }
 
 #[test]

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -69,6 +69,30 @@ name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#
     ))
+    .expect("config should parse")
+}
+
+fn config_with_mounts() -> Config {
+    Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+
+[[profiles.mounts]]
+source = "/home/core/.claude"
+target = "/home/site-builder/.claude"
+read_only = true
+
+[[profiles.mounts]]
+source = "/var/lib/tesserine/audit"
+target = "/home/site-builder/.runa"
+read_only = false
+"#,
+    )
     .expect("config should parse")
 }
 
@@ -274,4 +298,39 @@ command = ["site-builder", "exec"]
         }
         other => panic!("expected config error, got {other:?}"),
     }
+}
+
+#[test]
+fn dispatch_run_forwards_profile_mounts_into_session_spec() {
+    let config = config_with_mounts();
+    let request = RunRequest {
+        profile: "site-builder".to_string(),
+        repo_url: "https://example.com/repo.git".to_string(),
+        work_unit: None,
+    };
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
+
+    let state = state.lock().expect("recording state should lock");
+    let spec = state
+        .last_spec
+        .as_ref()
+        .expect("executor should receive spec");
+
+    assert_eq!(
+        spec.mounts,
+        vec![
+            agentd_runner::BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/home/site-builder/.claude"),
+                read_only: true,
+            },
+            agentd_runner::BindMount {
+                source: PathBuf::from("/var/lib/tesserine/audit"),
+                target: PathBuf::from("/home/site-builder/.runa"),
+                read_only: false,
+            },
+        ]
+    );
 }

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -37,7 +37,8 @@ repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 #[[profiles.mounts]]
 # Additional bind mounts are operator-chosen host paths.
 # `source` must be an absolute existing host path.
-# `target` must be an absolute container path.
+# `target` must be an absolute container path and must not duplicate or
+# overlap another mount target in the same profile.
 #source = "/home/core/.claude"
 #target = "/home/site-builder/.claude"
 #read_only = true

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -34,6 +34,14 @@ exec runa run
 # repository authentication. This value does not flow into the agent runtime.
 repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 
+#[[profiles.mounts]]
+# Additional bind mounts are operator-chosen host paths.
+# `source` must be an absolute existing host path.
+# `target` must be an absolute container path.
+#source = "/home/core/.claude"
+#target = "/home/site-builder/.claude"
+#read_only = true
+
 [[profiles.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"


### PR DESCRIPTION
Closes #74

## Summary
- add profile-declared `mounts` config entries and dispatch them into `SessionSpec`
- extend the runner with bind-mount validation, canonical source staging, and Podman mount assembly alongside the first-class methodology mount
- document the new bind-mount capability and cover it with config, unit, and Podman-backed lifecycle tests

## Verification
- `cargo fmt --all`
- `cargo test -p agentd --test config_parsing`
- `cargo test -p agentd --test session_dispatch`
- `cargo test -p agentd-runner --lib`
- `cargo test -p agentd-runner --test session_lifecycle`
- `cargo test -p agentd --test workspace_contract`
- `cargo clippy --workspace --all-targets -- -D warnings`