### PR TITLE
feat(runner): preserve host-side session audit records

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,11 @@ agentd is not:
 
 The key architectural consequence is simple: agentd may configure tool availability for a runtime, but it does not proxy the MCP wire protocol or ship domain-specific MCP servers inside this repository.
 
+Platform contract: `agentd-runner` targets Linux only. Non-Linux compilation
+failure is intentional and matches the runtime contract: rootless Podman,
+systemd user services, SELinux-aware host filesystem handling, and Linux UID
+mapping semantics are all part of the supported execution model.
+
 ### Terminology
 
 - **Profile**: a named, reusable environment specification in the daemon config — base image, methodology, optional default repo, optional schedule, credentials, and command. What the operator declares.
@@ -133,9 +138,19 @@ The runner drops privileges with `gosu` and launches the profile's configured se
 
 ### Phase 4: Teardown (`agentd-runner`)
 
-When the session ends or times out, the runner force-removes the container, finalizes `agentd/session.json` with end timestamp and outcome through an atomic same-directory temp-file rename, and seals the session record read-only on the host. The ephemeral container workspace still disappears, but the host audit record remains at `{audit_root}/{profile}/{session_id}/`.
+When the session ends or times out, the runner first force-removes the
+container. Only after cleanup succeeds does it finalize `agentd/session.json`
+with end timestamp and outcome through an atomic same-directory temp-file
+rename and seal the session record read-only on the host. The ephemeral
+container workspace still disappears, but the host audit record remains at
+`{audit_root}/{profile}/{session_id}/`.
 
-If agentd is interrupted after writing start metadata but before finalization, the session record remains **incomplete**: `agentd/session.json` has `start_timestamp` but no `end_timestamp` or `outcome`. Operators should read that state as "the daemon stopped before closeout completed," not as a successful or failed terminal outcome.
+If agentd is interrupted after writing start metadata but before finalization,
+or if teardown cleanup fails before finalization can begin, the session record
+remains **incomplete**: `agentd/session.json` has `start_timestamp` but no
+`end_timestamp` or `outcome`. Operators should read that state as "the daemon
+stopped before closeout completed" or "teardown cleanup did not complete," not
+as a successful or failed terminal outcome.
 
 ## 5. Container Isolation Model
 
@@ -217,7 +232,8 @@ verifies that the daemon can create and remove a file under the resolved audit
 root before dispatch begins. That catches ordinary permission and path errors
 early, but it does not validate network-filesystem behavior beyond the probe;
 NFS and similar targets can still fail later with semantics the probe does not
-model.
+model. If probe-file creation succeeds but probe-file removal fails, the audit
+root can retain that uniquely named probe file as leftover cruft.
 
 Session ids are 16 lowercase hex characters generated from `getrandom`, giving
 roughly `2^64` possible values per profile and a birthday bound near `2^32`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,17 +141,20 @@ The runner drops privileges with `gosu` and launches the profile's configured se
 When the session ends or times out, the runner first force-removes the
 container. Only after cleanup succeeds does it finalize `agentd/session.json`
 with end timestamp and outcome through an atomic same-directory temp-file
-rename and seal the session record read-only on the host. The ephemeral
-container workspace still disappears, but the host audit record remains at
+rename. Before that publish step it seals persisted non-metadata audit entries
+read-only on the host, then publishes a read-only `session.json` as the final
+commit point. Ancestor directories remain writable because the atomic replace
+requires a writable parent directory. The ephemeral container workspace still
+disappears, but the host audit record remains at
 `{audit_root}/{profile}/{session_id}/`.
 
 If agentd is interrupted after writing start metadata but before finalization,
 if teardown cleanup fails before finalization can begin, or if audit
 finalization attempts closeout and fails, the session record remains
 **incomplete**: `agentd/session.json` has `start_timestamp` but no
-`end_timestamp` or `outcome`, and `runa/` stays unsealed. The filesystem alone
-does not distinguish "cleanup never completed" from "finalization attempted
-and failed." Operators should use tracing to disambiguate when it matters:
+`end_timestamp` or `outcome`. The filesystem alone does not distinguish
+"cleanup never completed" from "finalization attempted and failed." Operators
+should use tracing to disambiguate when it matters:
 `runner.lifecycle_failure` reports the failing stage (`"session resource allocation"`,
 `"container creation"`, `"session execution"`, or `"session audit finalization"`),
 while `runner.session_outcome`, `runner.session_error`, and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,11 +146,19 @@ container workspace still disappears, but the host audit record remains at
 `{audit_root}/{profile}/{session_id}/`.
 
 If agentd is interrupted after writing start metadata but before finalization,
-or if teardown cleanup fails before finalization can begin, the session record
-remains **incomplete**: `agentd/session.json` has `start_timestamp` but no
-`end_timestamp` or `outcome`. Operators should read that state as "the daemon
-stopped before closeout completed" or "teardown cleanup did not complete," not
-as a successful or failed terminal outcome.
+if teardown cleanup fails before finalization can begin, or if audit
+finalization attempts closeout and fails, the session record remains
+**incomplete**: `agentd/session.json` has `start_timestamp` but no
+`end_timestamp` or `outcome`, and `runa/` stays unsealed. The filesystem alone
+does not distinguish "cleanup never completed" from "finalization attempted
+and failed." Operators should use tracing to disambiguate when it matters:
+`runner.lifecycle_failure` reports the failing stage (`"session resource allocation"`,
+`"container creation"`, `"session execution"`, or `"session audit finalization"`),
+while `runner.session_outcome`, `runner.session_error`, and
+`runner.session_teardown` provide the semantic outcome and teardown status.
+On disk, all of those failure paths intentionally preserve the same
+incomplete-record signal rather than inventing multiple partially-finalized
+states.
 
 ## 5. Container Isolation Model
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ The runner prepares the execution environment:
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
 5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, or `gosu` are not supported.
-6. Allocates a host audit record at `/var/lib/tesserine/audit/{profile}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
+6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{profile}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
 7. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets, the runner-owned audit leaf `/home/{username}/.agentd/audit/runa`, and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself, `/home/{username}/.agentd` plus its descendants, and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
 8. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
 
@@ -133,7 +133,7 @@ The runner drops privileges with `gosu` and launches the profile's configured se
 
 ### Phase 4: Teardown (`agentd-runner`)
 
-When the session ends or times out, the runner force-removes the container, finalizes `agentd/session.json` with end timestamp and outcome, and seals the session record read-only on the host. The ephemeral container workspace still disappears, but the host audit record remains at `/var/lib/tesserine/audit/{profile}/{session_id}/`.
+When the session ends or times out, the runner force-removes the container, finalizes `agentd/session.json` with end timestamp and outcome through an atomic same-directory temp-file rename, and seals the session record read-only on the host. The ephemeral container workspace still disappears, but the host audit record remains at `{audit_root}/{profile}/{session_id}/`.
 
 If agentd is interrupted after writing start metadata but before finalization, the session record remains **incomplete**: `agentd/session.json` has `start_timestamp` but no `end_timestamp` or `outcome`. Operators should read that state as "the daemon stopped before closeout completed," not as a successful or failed terminal outcome.
 
@@ -177,13 +177,18 @@ SELinux-enforcing hosts such as Fedora CoreOS. `agentd/session.json` is not
 mounted into the container; it stays host-only so runa-written state and
 agentd-written metadata are distinguishable on disk without disambiguation.
 
-Host audit records live under `/var/lib/tesserine/audit/<profile>/<session_id>/`
-with this layout:
+Host audit records live under the resolved audit root, by default
+`$XDG_STATE_HOME/tesserine/audit/<profile>/<session_id>/` or
+`$HOME/.local/state/tesserine/audit/<profile>/<session_id>/` when
+`XDG_STATE_HOME` is unset. Root-owned system installs should set
+`daemon.audit_root = "/var/lib/tesserine/audit"`. Each record has this
+layout:
 
 - `runa/` — preserved runa state written naturally by the runtime
 - `agentd/session.json` — agentd-written metadata (`session_id`, `profile`,
   `repo_url`, optional `work_unit`, timestamps, outcome, exit code when
-  applicable)
+  applicable) written by atomic temp-file replacement within the record
+  directory
 
 Coverage is intentionally scoped to the repo-root `.runa/` tree. That captures
 `runa`'s non-configurable `.runa/store/` and the default `.runa/workspace/`.
@@ -192,15 +197,35 @@ that workspace path is outside the audit mount and will not be preserved.
 Groundwork uses the default `.runa/workspace/` layout and is fully covered.
 
 Retention is intentionally out of scope here. Audit records accumulate
-indefinitely under `/var/lib/tesserine/audit/`; pruning and retention policy
-are future work, so disk growth is currently an operator concern.
+indefinitely under the resolved audit root; pruning and retention policy are
+future work, so disk growth is currently an operator concern. Completed records
+seal directories to `0555` and non-symlink entries to `0444`, so deleting old
+records requires restoring write permission first, for example
+`chmod -R u+w <record_dir> && rm -rf <record_dir>`.
 
 The host security model is intentionally single-tenant. While a session is
 running, agentd opens the mounted `runa/` subtree with mode `0o777` so writes
 through the rootless container's UID mapping succeed. Any user with host shell
-access can therefore read or write that subtree during the active session. For
-single-tenant deployments such as babbie, that tradeoff is acceptable; a
-multi-tenant host would need a different permission model before deployment.
+access can therefore read or write that subtree during the active session. On
+completion, agentd seals directories to `0555` and non-symlink entries to
+`0444`, making finished records world-readable on the host. For single-tenant
+deployments such as babbie, that tradeoff is acceptable; a multi-tenant host
+would need a different permission model before deployment.
+
+The startup writability probe is intentionally local-filesystem scoped. It
+verifies that the daemon can create and remove a file under the resolved audit
+root before dispatch begins. That catches ordinary permission and path errors
+early, but it does not validate network-filesystem behavior beyond the probe;
+NFS and similar targets can still fail later with semantics the probe does not
+model.
+
+Session ids are 16 lowercase hex characters generated from `getrandom`, giving
+roughly `2^64` possible values per profile and a birthday bound near `2^32`
+sessions before collisions become materially likely. On collision,
+`create_dir_all` would silently reuse the existing directory tree and merge two
+records. That is not an operational concern at current scale, but operators
+planning very long-lived or very high-volume deployments should understand the
+risk envelope.
 
 ## 6. Credential Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,9 @@ The runner prepares the execution environment:
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
 5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, or `gosu` are not supported.
-6. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
+6. Allocates a host audit record at `/var/lib/tesserine/audit/{profile}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
+7. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets, the runner-owned audit leaf `/home/{username}/.agentd/audit/runa`, and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself, `/home/{username}/.agentd` plus its descendants, and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
+8. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
 
 ### Phase 3: Execution (`agentd-runner`)
 
@@ -131,7 +133,9 @@ The runner drops privileges with `gosu` and launches the profile's configured se
 
 ### Phase 4: Teardown (`agentd-runner`)
 
-When the session ends or times out, the runner force-removes the container and discards the entire ephemeral workspace. No session state is preserved on the host by the runner.
+When the session ends or times out, the runner force-removes the container, finalizes `agentd/session.json` with end timestamp and outcome, and seals the session record read-only on the host. The ephemeral container workspace still disappears, but the host audit record remains at `/var/lib/tesserine/audit/{profile}/{session_id}/`.
+
+If agentd is interrupted after writing start metadata but before finalization, the session record remains **incomplete**: `agentd/session.json` has `start_timestamp` but no `end_timestamp` or `outcome`. Operators should read that state as "the daemon stopped before closeout completed," not as a successful or failed terminal outcome.
 
 ## 5. Container Isolation Model
 
@@ -140,6 +144,7 @@ agentd runs sessions in ephemeral Podman containers so agents remain separated f
 | Mount or Injection | Purpose | Need Served |
 |---|---|---|
 | Read-only methodology directory | Expose the configured methodology manifest and protocol assets without allowing mutation | Context |
+| Runner-owned audit bind mount at `/home/{username}/.agentd/audit/runa` | Persist runa state on the host while keeping agentd metadata distinct in the same session record | Context, Mission |
 | Profile-declared bind mounts | Expose host-managed state such as subscription auth or persistent artifact storage with per-mount read-only vs read-write policy | Context, Credentials |
 | Credentials | Authenticate to external systems without baking secrets into images | Credentials |
 | Home workspace at `/home/{username}` with repo at `/home/{username}/repo` | Give the session a writable standard Linux home and a clean project workspace that starts fresh each run | Mission, Tool Availability, Identity |
@@ -148,6 +153,7 @@ From inside the environment, an agent should see:
 - identity-related environment variables
 - `$HOME` set to `/home/{username}`
 - a read-only methodology mount rooted at `manifest.toml`
+- a runner-managed audit bridge at `/home/{username}/repo/.runa -> /home/{username}/.agentd/audit/runa`
 - any additional bind mounts declared by the selected profile
 - a fresh writable repository checkout at `/home/{username}/repo`
 - any runtime-managed state the configured session command creates inside the repo or home directory
@@ -163,6 +169,38 @@ consumer of this mechanism; persistent audit storage in `#76` builds on the
 same path with read-write mounts. Additional mounts are not relabelled; on
 SELinux-enabled hosts, operators must pre-label those host paths with a
 container-compatible context.
+
+The internal audit mount is different from operator-declared mounts. It is
+runner-owned, not operator-owned, and agentd applies `relabel=shared` to that
+bind mount so the persisted `runa/` subtree remains writable on
+SELinux-enforcing hosts such as Fedora CoreOS. `agentd/session.json` is not
+mounted into the container; it stays host-only so runa-written state and
+agentd-written metadata are distinguishable on disk without disambiguation.
+
+Host audit records live under `/var/lib/tesserine/audit/<profile>/<session_id>/`
+with this layout:
+
+- `runa/` — preserved runa state written naturally by the runtime
+- `agentd/session.json` — agentd-written metadata (`session_id`, `profile`,
+  `repo_url`, optional `work_unit`, timestamps, outcome, exit code when
+  applicable)
+
+Coverage is intentionally scoped to the repo-root `.runa/` tree. That captures
+`runa`'s non-configurable `.runa/store/` and the default `.runa/workspace/`.
+If a methodology sets `artifacts_dir` outside `.runa/` in `.runa/config.toml`,
+that workspace path is outside the audit mount and will not be preserved.
+Groundwork uses the default `.runa/workspace/` layout and is fully covered.
+
+Retention is intentionally out of scope here. Audit records accumulate
+indefinitely under `/var/lib/tesserine/audit/`; pruning and retention policy
+are future work, so disk growth is currently an operator concern.
+
+The host security model is intentionally single-tenant. While a session is
+running, agentd opens the mounted `runa/` subtree with mode `0o777` so writes
+through the rootless container's UID mapping succeed. Any user with host shell
+access can therefore read or write that subtree during the active session. For
+single-tenant deployments such as babbie, that tradeoff is acceptable; a
+multi-tenant host would need a different permission model before deployment.
 
 ## 6. Credential Flow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Session teardown now skips audit finalization and sealing when cleanup fails, leaving `agentd/session.json` intentionally incomplete instead of marking a session complete while its audit bind mount may still be live.
+- Completed session outcomes now remain caller-visible when only audit finalization fails after teardown cleanup succeeds.
+- Audit sealing now refuses multi-linked entries before rewriting metadata, preventing host file mode changes through hard-linked audit aliases.
+- Allocation rollback failure now preserves the incomplete audit-record signal instead of finalizing `agentd/session.json` after leaked cleanup state.
 
 ## [0.1.0] — 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
+- `agentd-runner` now declares its real platform contract at compile time: the crate targets Linux only, and downstream non-Linux builds now fail explicitly instead of compiling dead fallback code into a non-functional binary.
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
 - Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
 - Profile-declared bind mounts now reject overlapping container targets within the same profile, so nested targets fail validation before startup instead of reaching the container setup script.
 - Persistent audit records now default to `$XDG_STATE_HOME/tesserine/audit/<profile>/<session_id>/`, falling back to `$HOME/.local/state/tesserine/audit/<profile>/<session_id>/` for rootless installs, with `daemon.audit_root` available as an explicit override for root-owned system installs such as `/var/lib/tesserine/audit/`.
 - Completed audit records now seal directories to `0555` and non-symlink entries to `0444`, skip symlinks while sealing, and update `agentd/session.json` through atomic temp-file replacement instead of truncate-and-write.
 - `agentd_runner::SessionSpec` now requires an explicit `audit_root` field, making the audit-record destination part of the runner API instead of an implicit process-environment override.
+
+### Fixed
+
+- Session teardown now skips audit finalization and sealing when cleanup fails, leaving `agentd/session.json` intentionally incomplete instead of marking a session complete while its audit bind mount may still be live.
 
 ## [0.1.0] — 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
 - Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
 - Profile-declared bind mounts now reject overlapping container targets within the same profile, so nested targets fail validation before startup instead of reaching the container setup script.
-- Each session now leaves a persistent host audit record under `/var/lib/tesserine/audit/<profile>/<session_id>/`, with preserved `runa/` state, structured agentd metadata in `agentd/session.json`, repo-root `.runa` reserved as a runner-managed audit bridge, and completed records sealed read-only after teardown.
+- Persistent audit records now default to `$XDG_STATE_HOME/tesserine/audit/<profile>/<session_id>/`, falling back to `$HOME/.local/state/tesserine/audit/<profile>/<session_id>/` for rootless installs, with `daemon.audit_root` available as an explicit override for root-owned system installs such as `/var/lib/tesserine/audit/`.
+- Completed audit records now seal directories to `0555` and non-symlink entries to `0444`, skip symlinks while sealing, and update `agentd/session.json` through atomic temp-file replacement instead of truncate-and-write.
+- `agentd_runner::SessionSpec` now requires an explicit `audit_root` field, making the audit-record destination part of the runner API instead of an implicit process-environment override.
 
 ## [0.1.0] — 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
 - Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
 - Profile-declared bind mounts now reject overlapping container targets within the same profile, so nested targets fail validation before startup instead of reaching the container setup script.
+- Each session now leaves a persistent host audit record under `/var/lib/tesserine/audit/<profile>/<session_id>/`, with preserved `runa/` state, structured agentd metadata in `agentd/session.json`, repo-root `.runa` reserved as a runner-managed audit bridge, and completed records sealed read-only after teardown.
 
 ## [0.1.0] — 2026-04-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "getrandom",
  "serde",
  "serde_json",
+ "time",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -288,6 +289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +535,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +566,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -763,6 +785,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "agentd-scheduler",
  "clap",
  "croner",
+ "getrandom",
  "libc",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ clone, and read-only methodology context — supervised from setup through
 teardown. agentd prepares and supervises these environments; model inference and
 MCP transport belong to the agent runtime inside the container.
 
+The project targets Linux hosts. Non-Linux builds fail intentionally because
+the runner depends on Linux runtime primitives including rootless Podman,
+systemd user services, and SELinux-aware filesystem handling.
+
 ## Why
 
 Running autonomous agents requires infrastructure: isolated environments,
@@ -156,8 +160,10 @@ fires are not backfilled after downtime. Persistent audit records default to
 
 ## Running a Session
 
-Build from source with `cargo build --release`. Requires rootless Podman for
-container execution.
+Build from source with `cargo build --release`. agentd targets Linux and
+requires rootless Podman for container execution. Operational deployments also
+assume systemd user services and the SELinux considerations described in
+`ARCHITECTURE.md`.
 
 Start the daemon:
 
@@ -203,7 +209,8 @@ the container, the agent sees:
 The container is force-removed on completion. The session's audit record
 persists on the host under the resolved audit root
 `<audit_root>/<profile>/<session_id>/`, with runa state in `runa/` and agentd
-metadata in `agentd/session.json`.
+metadata in `agentd/session.json`. If teardown cleanup fails, that metadata
+remains intentionally incomplete with no `end_timestamp` or `outcome`.
 
 ## Scheduled Runs
 

--- a/README.md
+++ b/README.md
@@ -211,10 +211,14 @@ persists on the host under the resolved audit root
 `<audit_root>/<profile>/<session_id>/`, with runa state in `runa/` and agentd
 metadata in `agentd/session.json`. If teardown cleanup fails, or if audit
 finalization attempts closeout and fails, that metadata remains intentionally
-incomplete with no `end_timestamp` or `outcome`. The on-disk record does not
-encode which path occurred; operators should use `runner.lifecycle_failure`
-plus the surrounding `runner.session_outcome`, `runner.session_error`, and
-`runner.session_teardown` events to disambiguate cause.
+incomplete with no `end_timestamp` or `outcome`. On successful finalization,
+agentd seals persisted runa entries read-only and publishes a read-only
+`session.json` as the final commit point. Ancestor directories remain writable
+so the final same-directory atomic replace can occur. The on-disk metadata does
+not encode which incomplete path occurred; operators should use
+`runner.lifecycle_failure` plus the surrounding `runner.session_outcome`,
+`runner.session_error`, and `runner.session_teardown` events to disambiguate
+cause.
 
 ## Scheduled Runs
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Profiles may now declare a default repository and an optional cron schedule.
 Manual runs still flow through `agentd run`, and scheduled runs dispatch
 through the same daemon socket intake without introducing a separate job type.
 Profiles may also declare additional bind mounts for host-managed state such as
-subscription auth directories or persistent audit storage.
+subscription auth directories. Independently of profile mounts, agentd now
+persists each session's audit record under `/var/lib/tesserine/audit/`.
 
 ## Configuration
 
@@ -129,7 +130,8 @@ environment — export them before starting the daemon. Additional `mounts`
 entries are bind mounts: `source` must be an absolute existing host path,
 `target` must be an absolute container path, targets must be unique within the
 profile, and runner-managed targets are reserved: `/agentd/methodology`,
-`/home/{profile}`, and `/home/{profile}/repo` plus its descendants. Other
+`/home/{profile}`, `/home/{profile}/.agentd`, and `/home/{profile}/repo` plus
+their descendants. Other
 targets under `/home/{profile}` remain supported, including read-only auth
 mounts such as `/home/site-builder/.claude`. Additional mounts are not
 relabelled; on SELinux-enabled hosts, operators must ensure each host path
@@ -178,14 +180,16 @@ the container, the agent sees:
 
 - An unprivileged user with `$HOME` at `/home/site-builder`
 - A fresh clone of the repository at `/home/site-builder/repo`
+- Repo-root `.runa` bridged to persistent audit storage
 - Read-only methodology mount at `/agentd/methodology`
 - Any operator-declared additional bind mounts, read-only or read-write per profile
 - Credentials injected as environment variables
 - `AGENTD_WORK_UNIT` when the invocation includes one
 - The configured session command executing from the repo directory
 
-The container is force-removed on completion. No session state persists on the
-host.
+The container is force-removed on completion. The session's audit record
+persists on the host under `/var/lib/tesserine/audit/<profile>/<session_id>/`,
+with runa state in `runa/` and agentd metadata in `agentd/session.json`.
 
 ## Scheduled Runs
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ Manual runs still flow through `agentd run`, and scheduled runs dispatch
 through the same daemon socket intake without introducing a separate job type.
 Profiles may also declare additional bind mounts for host-managed state such as
 subscription auth directories. Independently of profile mounts, agentd now
-persists each session's audit record under `/var/lib/tesserine/audit/`.
+persists each session's audit record under the rootless default
+`$XDG_STATE_HOME/tesserine/audit/`, falling back to
+`$HOME/.local/state/tesserine/audit/`, with `daemon.audit_root` available as an
+explicit override for root-owned installs such as `/var/lib/tesserine/audit/`.
 
 ## Configuration
 
@@ -46,6 +49,14 @@ config file — start from
 ```toml
 # Static profile registry for agentd.
 # A profile can carry its own default repo and optional schedule.
+
+#[daemon]
+# Optional explicit host path for persistent audit records. Rootless installs
+# default to $XDG_STATE_HOME/tesserine/audit, falling back to
+# $HOME/.local/state/tesserine/audit when XDG_STATE_HOME is unset.
+# Root-owned system installs should typically point this at
+# /var/lib/tesserine/audit.
+#audit_root = "/var/lib/tesserine/audit"
 
 [[profiles]]
 # Stable operator-facing profile name used for lookup and container identity.
@@ -139,7 +150,9 @@ already has a container-compatible label. The base image must provide
 `/bin/sh`, `find`, `git`, `useradd`, `gosu`, and whatever binaries the
 configured session command uses. When a profile declares `schedule`, it must
 also declare `repo`. Schedules are evaluated in daemon-local time and missed
-fires are not backfilled after downtime.
+fires are not backfilled after downtime. Persistent audit records default to
+`$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set
+`daemon.audit_root` to override that for system installations.
 
 ## Running a Session
 
@@ -188,8 +201,9 @@ the container, the agent sees:
 - The configured session command executing from the repo directory
 
 The container is force-removed on completion. The session's audit record
-persists on the host under `/var/lib/tesserine/audit/<profile>/<session_id>/`,
-with runa state in `runa/` and agentd metadata in `agentd/session.json`.
+persists on the host under the resolved audit root
+`<audit_root>/<profile>/<session_id>/`, with runa state in `runa/` and agentd
+metadata in `agentd/session.json`.
 
 ## Scheduled Runs
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,12 @@ the container, the agent sees:
 The container is force-removed on completion. The session's audit record
 persists on the host under the resolved audit root
 `<audit_root>/<profile>/<session_id>/`, with runa state in `runa/` and agentd
-metadata in `agentd/session.json`. If teardown cleanup fails, that metadata
-remains intentionally incomplete with no `end_timestamp` or `outcome`.
+metadata in `agentd/session.json`. If teardown cleanup fails, or if audit
+finalization attempts closeout and fails, that metadata remains intentionally
+incomplete with no `end_timestamp` or `outcome`. The on-disk record does not
+encode which path occurred; operators should use `runner.lifecycle_failure`
+plus the surrounding `runner.session_outcome`, `runner.session_error`, and
+`runner.session_teardown` events to disambiguate cause.
 
 ## Scheduled Runs
 

--- a/crates/agentd-runner/Cargo.toml
+++ b/crates/agentd-runner/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+build = "build.rs"
 
 [dependencies]
 getrandom = "0.4.2"

--- a/crates/agentd-runner/Cargo.toml
+++ b/crates/agentd-runner/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 getrandom = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+time = { version = "0.3.44", features = ["formatting"] }
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/crates/agentd-runner/build.rs
+++ b/crates/agentd-runner/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
+    if target_os != "linux" {
+        println!(
+            "cargo:error=agentd-runner requires target_os = \"linux\"; got {target_os}. \
+this failure is intentional because the runner depends on Linux runtime primitives"
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -1,13 +1,12 @@
 use crate::podman::run_podman_command;
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-const HOST_AUDIT_ROOT: &str = "/var/lib/tesserine/audit";
-const TEST_AUDIT_ROOT_ENV: &str = "AGENTD_TEST_AUDIT_ROOT";
 const METADATA_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,7 +48,7 @@ pub(crate) fn prepare_session_audit_record(
     spec: &SessionSpec,
     invocation: &SessionInvocation,
 ) -> Result<SessionAuditRecord, RunnerError> {
-    prepare_session_audit_record_at(&host_audit_root(), session_id, spec, invocation)
+    prepare_session_audit_record_at(&spec.audit_root, session_id, spec, invocation)
 }
 
 fn prepare_session_audit_record_at(
@@ -117,7 +116,7 @@ fn write_session_audit_metadata(
     let mut payload = serde_json::to_vec_pretty(&metadata)
         .map_err(|error| RunnerError::Io(std::io::Error::other(error)))?;
     payload.push(b'\n');
-    fs::write(&record.metadata_path, payload)?;
+    write_atomic(&record.metadata_path, &payload)?;
     Ok(())
 }
 
@@ -125,12 +124,6 @@ fn current_timestamp() -> Result<String, RunnerError> {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .map_err(|error| RunnerError::Io(std::io::Error::other(error)))
-}
-
-fn host_audit_root() -> PathBuf {
-    std::env::var_os(TEST_AUDIT_ROOT_ENV)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(HOST_AUDIT_ROOT))
 }
 
 fn set_active_runa_permissions(path: &Path) -> Result<(), RunnerError> {
@@ -163,6 +156,10 @@ fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerEr
 
 fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
     let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
     if metadata.is_dir() {
         for entry in fs::read_dir(path)? {
             let entry = entry?;
@@ -170,15 +167,15 @@ fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
         }
     }
 
-    seal_path(path, metadata.permissions())
+    seal_path(path, metadata.is_dir())
 }
 
-fn seal_path(path: &Path, permissions: fs::Permissions) -> Result<(), RunnerError> {
+fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
 
-        let sealed_mode = permissions.mode() & !0o222;
+        let sealed_mode = if is_dir { 0o555 } else { 0o444 };
         fs::set_permissions(path, fs::Permissions::from_mode(sealed_mode))?;
         Ok(())
     }
@@ -195,12 +192,72 @@ fn seal_path(path: &Path, permissions: fs::Permissions) -> Result<(), RunnerErro
 fn seal_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
     run_podman_command(vec![
         "unshare".to_string(),
-        "chmod".to_string(),
-        "-R".to_string(),
-        "a-w".to_string(),
+        "find".to_string(),
+        "-P".to_string(),
         path.display().to_string(),
+        "-type".to_string(),
+        "d".to_string(),
+        "-exec".to_string(),
+        "chmod".to_string(),
+        "0555".to_string(),
+        "{}".to_string(),
+        "+".to_string(),
+    ])?;
+    run_podman_command(vec![
+        "unshare".to_string(),
+        "find".to_string(),
+        "-P".to_string(),
+        path.display().to_string(),
+        "!".to_string(),
+        "-type".to_string(),
+        "d".to_string(),
+        "!".to_string(),
+        "-type".to_string(),
+        "l".to_string(),
+        "-exec".to_string(),
+        "chmod".to_string(),
+        "0444".to_string(),
+        "{}".to_string(),
+        "+".to_string(),
     ])
     .map(|_| ())
+}
+
+fn write_atomic(path: &Path, payload: &[u8]) -> Result<(), RunnerError> {
+    let temp_path = path.with_extension("json.tmp");
+    let parent = path.parent().ok_or_else(|| {
+        RunnerError::Io(std::io::Error::other(
+            "audit metadata path must have a parent directory",
+        ))
+    })?;
+    let write_result = (|| -> Result<(), RunnerError> {
+        let mut temp_file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temp_path)?;
+        temp_file.write_all(payload)?;
+        temp_file.sync_all()?;
+        drop(temp_file);
+        fs::rename(&temp_path, path)?;
+        sync_parent_dir(parent)?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    write_result
+}
+
+fn sync_parent_dir(path: &Path) -> Result<(), RunnerError> {
+    #[cfg(unix)]
+    {
+        File::open(path)?.sync_all()?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -228,6 +285,10 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let metadata = fs::symlink_metadata(path).expect("path metadata should exist");
+        if metadata.file_type().is_symlink() {
+            return;
+        }
+
         if metadata.is_dir() {
             for entry in fs::read_dir(path).expect("directory should be readable") {
                 let entry = entry.expect("directory entry should be readable");
@@ -312,8 +373,93 @@ mod tests {
                 .expect("runa dir metadata should exist")
                 .permissions()
                 .mode();
-            assert_eq!(runa_mode & 0o222, 0);
+            let metadata_mode = fs::metadata(&record.metadata_path)
+                .expect("metadata file should exist")
+                .permissions()
+                .mode();
+            assert_eq!(runa_mode & 0o777, 0o555);
+            assert_eq!(metadata_mode & 0o777, 0o444);
         }
+
+        #[cfg(unix)]
+        make_tree_writable(&root);
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn finalize_session_audit_record_skips_symlinks_when_sealing() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let root = unique_test_dir("agentd-audit-symlink");
+        let outside_target = root.join("outside-target.txt");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "1111222233334444",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+
+        fs::write(&outside_target, "outside\n").expect("outside target should be writable");
+        fs::set_permissions(&outside_target, fs::Permissions::from_mode(0o666))
+            .expect("outside target mode should be writable");
+        symlink(&outside_target, record.runa_dir.join("escaped-link"))
+            .expect("symlink should be created");
+
+        super::finalize_session_audit_record(
+            &record,
+            SessionAuditCompletion::Outcome(&SessionOutcome::Success { exit_code: 0 }),
+        )
+        .expect("audit record should finalize");
+
+        let outside_mode = fs::metadata(&outside_target)
+            .expect("outside target metadata should exist")
+            .permissions()
+            .mode();
+        assert_eq!(outside_mode & 0o777, 0o666);
+
+        make_tree_writable(&root);
+        fs::remove_file(&outside_target).expect("outside target should be removed");
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn write_session_audit_metadata_replaces_file_without_leaving_temp_file() {
+        let root = unique_test_dir("agentd-audit-atomic-write");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "abcdabcdabcdabcd",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+
+        super::finalize_session_audit_record(
+            &record,
+            SessionAuditCompletion::Outcome(&SessionOutcome::Success { exit_code: 0 }),
+        )
+        .expect("audit record should finalize");
+
+        let payload = fs::read_to_string(&record.metadata_path)
+            .expect("final session metadata should be readable");
+        let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
+        assert_eq!(json["outcome"], "success");
+        assert!(
+            !record.metadata_path.with_extension("json.tmp").exists(),
+            "temporary metadata file should not remain after atomic replace"
+        );
 
         #[cfg(unix)]
         make_tree_writable(&root);

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -1,0 +1,330 @@
+use crate::podman::run_podman_command;
+use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+const HOST_AUDIT_ROOT: &str = "/var/lib/tesserine/audit";
+const TEST_AUDIT_ROOT_ENV: &str = "AGENTD_TEST_AUDIT_ROOT";
+const METADATA_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionAuditRecord {
+    pub(crate) record_dir: PathBuf,
+    pub(crate) runa_dir: PathBuf,
+    pub(crate) metadata_path: PathBuf,
+    pub(crate) session_id: String,
+    pub(crate) profile: String,
+    pub(crate) repo_url: String,
+    pub(crate) work_unit: Option<String>,
+    pub(crate) start_timestamp: String,
+}
+
+pub(crate) enum SessionAuditCompletion<'a> {
+    Outcome(&'a SessionOutcome),
+    Error,
+}
+
+#[derive(Debug, Serialize)]
+struct SessionAuditMetadata<'a> {
+    schema_version: u32,
+    session_id: &'a str,
+    profile: &'a str,
+    repo_url: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    work_unit: Option<&'a str>,
+    start_timestamp: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_timestamp: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+}
+
+pub(crate) fn prepare_session_audit_record(
+    session_id: &str,
+    spec: &SessionSpec,
+    invocation: &SessionInvocation,
+) -> Result<SessionAuditRecord, RunnerError> {
+    prepare_session_audit_record_at(&host_audit_root(), session_id, spec, invocation)
+}
+
+fn prepare_session_audit_record_at(
+    host_root: &Path,
+    session_id: &str,
+    spec: &SessionSpec,
+    invocation: &SessionInvocation,
+) -> Result<SessionAuditRecord, RunnerError> {
+    let record_dir = host_root.join(&spec.profile_name).join(session_id);
+    let runa_dir = record_dir.join("runa");
+    let agentd_dir = record_dir.join("agentd");
+    let metadata_path = agentd_dir.join("session.json");
+
+    fs::create_dir_all(&runa_dir)?;
+    fs::create_dir_all(&agentd_dir)?;
+    set_active_runa_permissions(&runa_dir)?;
+
+    let start_timestamp = current_timestamp()?;
+    let record = SessionAuditRecord {
+        record_dir,
+        runa_dir,
+        metadata_path,
+        session_id: session_id.to_string(),
+        profile: spec.profile_name.clone(),
+        repo_url: invocation.repo_url.clone(),
+        work_unit: invocation.work_unit.clone(),
+        start_timestamp,
+    };
+
+    write_session_audit_metadata(&record, None, None, None)?;
+    Ok(record)
+}
+
+pub(crate) fn finalize_session_audit_record(
+    record: &SessionAuditRecord,
+    completion: SessionAuditCompletion<'_>,
+) -> Result<(), RunnerError> {
+    let (outcome, exit_code) = match completion {
+        SessionAuditCompletion::Outcome(outcome) => (Some(outcome.label()), outcome.exit_code()),
+        SessionAuditCompletion::Error => (Some("error"), None),
+    };
+    let end_timestamp = current_timestamp()?;
+
+    write_session_audit_metadata(record, Some(&end_timestamp), outcome, exit_code)?;
+    seal_session_audit_record(record)
+}
+
+fn write_session_audit_metadata(
+    record: &SessionAuditRecord,
+    end_timestamp: Option<&str>,
+    outcome: Option<&str>,
+    exit_code: Option<i32>,
+) -> Result<(), RunnerError> {
+    let metadata = SessionAuditMetadata {
+        schema_version: METADATA_SCHEMA_VERSION,
+        session_id: &record.session_id,
+        profile: &record.profile,
+        repo_url: &record.repo_url,
+        work_unit: record.work_unit.as_deref(),
+        start_timestamp: &record.start_timestamp,
+        end_timestamp,
+        outcome,
+        exit_code,
+    };
+    let mut payload = serde_json::to_vec_pretty(&metadata)
+        .map_err(|error| RunnerError::Io(std::io::Error::other(error)))?;
+    payload.push(b'\n');
+    fs::write(&record.metadata_path, payload)?;
+    Ok(())
+}
+
+fn current_timestamp() -> Result<String, RunnerError> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| RunnerError::Io(std::io::Error::other(error)))
+}
+
+fn host_audit_root() -> PathBuf {
+    std::env::var_os(TEST_AUDIT_ROOT_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(HOST_AUDIT_ROOT))
+}
+
+fn set_active_runa_permissions(path: &Path) -> Result<(), RunnerError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(path, fs::Permissions::from_mode(0o777))?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_readonly(false);
+        fs::set_permissions(path, permissions)?;
+        Ok(())
+    }
+}
+
+fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerError> {
+    match seal_path_recursive(&record.record_dir) {
+        Ok(()) => Ok(()),
+        Err(RunnerError::Io(error)) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            seal_with_podman_unshare(&record.record_dir)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            seal_path_recursive(&entry.path())?;
+        }
+    }
+
+    seal_path(path, metadata.permissions())
+}
+
+fn seal_path(path: &Path, permissions: fs::Permissions) -> Result<(), RunnerError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let sealed_mode = permissions.mode() & !0o222;
+        fs::set_permissions(path, fs::Permissions::from_mode(sealed_mode))?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let mut sealed = permissions;
+        sealed.set_readonly(true);
+        fs::set_permissions(path, sealed)?;
+        Ok(())
+    }
+}
+
+fn seal_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
+    run_podman_command(vec![
+        "unshare".to_string(),
+        "chmod".to_string(),
+        "-R".to_string(),
+        "a-w".to_string(),
+        path.display().to_string(),
+    ])
+    .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SessionAuditCompletion, current_timestamp, prepare_session_audit_record_at};
+    use crate::test_support::test_session_spec;
+    use crate::{SessionInvocation, SessionOutcome};
+    use serde_json::Value;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn unique_test_dir(prefix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after the unix epoch")
+                .as_nanos()
+        ))
+    }
+
+    #[cfg(unix)]
+    fn make_tree_writable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = fs::symlink_metadata(path).expect("path metadata should exist");
+        if metadata.is_dir() {
+            for entry in fs::read_dir(path).expect("directory should be readable") {
+                let entry = entry.expect("directory entry should be readable");
+                make_tree_writable(&entry.path());
+            }
+        }
+
+        let writable_mode = metadata.permissions().mode() | 0o700;
+        fs::set_permissions(path, fs::Permissions::from_mode(writable_mode))
+            .expect("path should become writable for cleanup");
+    }
+
+    #[test]
+    fn prepare_session_audit_record_writes_initial_metadata_without_end_or_outcome() {
+        let root = unique_test_dir("agentd-audit-initial");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "0123456789abcdef",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: Some("issue-76".to_string()),
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+
+        let payload = fs::read_to_string(record.metadata_path)
+            .expect("initial session metadata should be readable");
+        let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
+
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["session_id"], "0123456789abcdef");
+        assert_eq!(json["profile"], "site-builder");
+        assert_eq!(json["repo_url"], "https://example.com/agentd.git");
+        assert_eq!(json["work_unit"], "issue-76");
+        assert!(json.get("end_timestamp").is_none());
+        assert!(json.get("outcome").is_none());
+        assert!(json.get("exit_code").is_none());
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_audit_record_writes_outcome_and_seals_record() {
+        let root = unique_test_dir("agentd-audit-final");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "fedcba9876543210",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        fs::write(record.runa_dir.join("artifact.txt"), "persisted\n")
+            .expect("runa artifact should be writable before sealing");
+
+        super::finalize_session_audit_record(
+            &record,
+            SessionAuditCompletion::Outcome(&SessionOutcome::WorkFailed { exit_code: 5 }),
+        )
+        .expect("audit record should finalize");
+
+        let payload = fs::read_to_string(&record.metadata_path)
+            .expect("final session metadata should be readable");
+        let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
+
+        assert_eq!(json["outcome"], "work_failed");
+        assert_eq!(json["exit_code"], 5);
+        assert!(json["end_timestamp"].is_string());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let runa_mode = fs::metadata(&record.runa_dir)
+                .expect("runa dir metadata should exist")
+                .permissions()
+                .mode();
+            assert_eq!(runa_mode & 0o222, 0);
+        }
+
+        #[cfg(unix)]
+        make_tree_writable(&root);
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn current_timestamp_emits_rfc3339_utc_values() {
+        let timestamp = current_timestamp().expect("timestamp should format");
+        assert!(timestamp.ends_with('Z'));
+        assert!(timestamp.contains('T'));
+    }
+}

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -1,6 +1,8 @@
 use crate::podman::run_podman_command;
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
+#[cfg(test)]
+use std::cell::Cell;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -9,8 +11,15 @@ use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
 const METADATA_SCHEMA_VERSION: u32 = 1;
+const ACTIVE_AUDIT_DIRECTORY_MODE: u32 = 0o755;
 const SEALED_FILE_MODE: u32 = 0o444;
 const SEALED_DIRECTORY_MODE: u32 = 0o555;
+
+#[cfg(test)]
+std::thread_local! {
+    static FAIL_SYNC_PARENT_DIR_CALL_FOR_TESTS: Cell<usize> = const { Cell::new(0) };
+    static SYNC_PARENT_DIR_CALL_COUNT_FOR_TESTS: Cell<usize> = const { Cell::new(0) };
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SessionAuditRecord {
@@ -60,7 +69,8 @@ fn prepare_session_audit_record_at(
     spec: &SessionSpec,
     invocation: &SessionInvocation,
 ) -> Result<SessionAuditRecord, RunnerError> {
-    let record_dir = host_root.join(&spec.profile_name).join(session_id);
+    let profile_dir = host_root.join(&spec.profile_name);
+    let record_dir = profile_dir.join(session_id);
     let runa_dir = record_dir.join("runa");
     let agentd_dir = record_dir.join("agentd");
     let metadata_path = agentd_dir.join("session.json");
@@ -69,6 +79,9 @@ fn prepare_session_audit_record_at(
     fs::create_dir_all(&agentd_dir)?;
 
     rollback_record_dir_on_error(&record_dir, || {
+        set_active_audit_directory_permissions(&profile_dir)?;
+        set_active_audit_directory_permissions(&record_dir)?;
+        set_active_audit_directory_permissions(&agentd_dir)?;
         set_active_runa_permissions(&runa_dir)?;
 
         let start_timestamp = current_timestamp()?;
@@ -179,6 +192,14 @@ where
 
 fn set_active_runa_permissions(path: &Path) -> Result<(), RunnerError> {
     fs::set_permissions(path, fs::Permissions::from_mode(0o777))?;
+    Ok(())
+}
+
+fn set_active_audit_directory_permissions(path: &Path) -> Result<(), RunnerError> {
+    fs::set_permissions(
+        path,
+        fs::Permissions::from_mode(ACTIVE_AUDIT_DIRECTORY_MODE),
+    )?;
     Ok(())
 }
 
@@ -355,8 +376,21 @@ fn write_atomic(path: &Path, payload: &[u8], file_mode: Option<u32>) -> Result<(
         }
         temp_file.sync_all()?;
         drop(temp_file);
+
+        // The atomic rename publishes the finalized metadata. A later parent
+        // directory sync failure is a durability warning, not a correctness
+        // failure.
         fs::rename(&temp_path, path)?;
-        sync_parent_dir(parent)?;
+        if let Err(error) = sync_parent_dir(parent) {
+            tracing::warn!(
+                event = "runner.audit_warning",
+                warning_kind = "post_rename_parent_sync",
+                metadata_path = %path.display(),
+                parent_dir = %parent.display(),
+                error = %error,
+                "parent directory sync failed after atomic audit metadata publish"
+            );
+        }
         Ok(())
     })();
 
@@ -368,8 +402,55 @@ fn write_atomic(path: &Path, payload: &[u8], file_mode: Option<u32>) -> Result<(
 }
 
 fn sync_parent_dir(path: &Path) -> Result<(), RunnerError> {
+    #[cfg(test)]
+    {
+        let call_count = SYNC_PARENT_DIR_CALL_COUNT_FOR_TESTS.with(|call_count| {
+            let next_call = call_count.get() + 1;
+            call_count.set(next_call);
+            next_call
+        });
+        let failure_call = FAIL_SYNC_PARENT_DIR_CALL_FOR_TESTS.with(Cell::get);
+        if failure_call != 0 && call_count == failure_call {
+            return Err(RunnerError::Io(std::io::Error::other(
+                "injected parent directory sync failure",
+            )));
+        }
+    }
+
     File::open(path)?.sync_all()?;
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn with_sync_parent_dir_failure_for_tests<T>(run: impl FnOnce() -> T) -> T {
+    with_sync_parent_dir_failure_on_call_for_tests(1, run)
+}
+
+#[cfg(test)]
+pub(crate) fn with_sync_parent_dir_failure_on_call_for_tests<T>(
+    call_index: usize,
+    run: impl FnOnce() -> T,
+) -> T {
+    FAIL_SYNC_PARENT_DIR_CALL_FOR_TESTS.with(|failure_call| {
+        assert!(
+            failure_call.get() == 0,
+            "sync_parent_dir failure injection should not be nested"
+        );
+        failure_call.set(call_index);
+    });
+    SYNC_PARENT_DIR_CALL_COUNT_FOR_TESTS.with(|call_count| call_count.set(0));
+
+    struct ResetGuard;
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            FAIL_SYNC_PARENT_DIR_CALL_FOR_TESTS.with(|failure_call| failure_call.set(0));
+            SYNC_PARENT_DIR_CALL_COUNT_FOR_TESTS.with(|call_count| call_count.set(0));
+        }
+    }
+
+    let _guard = ResetGuard;
+    run()
 }
 
 #[cfg(test)]
@@ -378,7 +459,7 @@ mod tests {
         SessionAuditCompletion, current_timestamp, prepare_session_audit_record_at,
         rollback_record_dir_on_error,
     };
-    use crate::test_support::test_session_spec;
+    use crate::test_support::{capture_tracing_events, test_session_spec};
     use crate::{RunnerError, SessionInvocation, SessionOutcome};
     use serde_json::Value;
     use std::fs;
@@ -557,6 +638,101 @@ mod tests {
         if root.exists() {
             fs::remove_dir_all(&root).expect("temporary audit root should be removed");
         }
+    }
+
+    #[test]
+    fn prepare_session_audit_record_normalizes_runner_managed_audit_dirs_to_host_traversable_modes()
+    {
+        let root = unique_test_dir("agentd-audit-dir-normalization");
+        let profile_root = root.join("site-builder");
+        let record_dir = profile_root.join("dir-normalization");
+        let agentd_dir = record_dir.join("agentd");
+
+        fs::create_dir_all(&agentd_dir).expect("audit dir tree should be created");
+        fs::set_permissions(&profile_root, fs::Permissions::from_mode(0o700))
+            .expect("profile dir should become private");
+        fs::set_permissions(&record_dir, fs::Permissions::from_mode(0o700))
+            .expect("record dir should become private");
+        fs::set_permissions(&agentd_dir, fs::Permissions::from_mode(0o700))
+            .expect("metadata dir should become private");
+
+        let record = prepare_session_audit_record_at(
+            &root,
+            "dir-normalization",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+
+        let profile_mode = fs::metadata(&profile_root)
+            .expect("profile dir metadata should exist")
+            .permissions()
+            .mode();
+        let record_mode = fs::metadata(&record.record_dir)
+            .expect("record dir metadata should exist")
+            .permissions()
+            .mode();
+        let agentd_mode = fs::metadata(record.metadata_path.parent().expect("metadata dir"))
+            .expect("metadata dir metadata should exist")
+            .permissions()
+            .mode();
+        let runa_mode = fs::metadata(&record.runa_dir)
+            .expect("runa dir metadata should exist")
+            .permissions()
+            .mode();
+
+        assert_eq!(profile_mode & 0o777, 0o755);
+        assert_eq!(record_mode & 0o777, 0o755);
+        assert_eq!(agentd_mode & 0o777, 0o755);
+        assert_eq!(runa_mode & 0o777, 0o777);
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn write_atomic_treats_post_rename_parent_sync_failure_as_a_warning() {
+        let root = unique_test_dir("agentd-audit-post-rename-sync");
+        let metadata_path = root.join("agentd").join("session.json");
+        let payload = br#"{"outcome":"success"}"#;
+
+        fs::create_dir_all(metadata_path.parent().expect("metadata parent"))
+            .expect("metadata parent dir should be created");
+
+        let result = std::cell::RefCell::new(None);
+        let events = capture_tracing_events(|| {
+            let write_result = super::with_sync_parent_dir_failure_for_tests(|| {
+                super::write_atomic(&metadata_path, payload, Some(super::SEALED_FILE_MODE))
+            });
+            result.replace(Some(write_result));
+        });
+
+        result
+            .into_inner()
+            .expect("write result should be captured")
+            .expect("post-rename parent sync failure should not propagate");
+
+        assert_eq!(
+            fs::read(&metadata_path).expect("metadata path should contain finalized payload"),
+            payload
+        );
+        assert!(
+            !metadata_path.with_extension("json.tmp").exists(),
+            "temporary metadata file should not remain after atomic replace"
+        );
+        assert!(
+            events.iter().any(|event| {
+                event["fields"]["event"] == "runner.audit_warning"
+                    && event["fields"]["warning_kind"] == "post_rename_parent_sync"
+            }),
+            "post-rename parent sync failure should emit a durability warning"
+        );
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
 
     #[test]

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -9,6 +9,8 @@ use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
 const METADATA_SCHEMA_VERSION: u32 = 1;
+const SEALED_FILE_MODE: u32 = 0o444;
+const SEALED_DIRECTORY_MODE: u32 = 0o555;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SessionAuditRecord {
@@ -100,8 +102,8 @@ pub(crate) fn finalize_session_audit_record(
     };
     let end_timestamp = current_timestamp()?;
 
-    write_session_audit_metadata(record, Some(&end_timestamp), outcome, exit_code)?;
-    seal_session_audit_record(record)
+    seal_session_audit_record(record)?;
+    write_finalized_session_audit_metadata(record, &end_timestamp, outcome, exit_code)
 }
 
 fn write_session_audit_metadata(
@@ -109,6 +111,31 @@ fn write_session_audit_metadata(
     end_timestamp: Option<&str>,
     outcome: Option<&str>,
     exit_code: Option<i32>,
+) -> Result<(), RunnerError> {
+    write_session_audit_metadata_with_mode(record, end_timestamp, outcome, exit_code, None)
+}
+
+fn write_finalized_session_audit_metadata(
+    record: &SessionAuditRecord,
+    end_timestamp: &str,
+    outcome: Option<&str>,
+    exit_code: Option<i32>,
+) -> Result<(), RunnerError> {
+    write_session_audit_metadata_with_mode(
+        record,
+        Some(end_timestamp),
+        outcome,
+        exit_code,
+        Some(SEALED_FILE_MODE),
+    )
+}
+
+fn write_session_audit_metadata_with_mode(
+    record: &SessionAuditRecord,
+    end_timestamp: Option<&str>,
+    outcome: Option<&str>,
+    exit_code: Option<i32>,
+    file_mode: Option<u32>,
 ) -> Result<(), RunnerError> {
     let metadata = SessionAuditMetadata {
         schema_version: METADATA_SCHEMA_VERSION,
@@ -124,7 +151,7 @@ fn write_session_audit_metadata(
     let mut payload = serde_json::to_vec_pretty(&metadata)
         .map_err(|error| RunnerError::Io(std::io::Error::other(error)))?;
     payload.push(b'\n');
-    write_atomic(&record.metadata_path, &payload)?;
+    write_atomic(&record.metadata_path, &payload, file_mode)?;
     Ok(())
 }
 
@@ -140,10 +167,10 @@ fn set_active_runa_permissions(path: &Path) -> Result<(), RunnerError> {
 }
 
 fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerError> {
-    match seal_path_recursive(&record.record_dir) {
+    match seal_path_recursive(record, &record.record_dir) {
         Ok(()) => Ok(()),
         Err(RunnerError::Io(error)) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-            seal_with_podman_unshare(&record.record_dir)
+            seal_with_podman_unshare(record)
         }
         Err(error) => Err(error),
     }
@@ -173,7 +200,7 @@ fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
     Ok(())
 }
 
-fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
+fn seal_path_recursive(record: &SessionAuditRecord, path: &Path) -> Result<(), RunnerError> {
     let metadata = fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() {
         return Ok(());
@@ -182,30 +209,61 @@ fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
     if metadata.is_dir() {
         for entry in fs::read_dir(path)? {
             let entry = entry?;
-            seal_path_recursive(&entry.path())?;
+            seal_path_recursive(record, &entry.path())?;
         }
+    }
+
+    if should_skip_sealing_path(record, path) {
+        return Ok(());
     }
 
     seal_path(path, metadata.is_dir())
 }
 
 fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
-    let sealed_mode = if is_dir { 0o555 } else { 0o444 };
+    let sealed_mode = if is_dir {
+        SEALED_DIRECTORY_MODE
+    } else {
+        SEALED_FILE_MODE
+    };
     fs::set_permissions(path, fs::Permissions::from_mode(sealed_mode))?;
     Ok(())
 }
 
-fn seal_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
+fn should_skip_sealing_path(record: &SessionAuditRecord, path: &Path) -> bool {
+    path == record.record_dir
+        || path == record.metadata_path
+        || record
+            .metadata_path
+            .parent()
+            .is_some_and(|metadata_dir| path == metadata_dir)
+}
+
+fn seal_with_podman_unshare(record: &SessionAuditRecord) -> Result<(), RunnerError> {
+    let record_root = record.record_dir.display().to_string();
+    let metadata_dir = record
+        .metadata_path
+        .parent()
+        .expect("metadata path should have a parent directory")
+        .display()
+        .to_string();
+    let metadata_path = record.metadata_path.display().to_string();
+
     run_podman_command(vec![
         "unshare".to_string(),
         "find".to_string(),
         "-P".to_string(),
-        path.display().to_string(),
+        record_root.clone(),
+        "-mindepth".to_string(),
+        "1".to_string(),
         "-type".to_string(),
         "d".to_string(),
+        "!".to_string(),
+        "-path".to_string(),
+        metadata_dir,
         "-exec".to_string(),
         "chmod".to_string(),
-        "0555".to_string(),
+        SEALED_DIRECTORY_MODE.to_string(),
         "{}".to_string(),
         "+".to_string(),
     ])?;
@@ -213,16 +271,19 @@ fn seal_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
         "unshare".to_string(),
         "find".to_string(),
         "-P".to_string(),
-        path.display().to_string(),
+        record_root,
         "!".to_string(),
         "-type".to_string(),
         "d".to_string(),
         "!".to_string(),
         "-type".to_string(),
         "l".to_string(),
+        "!".to_string(),
+        "-path".to_string(),
+        metadata_path,
         "-exec".to_string(),
         "chmod".to_string(),
-        "0444".to_string(),
+        SEALED_FILE_MODE.to_string(),
         "{}".to_string(),
         "+".to_string(),
     ])
@@ -255,7 +316,7 @@ fn validate_sealable_tree_with_podman_unshare(path: &Path) -> Result<(), RunnerE
     Ok(())
 }
 
-fn write_atomic(path: &Path, payload: &[u8]) -> Result<(), RunnerError> {
+fn write_atomic(path: &Path, payload: &[u8], file_mode: Option<u32>) -> Result<(), RunnerError> {
     let temp_path = path.with_extension("json.tmp");
     let parent = path.parent().ok_or_else(|| {
         RunnerError::Io(std::io::Error::other(
@@ -269,6 +330,9 @@ fn write_atomic(path: &Path, payload: &[u8]) -> Result<(), RunnerError> {
             .truncate(true)
             .open(&temp_path)?;
         temp_file.write_all(payload)?;
+        if let Some(file_mode) = file_mode {
+            temp_file.set_permissions(fs::Permissions::from_mode(file_mode))?;
+        }
         temp_file.sync_all()?;
         drop(temp_file);
         fs::rename(&temp_path, path)?;

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -3,7 +3,7 @@ use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
@@ -87,6 +87,13 @@ pub(crate) fn finalize_session_audit_record(
     record: &SessionAuditRecord,
     completion: SessionAuditCompletion<'_>,
 ) -> Result<(), RunnerError> {
+    match preflight_validate_sealable_tree(&record.record_dir) {
+        Ok(()) => {}
+        Err(RunnerError::Io(error)) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            validate_sealable_tree_with_podman_unshare(&record.record_dir)?;
+        }
+        Err(error) => return Err(error),
+    }
     let (outcome, exit_code) = match completion {
         SessionAuditCompletion::Outcome(outcome) => (Some(outcome.label()), outcome.exit_code()),
         SessionAuditCompletion::Error => (Some("error"), None),
@@ -140,6 +147,30 @@ fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerEr
         }
         Err(error) => Err(error),
     }
+}
+
+fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            preflight_validate_sealable_tree(&entry.path())?;
+        }
+        return Ok(());
+    }
+
+    if metadata.nlink() > 1 {
+        return Err(RunnerError::Io(std::io::Error::other(format!(
+            "refusing to seal multi-linked audit entry {}",
+            path.display()
+        ))));
+    }
+
+    Ok(())
 }
 
 fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
@@ -196,6 +227,32 @@ fn seal_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
         "+".to_string(),
     ])
     .map(|_| ())
+}
+
+fn validate_sealable_tree_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
+    let output = run_podman_command(vec![
+        "unshare".to_string(),
+        "find".to_string(),
+        "-P".to_string(),
+        path.display().to_string(),
+        "!".to_string(),
+        "-type".to_string(),
+        "d".to_string(),
+        "!".to_string(),
+        "-type".to_string(),
+        "l".to_string(),
+        "-links".to_string(),
+        "+1".to_string(),
+        "-print".to_string(),
+    ])?;
+
+    if let Some(first_path) = output.lines().find(|line| !line.trim().is_empty()) {
+        return Err(RunnerError::Io(std::io::Error::other(format!(
+            "refusing to seal multi-linked audit entry {first_path}"
+        ))));
+    }
+
+    Ok(())
 }
 
 fn write_atomic(path: &Path, payload: &[u8]) -> Result<(), RunnerError> {
@@ -389,6 +446,63 @@ mod tests {
 
         make_tree_writable(&root);
         fs::remove_file(&outside_target).expect("outside target should be removed");
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_audit_record_refuses_hard_linked_entries_before_metadata_rewrite() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_test_dir("agentd-audit-hard-link");
+        let outside_target = root.join("outside-target.txt");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "9999000011112222",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+
+        fs::write(&outside_target, "outside\n").expect("outside target should be writable");
+        fs::set_permissions(&outside_target, fs::Permissions::from_mode(0o666))
+            .expect("outside target mode should be writable");
+        fs::hard_link(&outside_target, record.runa_dir.join("escaped-hard-link"))
+            .expect("hard link should be created");
+
+        let error = super::finalize_session_audit_record(
+            &record,
+            SessionAuditCompletion::Outcome(&SessionOutcome::Success { exit_code: 0 }),
+        )
+        .expect_err("hard-linked audit entries should be rejected before sealing");
+        assert!(
+            matches!(error, crate::RunnerError::Io(_)),
+            "expected io error for unsafe hard-linked entry, got {error:?}"
+        );
+
+        let payload = fs::read_to_string(&record.metadata_path)
+            .expect("initial session metadata should remain readable");
+        let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
+        assert!(
+            json.get("end_timestamp").is_none(),
+            "hard-link refusal must leave end_timestamp incomplete"
+        );
+        assert!(
+            json.get("outcome").is_none(),
+            "hard-link refusal must leave outcome incomplete"
+        );
+
+        let outside_mode = fs::metadata(&outside_target)
+            .expect("outside target metadata should exist")
+            .permissions()
+            .mode();
+        assert_eq!(outside_mode & 0o777, 0o666);
+
+        make_tree_writable(&root);
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
 

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -255,6 +255,10 @@ fn should_skip_sealing_path(record: &SessionAuditRecord, path: &Path) -> bool {
             .is_some_and(|metadata_dir| path == metadata_dir)
 }
 
+fn chmod_mode_arg(mode: u32) -> String {
+    format!("{mode:o}")
+}
+
 fn seal_with_podman_unshare(record: &SessionAuditRecord) -> Result<(), RunnerError> {
     let record_root = record.record_dir.display().to_string();
     let metadata_dir = record
@@ -279,7 +283,7 @@ fn seal_with_podman_unshare(record: &SessionAuditRecord) -> Result<(), RunnerErr
         metadata_dir,
         "-exec".to_string(),
         "chmod".to_string(),
-        SEALED_DIRECTORY_MODE.to_string(),
+        chmod_mode_arg(SEALED_DIRECTORY_MODE),
         "{}".to_string(),
         "+".to_string(),
     ])?;
@@ -299,7 +303,7 @@ fn seal_with_podman_unshare(record: &SessionAuditRecord) -> Result<(), RunnerErr
         metadata_path,
         "-exec".to_string(),
         "chmod".to_string(),
-        SEALED_FILE_MODE.to_string(),
+        chmod_mode_arg(SEALED_FILE_MODE),
         "{}".to_string(),
         "+".to_string(),
     ])

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -3,6 +3,7 @@ use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
@@ -127,21 +128,8 @@ fn current_timestamp() -> Result<String, RunnerError> {
 }
 
 fn set_active_runa_permissions(path: &Path) -> Result<(), RunnerError> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        fs::set_permissions(path, fs::Permissions::from_mode(0o777))?;
-        Ok(())
-    }
-
-    #[cfg(not(unix))]
-    {
-        let mut permissions = fs::metadata(path)?.permissions();
-        permissions.set_readonly(false);
-        fs::set_permissions(path, permissions)?;
-        Ok(())
-    }
+    fs::set_permissions(path, fs::Permissions::from_mode(0o777))?;
+    Ok(())
 }
 
 fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerError> {
@@ -171,22 +159,9 @@ fn seal_path_recursive(path: &Path) -> Result<(), RunnerError> {
 }
 
 fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let sealed_mode = if is_dir { 0o555 } else { 0o444 };
-        fs::set_permissions(path, fs::Permissions::from_mode(sealed_mode))?;
-        Ok(())
-    }
-
-    #[cfg(not(unix))]
-    {
-        let mut sealed = permissions;
-        sealed.set_readonly(true);
-        fs::set_permissions(path, sealed)?;
-        Ok(())
-    }
+    let sealed_mode = if is_dir { 0o555 } else { 0o444 };
+    fs::set_permissions(path, fs::Permissions::from_mode(sealed_mode))?;
+    Ok(())
 }
 
 fn seal_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
@@ -252,11 +227,7 @@ fn write_atomic(path: &Path, payload: &[u8]) -> Result<(), RunnerError> {
 }
 
 fn sync_parent_dir(path: &Path) -> Result<(), RunnerError> {
-    #[cfg(unix)]
-    {
-        File::open(path)?.sync_all()?;
-    }
-
+    File::open(path)?.sync_all()?;
     Ok(())
 }
 
@@ -267,6 +238,7 @@ mod tests {
     use crate::{SessionInvocation, SessionOutcome};
     use serde_json::Value;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
 
     fn unique_test_dir(prefix: &str) -> PathBuf {
@@ -280,10 +252,7 @@ mod tests {
         ))
     }
 
-    #[cfg(unix)]
     fn make_tree_writable(path: &Path) {
-        use std::os::unix::fs::PermissionsExt;
-
         let metadata = fs::symlink_metadata(path).expect("path metadata should exist");
         if metadata.file_type().is_symlink() {
             return;
@@ -365,30 +334,23 @@ mod tests {
         assert_eq!(json["exit_code"], 5);
         assert!(json["end_timestamp"].is_string());
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
+        let runa_mode = fs::metadata(&record.runa_dir)
+            .expect("runa dir metadata should exist")
+            .permissions()
+            .mode();
+        let metadata_mode = fs::metadata(&record.metadata_path)
+            .expect("metadata file should exist")
+            .permissions()
+            .mode();
+        assert_eq!(runa_mode & 0o777, 0o555);
+        assert_eq!(metadata_mode & 0o777, 0o444);
 
-            let runa_mode = fs::metadata(&record.runa_dir)
-                .expect("runa dir metadata should exist")
-                .permissions()
-                .mode();
-            let metadata_mode = fs::metadata(&record.metadata_path)
-                .expect("metadata file should exist")
-                .permissions()
-                .mode();
-            assert_eq!(runa_mode & 0o777, 0o555);
-            assert_eq!(metadata_mode & 0o777, 0o444);
-        }
-
-        #[cfg(unix)]
         make_tree_writable(&root);
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
 
     #[test]
-    #[cfg(unix)]
     fn finalize_session_audit_record_skips_symlinks_when_sealing() {
         use std::os::unix::fs::{PermissionsExt, symlink};
 
@@ -461,7 +423,6 @@ mod tests {
             "temporary metadata file should not remain after atomic replace"
         );
 
-        #[cfg(unix)]
         make_tree_writable(&root);
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -67,22 +67,25 @@ fn prepare_session_audit_record_at(
 
     fs::create_dir_all(&runa_dir)?;
     fs::create_dir_all(&agentd_dir)?;
-    set_active_runa_permissions(&runa_dir)?;
 
-    let start_timestamp = current_timestamp()?;
-    let record = SessionAuditRecord {
-        record_dir,
-        runa_dir,
-        metadata_path,
-        session_id: session_id.to_string(),
-        profile: spec.profile_name.clone(),
-        repo_url: invocation.repo_url.clone(),
-        work_unit: invocation.work_unit.clone(),
-        start_timestamp,
-    };
+    rollback_record_dir_on_error(&record_dir, || {
+        set_active_runa_permissions(&runa_dir)?;
 
-    write_session_audit_metadata(&record, None, None, None)?;
-    Ok(record)
+        let start_timestamp = current_timestamp()?;
+        let record = SessionAuditRecord {
+            record_dir: record_dir.clone(),
+            runa_dir: runa_dir.clone(),
+            metadata_path: metadata_path.clone(),
+            session_id: session_id.to_string(),
+            profile: spec.profile_name.clone(),
+            repo_url: invocation.repo_url.clone(),
+            work_unit: invocation.work_unit.clone(),
+            start_timestamp,
+        };
+
+        write_session_audit_metadata(&record, None, None, None)?;
+        Ok(record)
+    })
 }
 
 pub(crate) fn finalize_session_audit_record(
@@ -159,6 +162,19 @@ fn current_timestamp() -> Result<String, RunnerError> {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .map_err(|error| RunnerError::Io(std::io::Error::other(error)))
+}
+
+fn rollback_record_dir_on_error<T, F>(record_dir: &Path, init: F) -> Result<T, RunnerError>
+where
+    F: FnOnce() -> Result<T, RunnerError>,
+{
+    match init() {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            let _ = fs::remove_dir_all(record_dir);
+            Err(error)
+        }
+    }
 }
 
 fn set_active_runa_permissions(path: &Path) -> Result<(), RunnerError> {
@@ -354,9 +370,12 @@ fn sync_parent_dir(path: &Path) -> Result<(), RunnerError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionAuditCompletion, current_timestamp, prepare_session_audit_record_at};
+    use super::{
+        SessionAuditCompletion, current_timestamp, prepare_session_audit_record_at,
+        rollback_record_dir_on_error,
+    };
     use crate::test_support::test_session_spec;
-    use crate::{SessionInvocation, SessionOutcome};
+    use crate::{RunnerError, SessionInvocation, SessionOutcome};
     use serde_json::Value;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
@@ -421,6 +440,119 @@ mod tests {
         assert!(json.get("exit_code").is_none());
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn rollback_record_dir_on_error_returns_value_without_removing_record_dir_when_init_succeeds() {
+        let root = unique_test_dir("agentd-audit-rollback-ok");
+        let record_dir = root.join("record");
+        fs::create_dir_all(&record_dir).expect("record dir should be created");
+
+        let value = rollback_record_dir_on_error(&record_dir, || Ok::<_, RunnerError>(42))
+            .expect("rollback wrapper should return success values");
+
+        assert_eq!(value, 42);
+        assert!(
+            record_dir.exists(),
+            "successful initialization should keep the record dir"
+        );
+
+        fs::remove_dir_all(&root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn rollback_record_dir_on_error_removes_record_dir_and_returns_original_error() {
+        let root = unique_test_dir("agentd-audit-rollback-error");
+        let record_dir = root.join("record");
+        fs::create_dir_all(&record_dir).expect("record dir should be created");
+        fs::write(record_dir.join("partial"), "stale\n").expect("partial state should be created");
+
+        let error = rollback_record_dir_on_error(&record_dir, || {
+            Err::<(), _>(RunnerError::Io(std::io::Error::other(
+                "initial metadata write failed",
+            )))
+        })
+        .expect_err("rollback wrapper should return the original initialization error");
+
+        match error {
+            RunnerError::Io(error) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::Other);
+                assert_eq!(error.to_string(), "initial metadata write failed");
+            }
+            other => panic!("expected original io error, got {other:?}"),
+        }
+        assert!(
+            !record_dir.exists(),
+            "failed initialization should remove the record dir"
+        );
+
+        fs::remove_dir_all(&root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn rollback_record_dir_on_error_ignores_cleanup_failure_and_returns_original_error() {
+        let root = unique_test_dir("agentd-audit-rollback-best-effort");
+        let record_dir = root.join("record");
+        fs::create_dir_all(&record_dir).expect("record dir should be created");
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o555))
+            .expect("record dir parent should become read-only");
+
+        let error = rollback_record_dir_on_error(&record_dir, || {
+            Err::<(), _>(RunnerError::Io(std::io::Error::other(
+                "initial metadata write failed",
+            )))
+        })
+        .expect_err("rollback wrapper should return the original initialization error");
+
+        match error {
+            RunnerError::Io(error) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::Other);
+                assert_eq!(error.to_string(), "initial metadata write failed");
+            }
+            other => panic!("expected original io error, got {other:?}"),
+        }
+        assert!(
+            record_dir.exists(),
+            "best-effort rollback should not replace the original error when cleanup fails"
+        );
+
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o755))
+            .expect("record dir parent should become writable for cleanup");
+        fs::remove_dir_all(&root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn prepare_session_audit_record_removes_record_dir_when_initial_metadata_write_fails() {
+        let root = unique_test_dir("agentd-audit-initial-write-failure");
+        let record_dir = root.join("site-builder").join("write-failure");
+        fs::create_dir_all(record_dir.join("agentd/session.json"))
+            .expect("conflicting metadata path directory should be created");
+
+        let error = prepare_session_audit_record_at(
+            &root,
+            "write-failure",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                timeout: None,
+            },
+        )
+        .expect_err("initial metadata write should fail when session.json is a directory");
+
+        assert!(
+            matches!(error, RunnerError::Io(_)),
+            "expected metadata write failure, got {error:?}"
+        );
+        assert!(
+            !record_dir.exists(),
+            "metadata write failure should remove the partially-created record dir"
+        );
+
+        if root.exists() {
+            fs::remove_dir_all(&root).expect("temporary audit root should be removed");
+        }
     }
 
     #[test]

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -11,7 +11,10 @@
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::podman::{run_podman_command, run_podman_command_until};
 use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
-use crate::session_paths::{session_home_dir, session_repo_dir};
+use crate::session_paths::{
+    session_home_dir, session_internal_audit_dir, session_internal_audit_runa_dir,
+    session_repo_dir, session_repo_runa_dir,
+};
 use crate::types::{BindMount, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
 use std::collections::VecDeque;
@@ -147,18 +150,27 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     let username = &spec.profile_name;
     let home_dir_path = session_home_dir(username);
     let home_dir = home_dir_path.display().to_string();
+    let internal_audit_dir_path = session_internal_audit_dir(username);
+    let internal_audit_dir = internal_audit_dir_path.display().to_string();
+    let internal_audit_runa_dir_path = session_internal_audit_runa_dir(username);
+    let internal_audit_runa_dir = internal_audit_runa_dir_path.display().to_string();
     let repo_dir_path = session_repo_dir(username);
     let repo_dir = repo_dir_path.display().to_string();
+    let repo_runa_dir = session_repo_runa_dir(username).display().to_string();
     let user_group = format!("{username}:{username}");
     let mut script = String::from("set -eu\nuseradd --create-home --home-dir ");
     script.push_str(&shell_quote(&home_dir));
     script.push_str(" --shell /bin/sh --user-group ");
     script.push_str(&shell_quote(username));
     script.push('\n');
+    script.push_str("mkdir -p ");
+    script.push_str(&shell_quote(&internal_audit_dir));
+    script.push('\n');
     script.push_str(&build_home_ownership_command(
         &home_dir_path,
         &repo_dir_path,
         &spec.mounts,
+        &internal_audit_runa_dir_path,
         &user_group,
     ));
     script.push_str("\nrm -rf ");
@@ -171,6 +183,19 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     script.push_str(&shell_quote(&user_group));
     script.push(' ');
     script.push_str(&shell_quote(&repo_dir));
+    script.push_str("\nif [ -e ");
+    script.push_str(&shell_quote(&repo_runa_dir));
+    script.push_str(" ] || [ -L ");
+    script.push_str(&shell_quote(&repo_runa_dir));
+    script.push_str(" ]; then\n");
+    script.push_str("echo ");
+    script.push_str(&shell_quote(
+        "repo root .runa is reserved by agentd for persistent audit state",
+    ));
+    script.push_str(" >&2\nexit 6\nfi\nln -s ");
+    script.push_str(&shell_quote(&internal_audit_runa_dir));
+    script.push(' ');
+    script.push_str(&shell_quote(&repo_runa_dir));
     script.push_str("\nexport HOME=");
     script.push_str(&shell_quote(&home_dir));
     if let Some(work_unit) = &invocation.work_unit {
@@ -191,12 +216,14 @@ fn build_home_ownership_command(
     home_dir: &Path,
     repo_dir: &Path,
     mounts: &[BindMount],
+    internal_audit_runa_dir: &Path,
     user_group: &str,
 ) -> String {
     let mut prune_targets = mounts
         .iter()
         .filter_map(|mount| home_descendant_mount_target(home_dir, &mount.target))
         .collect::<Vec<_>>();
+    prune_targets.push(internal_audit_runa_dir.display().to_string());
     prune_targets.push(repo_dir.display().to_string());
 
     let mut command = String::from("find ");
@@ -278,14 +305,26 @@ fn build_create_container_args(
         ),
     ];
 
+    args.push("--mount".to_string());
+    args.push(format!(
+        "type=bind,src={},target={},ro={},relabel=shared",
+        resources.audit_mount.source.display(),
+        resources.audit_mount.target.display(),
+        resources.audit_mount.read_only
+    ));
+
     for mount in &resources.additional_mounts {
         args.push("--mount".to_string());
-        args.push(format!(
+        let mut mount_value = format!(
             "type=bind,src={},target={},ro={}",
             mount.source.display(),
             mount.target.display(),
             mount.read_only
-        ));
+        );
+        if mount.relabel_shared {
+            mount_value.push_str(",relabel=shared");
+        }
+        args.push(mount_value);
     }
 
     let mut secret_bindings = resources.environment_secret_bindings.iter();

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -19,7 +19,6 @@ use crate::types::{BindMount, RunnerError, SessionInvocation, SessionOutcome, Se
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
 use std::collections::VecDeque;
 use std::io::{Read, Write};
-#[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -541,7 +540,6 @@ where
 }
 
 fn container_status_to_outcome(status: ExitStatus) -> SessionOutcome {
-    #[cfg(unix)]
     if let Some(signal) = status.signal() {
         return SessionOutcome::TerminatedBySignal {
             exit_code: 128 + signal,

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -413,7 +413,6 @@ fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
     assert!(script.contains("\nexec gosu 'myprofile:myprofile' 'site-builder' 'exec'"));
 }
 
-#[cfg(unix)]
 #[test]
 fn clone_command_passes_repo_token_to_git_via_environment_not_argv() {
     let root = unique_test_dir("agentd-runner-clone-auth");
@@ -461,7 +460,6 @@ fn clone_command_passes_repo_token_to_git_via_environment_not_argv() {
     assert!(!git_env.contains(&format!("{REPO_TOKEN_ENV}=test-token")));
 }
 
-#[cfg(unix)]
 #[test]
 fn clone_command_omits_git_auth_environment_when_repo_token_is_absent() {
     let root = unique_test_dir("agentd-runner-clone-public");
@@ -674,7 +672,6 @@ fn attached_start_classifies_signal_exit_as_signal_termination() {
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn attached_start_classifies_real_process_signals_as_signal_termination() {
     use std::os::unix::process::ExitStatusExt;
@@ -1452,7 +1449,6 @@ fn unique_test_dir(prefix: &str) -> PathBuf {
     ))
 }
 
-#[cfg(unix)]
 fn install_fake_git(bin_dir: &Path, log_dir: &Path) {
     let script_path = bin_dir.join("git");
     fs::write(

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::audit::SessionAuditRecord;
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::resources::{PreparedBindMount, SessionResources};
 use crate::test_support::{
@@ -14,6 +15,21 @@ use std::time::{Duration, Instant, SystemTime};
 
 const VALID_REMOTE_REPO_URL: &str = "https://example.com/agentd.git";
 
+fn test_audit_record() -> SessionAuditRecord {
+    SessionAuditRecord {
+        record_dir: PathBuf::from("/tmp/audit/site-builder/0123456789abcdef"),
+        runa_dir: PathBuf::from("/tmp/audit/site-builder/0123456789abcdef/runa"),
+        metadata_path: PathBuf::from(
+            "/tmp/audit/site-builder/0123456789abcdef/agentd/session.json",
+        ),
+        session_id: "0123456789abcdef".to_string(),
+        profile: "site-builder".to_string(),
+        repo_url: VALID_REMOTE_REPO_URL.to_string(),
+        work_unit: None,
+        start_timestamp: "2026-04-16T00:00:00Z".to_string(),
+    }
+}
+
 #[test]
 fn create_container_args_include_shared_relabel_for_methodology_mount() {
     let args = build_create_container_args(
@@ -21,6 +37,13 @@ fn create_container_args_include_shared_relabel_for_methodology_mount() {
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            audit_record: test_audit_record(),
+            audit_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/audit-runa"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
@@ -50,6 +73,13 @@ fn create_container_args_force_root_user_and_entrypoint_before_image_argument() 
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            audit_record: test_audit_record(),
+            audit_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/audit-runa"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
@@ -98,6 +128,13 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            audit_record: test_audit_record(),
+            audit_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/audit-runa"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
@@ -125,16 +162,25 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
             container_name: "agentd-agent-session".to_string(),
             methodology_staging_dir: PathBuf::from("/tmp/staging"),
             methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            audit_record: test_audit_record(),
+            audit_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/audit-runa"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
             additional_mounts: vec![
                 PreparedBindMount {
                     source: PathBuf::from("/tmp/staging/mount-0"),
                     target: PathBuf::from("/home/site-builder/.claude"),
                     read_only: true,
+                    relabel_shared: false,
                 },
                 PreparedBindMount {
                     source: PathBuf::from("/tmp/staging/mount-1"),
                     target: PathBuf::from("/home/site-builder/.runa"),
                     read_only: false,
+                    relabel_shared: false,
                 },
             ],
             environment_secret_bindings: Vec::new(),
@@ -150,23 +196,27 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
     );
 
     let mount_values = argument_values(&args, "--mount");
-    assert_eq!(mount_values.len(), 3);
+    assert_eq!(mount_values.len(), 4);
     assert!(mount_values[0].contains("src=/tmp/staging/methodology"));
-    assert!(mount_values[1].contains("src=/tmp/staging/mount-0"));
-    assert!(mount_values[1].contains("target=/home/site-builder/.claude"));
-    assert!(mount_values[1].contains("ro=true"));
-    assert!(
-        !mount_values[1].contains("relabel="),
-        "operator-declared mounts should not mutate host SELinux labels: {}",
-        mount_values[1]
-    );
-    assert!(mount_values[2].contains("src=/tmp/staging/mount-1"));
-    assert!(mount_values[2].contains("target=/home/site-builder/.runa"));
-    assert!(mount_values[2].contains("ro=false"));
+    assert!(mount_values[1].contains("src=/tmp/staging/audit-runa"));
+    assert!(mount_values[1].contains("target=/home/site-builder/.agentd/audit/runa"));
+    assert!(mount_values[1].contains("ro=false"));
+    assert!(mount_values[1].contains("relabel=shared"));
+    assert!(mount_values[2].contains("src=/tmp/staging/mount-0"));
+    assert!(mount_values[2].contains("target=/home/site-builder/.claude"));
+    assert!(mount_values[2].contains("ro=true"));
     assert!(
         !mount_values[2].contains("relabel="),
         "operator-declared mounts should not mutate host SELinux labels: {}",
         mount_values[2]
+    );
+    assert!(mount_values[3].contains("src=/tmp/staging/mount-1"));
+    assert!(mount_values[3].contains("target=/home/site-builder/.runa"));
+    assert!(mount_values[3].contains("ro=false"));
+    assert!(
+        !mount_values[3].contains("relabel="),
+        "operator-declared mounts should not mutate host SELinux labels: {}",
+        mount_values[3]
     );
 }
 
@@ -217,14 +267,26 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
     );
 
     assert!(script.contains("useradd --create-home --home-dir '/home/myprofile' --shell /bin/sh --user-group 'myprofile'"));
+    assert!(script.contains("\nmkdir -p '/home/myprofile/.agentd/audit'\n"));
     assert!(script.contains(
-        "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
+        "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/.agentd/audit/runa' -o -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
     ));
     assert!(script.contains(
         "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/myprofile/repo'"
     ));
     assert!(script.contains("\ncd '/home/myprofile/repo'\n"));
     assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile/repo'\n"));
+    assert!(
+        script.contains(
+            "if [ -e '/home/myprofile/repo/.runa' ] || [ -L '/home/myprofile/repo/.runa' ]; then"
+        ),
+        "{script}"
+    );
+    assert!(
+        script.contains(
+            "\nln -s '/home/myprofile/.agentd/audit/runa' '/home/myprofile/repo/.runa'\n"
+        )
+    );
     assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(!script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
     assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
@@ -279,7 +341,7 @@ fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_t
 
     assert!(
         script.contains(
-            "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/.claude' -o -path '/home/myprofile/.config/claude workspace' -o -path '/home/myprofile/.config/git (session)' -o -path '/home/myprofile/a/b/c' -o -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
+            "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/.claude' -o -path '/home/myprofile/.config/claude workspace' -o -path '/home/myprofile/.config/git (session)' -o -path '/home/myprofile/a/b/c' -o -path '/home/myprofile/.agentd/audit/runa' -o -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
         ),
         "home ownership should be repaired with one find traversal that prunes mounts and the repo: {script}"
     );
@@ -1061,7 +1123,7 @@ fn wait_for_container_exit_returns_timeout_when_secret_release_fails() {
     );
 
     let mut child = Command::new("sh")
-        .args(["-c", "sleep 0.3"])
+        .args(["-c", "sleep 1"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -1078,14 +1140,14 @@ fn wait_for_container_exit_returns_timeout_when_secret_release_fails() {
                     secret_name: "secret".to_string(),
                     target_name: "GITHUB_TOKEN".to_string(),
                 }],
-                Some(Duration::from_millis(50)),
+                Some(Duration::from_millis(500)),
             )
         })
         .expect("secret release failure should not surface as a runner error");
     let elapsed = started_at.elapsed();
 
     assert_eq!(outcome, None);
-    assert!(elapsed < Duration::from_millis(250));
+    assert!(elapsed < Duration::from_millis(900));
     assert_eq!(
         fixture
             .secret_commands()

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -44,8 +44,8 @@ use lifecycle::{
 };
 use naming::format_container_name;
 use resources::{
-    SessionResources, cleanup_methodology_staging_dir, cleanup_podman_secrets,
-    prepare_session_resources, unique_suffix,
+    ResourceAllocationFailure, SessionResources, cleanup_methodology_staging_dir,
+    cleanup_podman_secrets, prepare_session_resources, unique_suffix,
 };
 use validation::{validate_invocation, validate_spec};
 
@@ -107,9 +107,15 @@ pub fn run_session(
         audit_record.clone(),
     ) {
         Ok(resources) => resources,
-        Err(error) => {
-            let audit_result =
-                finalize_session_audit_record(&audit_record, SessionAuditCompletion::Error);
+        Err(ResourceAllocationFailure {
+            allocation_error,
+            rollback_result,
+        }) => {
+            let audit_result = finalize_session_audit_record_if_cleanup_succeeded(
+                &rollback_result,
+                &audit_record,
+                SessionAuditCompletion::Error,
+            );
             if let Err(audit_error) = &audit_result {
                 log_lifecycle_failure(
                     LifecycleFailureKind::Cleanup,
@@ -123,14 +129,14 @@ pub fn run_session(
                 &session_id,
                 &container_name,
                 "session_resource_allocation",
-                &error,
+                &allocation_error,
             );
             log_session_teardown(
                 &session_id,
                 &container_name,
-                audit_result.as_ref().map(|_| ()),
+                combined_teardown_result(&rollback_result, &audit_result),
             );
-            return Err(error);
+            return Err(allocation_error);
         }
     };
 
@@ -168,9 +174,7 @@ pub fn run_session(
         log_session_teardown(
             &session_id,
             &resources.container_name,
-            combined_teardown_result(cleanup_result, audit_result)
-                .as_ref()
-                .map(|_| ()),
+            combined_teardown_result(&cleanup_result, &audit_result),
         );
         return Err(error);
     }
@@ -207,6 +211,15 @@ pub fn run_session(
             Err(_) => SessionAuditCompletion::Error,
         },
     );
+    if let Err(cleanup_error) = &cleanup_result {
+        log_lifecycle_failure(
+            LifecycleFailureKind::Cleanup,
+            "session execution",
+            &resources.container_name,
+            &session_id,
+            cleanup_error,
+        );
+    }
     if let Err(audit_error) = &audit_result {
         log_lifecycle_failure(
             LifecycleFailureKind::Cleanup,
@@ -216,27 +229,13 @@ pub fn run_session(
             audit_error,
         );
     }
-    let teardown_result = combined_teardown_result(cleanup_result, audit_result);
-    log_session_teardown(
-        &session_id,
-        &resources.container_name,
-        teardown_result.as_ref().map(|_| ()),
-    );
+    let teardown_result = combined_teardown_result(&cleanup_result, &audit_result);
+    log_session_teardown(&session_id, &resources.container_name, teardown_result);
 
-    match (start_result, teardown_result) {
+    match (start_result, cleanup_result) {
         (Ok(outcome), Ok(())) => Ok(outcome),
-        (Err(error), Ok(())) => Err(error),
-        (Ok(_), Err(error)) => Err(error),
-        (Err(error), Err(cleanup_error)) => {
-            log_lifecycle_failure(
-                LifecycleFailureKind::Cleanup,
-                "session execution",
-                &resources.container_name,
-                &session_id,
-                &cleanup_error,
-            );
-            Err(error)
-        }
+        (Ok(_), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(error), _) => Err(error),
     }
 }
 
@@ -263,10 +262,10 @@ fn finalize_session_audit_record_if_cleanup_succeeded(
     finalize_session_audit_record(record, completion)
 }
 
-fn combined_teardown_result(
-    cleanup_result: Result<(), RunnerError>,
-    audit_result: Result<(), RunnerError>,
-) -> Result<(), RunnerError> {
+fn combined_teardown_result<'a>(
+    cleanup_result: &'a Result<(), RunnerError>,
+    audit_result: &'a Result<(), RunnerError>,
+) -> Result<(), &'a RunnerError> {
     match (cleanup_result, audit_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
@@ -285,6 +284,8 @@ mod tests {
     use serde_json::Value;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     fn only_session_record_dir(audit_root: &Path, profile_name: &str) -> PathBuf {
         let profile_root = audit_root.join(profile_name);
@@ -393,7 +394,8 @@ mod tests {
     }
 
     #[test]
-    fn run_session_marks_teardown_skipped_when_allocation_rollback_logs_failure() {
+    fn run_session_leaves_audit_record_incomplete_and_reports_teardown_error_when_allocation_rollback_fails()
+     {
         let _guard = fake_podman_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -417,6 +419,8 @@ mod tests {
                 )),
         );
         let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let audit_root = unique_temp_dir("runner-audit-allocation-rollback-failure");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
 
         let events = capture_tracing_events(|| {
             let error = fixture
@@ -424,6 +428,7 @@ mod tests {
                     run_session(
                         SessionSpec {
                             methodology_dir,
+                            audit_root: audit_root.clone(),
                             environment: vec![
                                 ResolvedEnvironmentVariable {
                                     name: "GITHUB_TOKEN".to_string(),
@@ -459,7 +464,32 @@ mod tests {
         assert_eq!(events[2]["fields"]["event"], "runner.session_error");
         assert_eq!(events[2]["fields"]["stage"], "session_resource_allocation");
         assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
-        assert_eq!(events[3]["fields"]["result"], "ok");
+        assert_eq!(events[3]["fields"]["result"], "error");
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert!(
+            metadata.get("end_timestamp").is_none(),
+            "allocation rollback failure must not finalize end_timestamp"
+        );
+        assert!(
+            metadata.get("outcome").is_none(),
+            "allocation rollback failure must not finalize outcome"
+        );
+
+        use std::os::unix::fs::PermissionsExt;
+
+        let runa_mode = fs::metadata(record_dir.join("runa"))
+            .expect("runa dir metadata should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            runa_mode, 0o777,
+            "allocation rollback failure must leave the top-level runa dir in its active writable mode"
+        );
+
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
     #[test]
@@ -635,6 +665,137 @@ mod tests {
         );
 
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn run_session_preserves_session_outcome_when_audit_finalization_fails_after_successful_cleanup()
+     {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        fixture.install(
+            &FakePodmanScenario::new().with_start(CommandBehavior::from_outcome(
+                CommandOutcome::new()
+                    .touch_file("start-blocked")
+                    .wait_for_file(
+                        "release-start",
+                        Duration::from_secs(5),
+                        "timed out waiting to release start",
+                        91,
+                    ),
+            )),
+        );
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let audit_root = unique_temp_dir("runner-audit-finalization-failure");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+        let helper_audit_root = audit_root.clone();
+
+        let events = fixture.run_with_fake_podman_env(|| {
+            let log_dir = PathBuf::from(
+                std::env::var("AGENTD_FAKE_PODMAN_LOG_DIR")
+                    .expect("fake podman log dir should be configured"),
+            );
+            let helper = thread::spawn(move || {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                while Instant::now() < deadline && !log_dir.join("start-blocked").exists() {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                assert!(
+                    log_dir.join("start-blocked").exists(),
+                    "fake podman start should block before audit finalization"
+                );
+
+                let record_dir =
+                    wait_for_only_session_record_dir(&helper_audit_root, "site-builder", deadline);
+                let agentd_dir = record_dir.join("agentd");
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&agentd_dir, fs::Permissions::from_mode(0o555))
+                    .expect("agentd dir should become read-only");
+                fs::write(log_dir.join("release-start"), b"release\n")
+                    .expect("start should be released");
+            });
+
+            let events = capture_tracing_events(|| {
+                let outcome = run_session(
+                    SessionSpec {
+                        methodology_dir,
+                        audit_root: audit_root.clone(),
+                        ..test_session_spec()
+                    },
+                    SessionInvocation {
+                        repo_url: "https://example.com/agentd.git".to_string(),
+                        repo_token: None,
+                        work_unit: None,
+                        timeout: None,
+                    },
+                )
+                .expect("session outcome should survive audit finalization failure");
+
+                assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+            });
+
+            helper
+                .join()
+                .expect("audit-finalization helper thread should complete");
+            events
+        });
+
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0]["fields"]["event"], "runner.session_started");
+        assert_eq!(events[1]["fields"]["event"], "runner.session_outcome");
+        assert_eq!(events[1]["fields"]["outcome"], "success");
+        assert_eq!(events[2]["fields"]["event"], "runner.lifecycle_failure");
+        assert_eq!(events[2]["fields"]["stage"], "session audit finalization");
+        assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
+        assert_eq!(events[3]["fields"]["result"], "error");
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert!(
+            metadata.get("end_timestamp").is_none(),
+            "audit finalization failure must leave end_timestamp incomplete"
+        );
+        assert!(
+            metadata.get("outcome").is_none(),
+            "audit finalization failure must leave outcome incomplete"
+        );
+
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(record_dir.join("agentd"), fs::Permissions::from_mode(0o755))
+            .expect("agentd dir should become removable for test cleanup");
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+    }
+
+    fn wait_for_only_session_record_dir(
+        audit_root: &Path,
+        profile_name: &str,
+        deadline: Instant,
+    ) -> PathBuf {
+        loop {
+            let profile_root = audit_root.join(profile_name);
+            if let Ok(entries) = fs::read_dir(&profile_root) {
+                let entries = entries
+                    .map(|entry| {
+                        entry
+                            .expect("session record entry should be readable")
+                            .path()
+                    })
+                    .filter(|path| path.is_dir())
+                    .collect::<Vec<_>>();
+                if entries.len() == 1 {
+                    return entries[0].clone();
+                }
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for session record under {}",
+                profile_root.display()
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
     }
 
     #[test]

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -787,9 +787,11 @@ mod tests {
                         ),
                 ))
                 .with_unshare(CommandBehavior::sequence(vec![
-                    CommandOutcome::new(),
-                    CommandOutcome::new(),
                     CommandOutcome::new()
+                        .append_args_with_prefix("unshare-commands.log", "validate"),
+                    CommandOutcome::new().append_args_with_prefix("unshare-commands.log", "dir"),
+                    CommandOutcome::new()
+                        .append_args_with_prefix("unshare-commands.log", "file")
                         .stderr("podman unshare file chmod failed")
                         .exit_code(61),
                 ])),
@@ -864,6 +866,18 @@ mod tests {
 
         let record_dir = only_session_record_dir(&audit_root, "site-builder");
         let metadata = read_session_metadata(&record_dir);
+        assert_eq!(
+            fixture.read_log("unshare-commands.log"),
+            format!(
+                "validate find -P {root} ! -type d ! -type l -links +1 -print\n\
+dir find -P {root} -mindepth 1 -type d ! -path {metadata_dir} -exec chmod 555 {{}} +\n\
+file find -P {root} ! -type d ! -type l ! -path {metadata_path} -exec chmod 444 {{}} +\n",
+                root = record_dir.display(),
+                metadata_dir = record_dir.join("agentd").display(),
+                metadata_path = record_dir.join("agentd/session.json").display(),
+            ),
+            "podman unshare fallback must invoke chmod with octal mode arguments"
+        );
         assert!(
             metadata.get("end_timestamp").is_none(),
             "audit finalization failure must leave end_timestamp incomplete"

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -351,6 +351,61 @@ mod tests {
     }
 
     #[test]
+    fn run_session_emits_a_durability_warning_without_reporting_audit_finalization_failure() {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        fixture.install(&FakePodmanScenario::new());
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let audit_root = unique_temp_dir("runner-audit-post-rename-sync-warning");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+
+        let events = capture_tracing_events(|| {
+            let outcome = audit::with_sync_parent_dir_failure_on_call_for_tests(2, || {
+                fixture.run_with_fake_podman(SessionSpec {
+                    audit_root: audit_root.clone(),
+                    methodology_dir,
+                    ..test_session_spec()
+                })
+            });
+
+            assert_eq!(
+                outcome.expect("session should succeed despite durability warning"),
+                SessionOutcome::Success { exit_code: 0 }
+            );
+        });
+
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0]["fields"]["event"], "runner.session_started");
+        assert_eq!(events[1]["fields"]["event"], "runner.session_outcome");
+        assert_eq!(events[1]["fields"]["outcome"], "success");
+        assert_eq!(events[2]["fields"]["event"], "runner.audit_warning");
+        assert_eq!(
+            events[2]["fields"]["warning_kind"],
+            "post_rename_parent_sync"
+        );
+        assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
+        assert_eq!(events[3]["fields"]["result"], "ok");
+        assert!(
+            events
+                .iter()
+                .all(|event| event["fields"]["event"] != "runner.lifecycle_failure"),
+            "post-rename parent sync failures must not be reported as lifecycle failures"
+        );
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert!(
+            metadata["end_timestamp"].is_string(),
+            "durability warnings must still leave finalized metadata on disk"
+        );
+        assert_eq!(metadata["outcome"], "success");
+
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
     fn run_session_emits_teardown_after_resource_allocation_failure() {
         let _guard = fake_podman_lock()
             .lock()

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -11,6 +11,7 @@
 //! See `ARCHITECTURE.md` section "Session Lifecycle" for the design-level
 //! treatment of these phases.
 
+mod audit;
 mod container;
 mod lifecycle;
 mod naming;
@@ -35,6 +36,7 @@ pub use validation::{
     validate_profile_name, validate_repo_url,
 };
 
+use audit::{SessionAuditCompletion, finalize_session_audit_record, prepare_session_audit_record};
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
 use lifecycle::{
     LifecycleFailureKind, log_lifecycle_failure, log_session_error, log_session_outcome,
@@ -77,29 +79,65 @@ pub fn run_session(
         invocation.timeout,
     );
 
-    let resources =
-        match prepare_session_resources(&container_name, &spec, &invocation, &session_id) {
-            Ok(resources) => resources,
-            Err(error) => {
-                log_session_error(
-                    &session_id,
+    let audit_record = match prepare_session_audit_record(&session_id, &spec, &invocation) {
+        Ok(record) => record,
+        Err(error) => {
+            log_session_error(
+                &session_id,
+                &container_name,
+                "session_audit_allocation",
+                &error,
+            );
+            tracing::info!(
+                event = "runner.session_teardown",
+                session_id = session_id,
+                container_name = container_name,
+                result = "skipped",
+                "runner session teardown skipped"
+            );
+            return Err(error);
+        }
+    };
+
+    let resources = match prepare_session_resources(
+        &container_name,
+        &spec,
+        &invocation,
+        &session_id,
+        audit_record.clone(),
+    ) {
+        Ok(resources) => resources,
+        Err(error) => {
+            let audit_result =
+                finalize_session_audit_record(&audit_record, SessionAuditCompletion::Error);
+            if let Err(audit_error) = &audit_result {
+                log_lifecycle_failure(
+                    LifecycleFailureKind::Cleanup,
+                    "session audit finalization",
                     &container_name,
-                    "session_resource_allocation",
-                    &error,
+                    &session_id,
+                    audit_error,
                 );
-                tracing::info!(
-                    event = "runner.session_teardown",
-                    session_id = session_id,
-                    container_name = container_name,
-                    result = "skipped",
-                    "runner session teardown skipped"
-                );
-                return Err(error);
             }
-        };
+            log_session_error(
+                &session_id,
+                &container_name,
+                "session_resource_allocation",
+                &error,
+            );
+            log_session_teardown(
+                &session_id,
+                &container_name,
+                audit_result.as_ref().map(|_| ()),
+            );
+            return Err(error);
+        }
+    };
 
     if let Err(error) = create_container(&resources, &spec, &invocation) {
         let cleanup_result = cleanup_session_resources(&resources);
+        let audit_result =
+            finalize_session_audit_record(&resources.audit_record, SessionAuditCompletion::Error);
         if let Err(cleanup_error) = &cleanup_result {
             log_lifecycle_failure(
                 LifecycleFailureKind::Cleanup,
@@ -107,6 +145,15 @@ pub fn run_session(
                 &resources.container_name,
                 &session_id,
                 cleanup_error,
+            );
+        }
+        if let Err(audit_error) = &audit_result {
+            log_lifecycle_failure(
+                LifecycleFailureKind::Cleanup,
+                "session audit finalization",
+                &resources.container_name,
+                &session_id,
+                audit_error,
             );
         }
         log_session_error(
@@ -118,7 +165,9 @@ pub fn run_session(
         log_session_teardown(
             &session_id,
             &resources.container_name,
-            cleanup_result.as_ref().map(|_| ()),
+            combined_teardown_result(cleanup_result, audit_result)
+                .as_ref()
+                .map(|_| ()),
         );
         return Err(error);
     }
@@ -147,13 +196,30 @@ pub fn run_session(
     }
 
     let cleanup_result = cleanup_session_resources(&resources);
+    let audit_result = finalize_session_audit_record(
+        &resources.audit_record,
+        match &start_result {
+            Ok(outcome) => SessionAuditCompletion::Outcome(outcome),
+            Err(_) => SessionAuditCompletion::Error,
+        },
+    );
+    if let Err(audit_error) = &audit_result {
+        log_lifecycle_failure(
+            LifecycleFailureKind::Cleanup,
+            "session audit finalization",
+            &resources.container_name,
+            &session_id,
+            audit_error,
+        );
+    }
+    let teardown_result = combined_teardown_result(cleanup_result, audit_result);
     log_session_teardown(
         &session_id,
         &resources.container_name,
-        cleanup_result.as_ref().map(|_| ()),
+        teardown_result.as_ref().map(|_| ()),
     );
 
-    match (start_result, cleanup_result) {
+    match (start_result, teardown_result) {
         (Ok(outcome), Ok(())) => Ok(outcome),
         (Err(error), Ok(())) => Err(error),
         (Ok(_), Err(error)) => Err(error),
@@ -179,6 +245,17 @@ fn cleanup_session_resources(resources: &SessionResources) -> Result<(), RunnerE
     container_result?;
     secret_result?;
     staging_result
+}
+
+fn combined_teardown_result(
+    cleanup_result: Result<(), RunnerError>,
+    audit_result: Result<(), RunnerError>,
+) -> Result<(), RunnerError> {
+    match (cleanup_result, audit_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(_)) => Err(error),
+    }
 }
 
 #[cfg(test)]
@@ -228,28 +305,34 @@ mod tests {
 
     #[test]
     fn run_session_emits_teardown_after_resource_allocation_failure() {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
         let methodology_dir = unique_temp_dir("runner-missing-manifest");
         fs::create_dir_all(&methodology_dir).expect("methodology directory should be created");
 
-        let events = capture_tracing_events(|| {
-            let error = run_session(
-                SessionSpec {
-                    methodology_dir: methodology_dir.clone(),
-                    ..test_session_spec()
-                },
-                SessionInvocation {
-                    repo_url: "https://example.com/agentd.git".to_string(),
-                    repo_token: None,
-                    work_unit: None,
-                    timeout: None,
-                },
-            )
-            .expect_err("session should fail during resource allocation");
+        let events = fixture.run_with_fake_podman_env(|| {
+            capture_tracing_events(|| {
+                let error = run_session(
+                    SessionSpec {
+                        methodology_dir: methodology_dir.clone(),
+                        ..test_session_spec()
+                    },
+                    SessionInvocation {
+                        repo_url: "https://example.com/agentd.git".to_string(),
+                        repo_token: None,
+                        work_unit: None,
+                        timeout: None,
+                    },
+                )
+                .expect_err("session should fail during resource allocation");
 
-            assert!(
-                matches!(error, RunnerError::MissingMethodologyManifest { .. }),
-                "expected missing manifest error, got {error:?}"
-            );
+                assert!(
+                    matches!(error, RunnerError::MissingMethodologyManifest { .. }),
+                    "expected missing manifest error, got {error:?}"
+                );
+            })
         });
 
         fs::remove_dir_all(&methodology_dir)
@@ -260,7 +343,7 @@ mod tests {
         assert_eq!(events[1]["fields"]["event"], "runner.session_error");
         assert_eq!(events[1]["fields"]["stage"], "session_resource_allocation");
         assert_eq!(events[2]["fields"]["event"], "runner.session_teardown");
-        assert_eq!(events[2]["fields"]["result"], "skipped");
+        assert_eq!(events[2]["fields"]["result"], "ok");
     }
 
     #[test]
@@ -330,7 +413,7 @@ mod tests {
         assert_eq!(events[2]["fields"]["event"], "runner.session_error");
         assert_eq!(events[2]["fields"]["stage"], "session_resource_allocation");
         assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
-        assert_eq!(events[3]["fields"]["result"], "skipped");
+        assert_eq!(events[3]["fields"]["result"], "ok");
     }
 
     #[test]

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -136,8 +136,11 @@ pub fn run_session(
 
     if let Err(error) = create_container(&resources, &spec, &invocation) {
         let cleanup_result = cleanup_session_resources(&resources);
-        let audit_result =
-            finalize_session_audit_record(&resources.audit_record, SessionAuditCompletion::Error);
+        let audit_result = finalize_session_audit_record_if_cleanup_succeeded(
+            &cleanup_result,
+            &resources.audit_record,
+            SessionAuditCompletion::Error,
+        );
         if let Err(cleanup_error) = &cleanup_result {
             log_lifecycle_failure(
                 LifecycleFailureKind::Cleanup,
@@ -196,7 +199,8 @@ pub fn run_session(
     }
 
     let cleanup_result = cleanup_session_resources(&resources);
-    let audit_result = finalize_session_audit_record(
+    let audit_result = finalize_session_audit_record_if_cleanup_succeeded(
+        &cleanup_result,
         &resources.audit_record,
         match &start_result {
             Ok(outcome) => SessionAuditCompletion::Outcome(outcome),
@@ -247,6 +251,18 @@ fn cleanup_session_resources(resources: &SessionResources) -> Result<(), RunnerE
     staging_result
 }
 
+fn finalize_session_audit_record_if_cleanup_succeeded(
+    cleanup_result: &Result<(), RunnerError>,
+    record: &audit::SessionAuditRecord,
+    completion: SessionAuditCompletion<'_>,
+) -> Result<(), RunnerError> {
+    if cleanup_result.is_err() {
+        return Ok(());
+    }
+
+    finalize_session_audit_record(record, completion)
+}
+
 fn combined_teardown_result(
     cleanup_result: Result<(), RunnerError>,
     audit_result: Result<(), RunnerError>,
@@ -266,7 +282,37 @@ mod tests {
         capture_tracing_events, fake_podman_lock, fake_podman_ps_json, test_session_spec,
         unique_temp_dir,
     };
+    use serde_json::Value;
     use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn only_session_record_dir(audit_root: &Path, profile_name: &str) -> PathBuf {
+        let profile_root = audit_root.join(profile_name);
+        let entries = fs::read_dir(&profile_root)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", profile_root.display()))
+            .map(|entry| {
+                entry
+                    .expect("session record entry should be readable")
+                    .path()
+            })
+            .filter(|path| path.is_dir())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected exactly one session record under {}",
+            profile_root.display()
+        );
+        entries[0].clone()
+    }
+
+    fn read_session_metadata(record_dir: &Path) -> Value {
+        serde_json::from_str(
+            &fs::read_to_string(record_dir.join("agentd/session.json"))
+                .expect("session metadata should be readable"),
+        )
+        .expect("session metadata should be valid json")
+    }
 
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
 
@@ -414,6 +460,181 @@ mod tests {
         assert_eq!(events[2]["fields"]["stage"], "session_resource_allocation");
         assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
         assert_eq!(events[3]["fields"]["result"], "ok");
+    }
+
+    #[test]
+    fn run_session_leaves_audit_record_incomplete_and_unsealed_when_container_creation_cleanup_fails()
+     {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        fixture.install(
+            &FakePodmanScenario::new()
+                .with_create(CommandBehavior::from_outcome(
+                    CommandOutcome::new().stderr("create failed").exit_code(42),
+                ))
+                .with_rm(CommandBehavior::from_outcome(
+                    CommandOutcome::new()
+                        .append_args_with_prefix("rm-commands.log", "rm")
+                        .stderr("rm failed")
+                        .exit_code(51),
+                )),
+        );
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let audit_root = unique_temp_dir("runner-audit-create-cleanup-failure");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+
+        let error = fixture
+            .run_with_fake_podman_env(|| {
+                run_session(
+                    SessionSpec {
+                        methodology_dir,
+                        audit_root: audit_root.clone(),
+                        ..test_session_spec()
+                    },
+                    SessionInvocation {
+                        repo_url: "https://example.com/agentd.git".to_string(),
+                        repo_token: None,
+                        work_unit: None,
+                        timeout: None,
+                    },
+                )
+            })
+            .expect_err("session should fail during container creation");
+
+        match error {
+            RunnerError::PodmanCommandFailed {
+                args,
+                status,
+                stderr,
+            } => {
+                assert_eq!(args[0], "create");
+                assert_eq!(status.code(), Some(42));
+                assert_eq!(stderr.trim(), "create failed");
+            }
+            other => panic!("expected create failure, got {other:?}"),
+        }
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert!(
+            metadata.get("end_timestamp").is_none(),
+            "cleanup failure must not finalize end_timestamp"
+        );
+        assert!(
+            metadata.get("outcome").is_none(),
+            "cleanup failure must not finalize outcome"
+        );
+
+        use std::os::unix::fs::PermissionsExt;
+
+        let runa_mode = fs::metadata(record_dir.join("runa"))
+            .expect("runa dir metadata should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            runa_mode, 0o777,
+            "cleanup failure must leave the top-level runa dir in its active writable mode"
+        );
+        assert_ne!(
+            runa_mode, 0o555,
+            "cleanup failure must not seal the top-level runa dir"
+        );
+
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn run_session_leaves_audit_record_incomplete_and_unsealed_when_post_execution_cleanup_fails() {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        fixture.install(
+            &FakePodmanScenario::new().with_rm(CommandBehavior::from_outcome(
+                CommandOutcome::new()
+                    .append_args_with_prefix("rm-commands.log", "rm")
+                    .stderr("rm failed")
+                    .exit_code(51),
+            )),
+        );
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let audit_root = unique_temp_dir("runner-audit-post-cleanup-failure");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+
+        let error = fixture
+            .run_with_fake_podman_env(|| {
+                run_session(
+                    SessionSpec {
+                        methodology_dir,
+                        audit_root: audit_root.clone(),
+                        ..test_session_spec()
+                    },
+                    SessionInvocation {
+                        repo_url: "https://example.com/agentd.git".to_string(),
+                        repo_token: None,
+                        work_unit: None,
+                        timeout: None,
+                    },
+                )
+            })
+            .expect_err("cleanup failure should surface as a session error");
+
+        match error {
+            RunnerError::PodmanCommandFailed {
+                args,
+                status,
+                stderr,
+            } => {
+                assert_eq!(
+                    args.len(),
+                    4,
+                    "cleanup failure should come from podman rm --force --ignore <container>"
+                );
+                assert_eq!(args[0], "rm");
+                assert_eq!(args[1], "--force");
+                assert_eq!(args[2], "--ignore");
+                assert!(
+                    args[3].starts_with("agentd-1a2b3c4d-site-builder-"),
+                    "unexpected cleanup target: {}",
+                    args[3]
+                );
+                assert_eq!(status.code(), Some(51));
+                assert_eq!(stderr.trim(), "rm failed");
+            }
+            other => panic!("expected cleanup failure, got {other:?}"),
+        }
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert!(
+            metadata.get("end_timestamp").is_none(),
+            "cleanup failure must not finalize end_timestamp"
+        );
+        assert!(
+            metadata.get("outcome").is_none(),
+            "cleanup failure must not finalize outcome"
+        );
+
+        use std::os::unix::fs::PermissionsExt;
+
+        let runa_mode = fs::metadata(record_dir.join("runa"))
+            .expect("runa dir metadata should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            runa_mode, 0o777,
+            "cleanup failure must leave the top-level runa dir in its active writable mode"
+        );
+        assert_ne!(
+            runa_mode, 0o555,
+            "cleanup failure must not seal the top-level runa dir"
+        );
+
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
     #[test]

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -768,6 +768,121 @@ mod tests {
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
+    #[test]
+    fn run_session_leaves_metadata_incomplete_when_podman_unshare_sealing_fails_after_preflight() {
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        fixture.install(
+            &FakePodmanScenario::new()
+                .with_start(CommandBehavior::from_outcome(
+                    CommandOutcome::new()
+                        .touch_file("start-blocked")
+                        .wait_for_file(
+                            "release-start",
+                            Duration::from_secs(5),
+                            "timed out waiting to release start",
+                            91,
+                        ),
+                ))
+                .with_unshare(CommandBehavior::sequence(vec![
+                    CommandOutcome::new(),
+                    CommandOutcome::new(),
+                    CommandOutcome::new()
+                        .stderr("podman unshare file chmod failed")
+                        .exit_code(61),
+                ])),
+        );
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        let audit_root = unique_temp_dir("runner-audit-unshare-finalization-failure");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+        let helper_audit_root = audit_root.clone();
+
+        let events = fixture.run_with_fake_podman_env(|| {
+            let log_dir = PathBuf::from(
+                std::env::var("AGENTD_FAKE_PODMAN_LOG_DIR")
+                    .expect("fake podman log dir should be configured"),
+            );
+            let helper = thread::spawn(move || {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                while Instant::now() < deadline && !log_dir.join("start-blocked").exists() {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                assert!(
+                    log_dir.join("start-blocked").exists(),
+                    "fake podman start should block before audit finalization"
+                );
+
+                let record_dir =
+                    wait_for_only_session_record_dir(&helper_audit_root, "site-builder", deadline);
+                let sealed_by_unshare_dir = record_dir.join("runa/unshare-private");
+                fs::create_dir_all(&sealed_by_unshare_dir)
+                    .expect("fallback-private audit dir should be created");
+                fs::write(sealed_by_unshare_dir.join("artifact.txt"), "persisted\n")
+                    .expect("fallback-private audit file should be created");
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&sealed_by_unshare_dir, fs::Permissions::from_mode(0o111))
+                    .expect("fallback-private audit dir should become unreadable to the host");
+                fs::write(log_dir.join("release-start"), b"release\n")
+                    .expect("start should be released");
+            });
+
+            let events = capture_tracing_events(|| {
+                let outcome = run_session(
+                    SessionSpec {
+                        methodology_dir,
+                        audit_root: audit_root.clone(),
+                        ..test_session_spec()
+                    },
+                    SessionInvocation {
+                        repo_url: "https://example.com/agentd.git".to_string(),
+                        repo_token: None,
+                        work_unit: None,
+                        timeout: None,
+                    },
+                )
+                .expect("session outcome should survive audit finalization failure");
+
+                assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+            });
+
+            helper
+                .join()
+                .expect("audit-finalization helper thread should complete");
+            events
+        });
+
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0]["fields"]["event"], "runner.session_started");
+        assert_eq!(events[1]["fields"]["event"], "runner.session_outcome");
+        assert_eq!(events[1]["fields"]["outcome"], "success");
+        assert_eq!(events[2]["fields"]["event"], "runner.lifecycle_failure");
+        assert_eq!(events[2]["fields"]["stage"], "session audit finalization");
+        assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
+        assert_eq!(events[3]["fields"]["result"], "error");
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert!(
+            metadata.get("end_timestamp").is_none(),
+            "audit finalization failure must leave end_timestamp incomplete"
+        );
+        assert!(
+            metadata.get("outcome").is_none(),
+            "audit finalization failure must leave outcome incomplete"
+        );
+
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(
+            record_dir.join("runa/unshare-private"),
+            fs::Permissions::from_mode(0o755),
+        )
+        .expect("fallback-private dir should become removable for test cleanup");
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+    }
+
     fn wait_for_only_session_record_dir(
         audit_root: &Path,
         profile_name: &str,

--- a/crates/agentd-runner/src/podman.rs
+++ b/crates/agentd-runner/src/podman.rs
@@ -193,7 +193,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn podman_commands_with_input_reap_failed_children_before_returning() {
         let _guard = fake_podman_lock()
@@ -236,7 +235,6 @@ mod tests {
         assert_eq!(exit_status(17).code(), Some(17));
     }
 
-    #[cfg(unix)]
     #[test]
     fn podman_commands_with_input_until_reap_failed_children_before_returning() {
         let _guard = fake_podman_lock()

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -57,6 +57,21 @@ impl SessionResources {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct ResourceAllocationFailure {
+    pub(crate) allocation_error: RunnerError,
+    pub(crate) rollback_result: Result<(), RunnerError>,
+}
+
+impl ResourceAllocationFailure {
+    fn without_rollback_failure(error: RunnerError) -> Self {
+        Self {
+            allocation_error: error,
+            rollback_result: Ok(()),
+        }
+    }
+}
+
 pub(crate) fn unique_suffix() -> Result<String, RunnerError> {
     unique_suffix_with(|bytes| fill_random_bytes(bytes).map_err(std::io::Error::other))
 }
@@ -67,21 +82,23 @@ pub(crate) fn prepare_session_resources(
     invocation: &SessionInvocation,
     session_id: &str,
     audit_record: SessionAuditRecord,
-) -> Result<SessionResources, RunnerError> {
+) -> Result<SessionResources, ResourceAllocationFailure> {
     let manifest_path = spec.methodology_dir.join("manifest.toml");
     if !manifest_path.is_file() {
-        return Err(RunnerError::MissingMethodologyManifest {
-            path: manifest_path,
-        });
+        return Err(ResourceAllocationFailure::without_rollback_failure(
+            RunnerError::MissingMethodologyManifest {
+                path: manifest_path,
+            },
+        ));
     }
 
-    let methodology_staging_dir =
-        create_methodology_staging_dir(&spec.methodology_dir, session_id)?;
+    let methodology_staging_dir = create_methodology_staging_dir(&spec.methodology_dir, session_id)
+        .map_err(ResourceAllocationFailure::without_rollback_failure)?;
     let audit_mount = match create_audit_mount(&audit_record, spec, &methodology_staging_dir) {
         Ok(mount) => mount,
         Err(error) => {
             let _ = fs::remove_dir_all(&methodology_staging_dir);
-            return Err(error);
+            return Err(ResourceAllocationFailure::without_rollback_failure(error));
         }
     };
     let methodology_mount_source = methodology_staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
@@ -89,7 +106,7 @@ pub(crate) fn prepare_session_resources(
         Ok(mounts) => mounts,
         Err(error) => {
             let _ = fs::remove_dir_all(&methodology_staging_dir);
-            return Err(error);
+            return Err(ResourceAllocationFailure::without_rollback_failure(error));
         }
     };
     let mut resources = SessionResources {
@@ -145,7 +162,9 @@ fn rollback_failed_resource_allocation(
     resources: &SessionResources,
     session_id: &str,
     error: RunnerError,
-) -> RunnerError {
+) -> ResourceAllocationFailure {
+    let mut rollback_error = None;
+
     if let Err(cleanup_error) = cleanup_podman_secrets(&resources.all_secret_bindings()) {
         log_lifecycle_failure(
             LifecycleFailureKind::Cleanup,
@@ -154,6 +173,7 @@ fn rollback_failed_resource_allocation(
             session_id,
             &cleanup_error,
         );
+        rollback_error = Some(cleanup_error);
     }
     if let Err(cleanup_error) = cleanup_methodology_staging_dir(&resources.methodology_staging_dir)
     {
@@ -164,9 +184,13 @@ fn rollback_failed_resource_allocation(
             session_id,
             &cleanup_error,
         );
+        rollback_error.get_or_insert(cleanup_error);
     }
 
-    error
+    ResourceAllocationFailure {
+        allocation_error: error,
+        rollback_result: rollback_error.map_or(Ok(()), Err),
+    }
 }
 
 pub(crate) fn cleanup_podman_secrets(secret_bindings: &[SecretBinding]) -> Result<(), RunnerError> {
@@ -471,7 +495,10 @@ mod tests {
             )
         });
 
-        match result.expect_err("second secret create should fail") {
+        match result
+            .expect_err("second secret create should fail")
+            .allocation_error
+        {
             RunnerError::PodmanCommandFailed {
                 args,
                 status,
@@ -544,7 +571,10 @@ mod tests {
             )
         });
 
-        match result.expect_err("repo token secret create should fail") {
+        match result
+            .expect_err("repo token secret create should fail")
+            .allocation_error
+        {
             RunnerError::PodmanCommandFailed {
                 args,
                 status,
@@ -607,7 +637,10 @@ mod tests {
             test_audit_record(&session_id),
         );
 
-        match result.expect_err("missing mount sources should be rejected") {
+        match result
+            .expect_err("missing mount sources should be rejected")
+            .allocation_error
+        {
             RunnerError::MissingMountSource { path } => {
                 assert_eq!(path, missing_mount_source);
             }

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -70,6 +70,16 @@ impl ResourceAllocationFailure {
             rollback_result: Ok(()),
         }
     }
+
+    fn with_rollback_result(
+        allocation_error: RunnerError,
+        rollback_result: Result<(), RunnerError>,
+    ) -> Self {
+        Self {
+            allocation_error,
+            rollback_result,
+        }
+    }
 }
 
 pub(crate) fn unique_suffix() -> Result<String, RunnerError> {
@@ -97,16 +107,24 @@ pub(crate) fn prepare_session_resources(
     let audit_mount = match create_audit_mount(&audit_record, spec, &methodology_staging_dir) {
         Ok(mount) => mount,
         Err(error) => {
-            let _ = fs::remove_dir_all(&methodology_staging_dir);
-            return Err(ResourceAllocationFailure::without_rollback_failure(error));
+            return Err(rollback_failed_staging_dir_allocation(
+                container_name,
+                session_id,
+                &methodology_staging_dir,
+                error,
+            ));
         }
     };
     let methodology_mount_source = methodology_staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
     let additional_mounts = match create_additional_mounts(&spec.mounts, &methodology_staging_dir) {
         Ok(mounts) => mounts,
         Err(error) => {
-            let _ = fs::remove_dir_all(&methodology_staging_dir);
-            return Err(ResourceAllocationFailure::without_rollback_failure(error));
+            return Err(rollback_failed_staging_dir_allocation(
+                container_name,
+                session_id,
+                &methodology_staging_dir,
+                error,
+            ));
         }
     };
     let mut resources = SessionResources {
@@ -187,10 +205,27 @@ fn rollback_failed_resource_allocation(
         rollback_error.get_or_insert(cleanup_error);
     }
 
-    ResourceAllocationFailure {
-        allocation_error: error,
-        rollback_result: rollback_error.map_or(Ok(()), Err),
+    ResourceAllocationFailure::with_rollback_result(error, rollback_error.map_or(Ok(()), Err))
+}
+
+fn rollback_failed_staging_dir_allocation(
+    container_name: &str,
+    session_id: &str,
+    staging_dir: &Path,
+    error: RunnerError,
+) -> ResourceAllocationFailure {
+    let rollback_result = cleanup_methodology_staging_dir(staging_dir);
+    if let Err(cleanup_error) = &rollback_result {
+        log_lifecycle_failure(
+            LifecycleFailureKind::Cleanup,
+            "session resource allocation",
+            container_name,
+            session_id,
+            cleanup_error,
+        );
     }
+
+    ResourceAllocationFailure::with_rollback_result(error, rollback_result)
 }
 
 pub(crate) fn cleanup_podman_secrets(secret_bindings: &[SecretBinding]) -> Result<(), RunnerError> {
@@ -356,13 +391,18 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{prepare_session_resources, unique_suffix_with};
+    use super::{
+        prepare_session_resources, rollback_failed_staging_dir_allocation, unique_suffix_with,
+    };
     use crate::audit::SessionAuditRecord;
     use crate::test_support::{
         CommandBehavior, CommandOutcome, FakePodmanFixture, FakePodmanScenario,
         capture_tracing_events, fake_podman_lock, test_session_spec,
     };
     use crate::{BindMount, ResolvedEnvironmentVariable, RunnerError, SessionInvocation};
+    use std::cell::RefCell;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
 
     fn test_audit_record(session_id: &str) -> SessionAuditRecord {
@@ -389,6 +429,17 @@ mod tests {
         }
     }
 
+    fn unique_test_dir(prefix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after the unix epoch")
+                .as_nanos()
+        ))
+    }
+
     #[test]
     fn unique_suffix_with_encodes_eight_random_bytes_as_sixteen_lower_hex_characters() {
         let suffix = unique_suffix_with(|bytes| {
@@ -405,6 +456,90 @@ mod tests {
                 .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f')),
             "session suffix should be lowercase hex: {suffix}"
         );
+    }
+
+    #[test]
+    fn rollback_failed_staging_dir_allocation_returns_ok_rollback_when_cleanup_succeeds() {
+        let root = unique_test_dir("agentd-staging-rollback-ok");
+        let staging_dir = root.join("staging");
+        fs::create_dir_all(&staging_dir).expect("staging dir should be created");
+        fs::write(staging_dir.join("mounted"), "test\n").expect("staging child should be created");
+
+        let failure = rollback_failed_staging_dir_allocation(
+            "agentd-agent-session",
+            "session-ok",
+            &staging_dir,
+            RunnerError::MissingMountSource {
+                path: PathBuf::from("/missing"),
+            },
+        );
+
+        assert!(
+            matches!(
+                failure.allocation_error,
+                RunnerError::MissingMountSource { ref path } if path == &PathBuf::from("/missing")
+            ),
+            "original allocation error should be preserved: {:?}",
+            failure.allocation_error
+        );
+        assert!(
+            failure.rollback_result.is_ok(),
+            "successful rollback should report Ok(()): {:?}",
+            failure.rollback_result
+        );
+        assert!(
+            !staging_dir.exists(),
+            "successful rollback should remove the staging dir"
+        );
+
+        fs::remove_dir_all(&root).expect("temporary rollback root should be removed");
+    }
+
+    #[test]
+    fn rollback_failed_staging_dir_allocation_returns_cleanup_error_and_logs_failure() {
+        let root = unique_test_dir("agentd-staging-rollback-error");
+        let staging_dir = root.join("staging");
+        fs::create_dir_all(&staging_dir).expect("staging dir should be created");
+        fs::write(staging_dir.join("mounted"), "test\n").expect("staging child should be created");
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o555))
+            .expect("rollback parent should become read-only");
+
+        let failure = RefCell::new(None);
+        let events = capture_tracing_events(|| {
+            failure.replace(Some(rollback_failed_staging_dir_allocation(
+                "agentd-agent-session",
+                "session-error",
+                &staging_dir,
+                RunnerError::MissingMountSource {
+                    path: PathBuf::from("/missing"),
+                },
+            )));
+        });
+
+        let failure = failure
+            .into_inner()
+            .expect("staging rollback failure should be captured");
+        assert!(
+            matches!(
+                failure.allocation_error,
+                RunnerError::MissingMountSource { ref path } if path == &PathBuf::from("/missing")
+            ),
+            "original allocation error should be preserved: {:?}",
+            failure.allocation_error
+        );
+        match failure.rollback_result {
+            Err(RunnerError::Io(error)) => {
+                assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("expected permission denied rollback failure, got {other:?}"),
+        }
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["fields"]["event"], "runner.lifecycle_failure");
+        assert_eq!(events[0]["fields"]["stage"], "session resource allocation");
+
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o755))
+            .expect("rollback parent should become writable for cleanup");
+        fs::remove_dir_all(&root).expect("temporary rollback root should be removed");
     }
 
     #[test]

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -5,9 +5,11 @@
 //! completes. Partial-failure cleanup during allocation ensures no leaked
 //! secrets or stale staging directories when resource creation fails midway.
 
+use crate::audit::SessionAuditRecord;
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::naming::{SESSION_ID_LEN, format_secret_name};
 use crate::podman::run_podman_command_with_input;
+use crate::session_paths::session_internal_audit_runa_dir;
 use crate::types::{RunnerError, SessionInvocation, SessionSpec};
 use crate::validation::REPO_TOKEN_ENV;
 use getrandom::fill as fill_random_bytes;
@@ -15,6 +17,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const METHODOLOGY_STAGE_LINK_NAME: &str = "methodology";
+const AUDIT_RUNA_STAGE_LINK_NAME: &str = "audit-runa";
 const ADDITIONAL_MOUNT_STAGE_PREFIX: &str = "mount-";
 const SESSION_STAGE_PREFIX: &str = "agentd-session-stage-";
 
@@ -29,6 +32,7 @@ pub(crate) struct PreparedBindMount {
     pub(crate) source: PathBuf,
     pub(crate) target: PathBuf,
     pub(crate) read_only: bool,
+    pub(crate) relabel_shared: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,6 +40,8 @@ pub(crate) struct SessionResources {
     pub(crate) container_name: String,
     pub(crate) methodology_staging_dir: PathBuf,
     pub(crate) methodology_mount_source: PathBuf,
+    pub(crate) audit_record: SessionAuditRecord,
+    pub(crate) audit_mount: PreparedBindMount,
     pub(crate) additional_mounts: Vec<PreparedBindMount>,
     pub(crate) environment_secret_bindings: Vec<SecretBinding>,
     pub(crate) repo_token_secret_binding: Option<SecretBinding>,
@@ -60,6 +66,7 @@ pub(crate) fn prepare_session_resources(
     spec: &SessionSpec,
     invocation: &SessionInvocation,
     session_id: &str,
+    audit_record: SessionAuditRecord,
 ) -> Result<SessionResources, RunnerError> {
     let manifest_path = spec.methodology_dir.join("manifest.toml");
     if !manifest_path.is_file() {
@@ -70,6 +77,13 @@ pub(crate) fn prepare_session_resources(
 
     let methodology_staging_dir =
         create_methodology_staging_dir(&spec.methodology_dir, session_id)?;
+    let audit_mount = match create_audit_mount(&audit_record, spec, &methodology_staging_dir) {
+        Ok(mount) => mount,
+        Err(error) => {
+            let _ = fs::remove_dir_all(&methodology_staging_dir);
+            return Err(error);
+        }
+    };
     let methodology_mount_source = methodology_staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
     let additional_mounts = match create_additional_mounts(&spec.mounts, &methodology_staging_dir) {
         Ok(mounts) => mounts,
@@ -82,6 +96,8 @@ pub(crate) fn prepare_session_resources(
         container_name: container_name.to_string(),
         methodology_staging_dir,
         methodology_mount_source,
+        audit_record,
+        audit_mount,
         additional_mounts,
         environment_secret_bindings: Vec::new(),
         repo_token_secret_binding: None,
@@ -207,25 +223,52 @@ fn create_additional_mounts(
     let mut prepared_mounts = Vec::with_capacity(mounts.len());
 
     for (index, mount) in mounts.iter().enumerate() {
-        let canonical_source = mount
-            .source
-            .canonicalize()
-            .map_err(|error| match error.kind() {
-                std::io::ErrorKind::NotFound => RunnerError::MissingMountSource {
-                    path: mount.source.clone(),
-                },
-                _ => RunnerError::Io(error),
-            })?;
-        let staged_source = staging_dir.join(format!("{ADDITIONAL_MOUNT_STAGE_PREFIX}{index}"));
-        create_path_symlink(&canonical_source, &staged_source)?;
-        prepared_mounts.push(PreparedBindMount {
-            source: staged_source,
-            target: mount.target.clone(),
-            read_only: mount.read_only,
-        });
+        prepared_mounts.push(create_prepared_bind_mount(
+            &mount.source,
+            staging_dir.join(format!("{ADDITIONAL_MOUNT_STAGE_PREFIX}{index}")),
+            mount.target.clone(),
+            mount.read_only,
+            false,
+        )?);
     }
 
     Ok(prepared_mounts)
+}
+
+fn create_audit_mount(
+    audit_record: &SessionAuditRecord,
+    spec: &SessionSpec,
+    staging_dir: &Path,
+) -> Result<PreparedBindMount, RunnerError> {
+    create_prepared_bind_mount(
+        &audit_record.runa_dir,
+        staging_dir.join(AUDIT_RUNA_STAGE_LINK_NAME),
+        session_internal_audit_runa_dir(&spec.profile_name),
+        false,
+        true,
+    )
+}
+
+fn create_prepared_bind_mount(
+    source: &Path,
+    staged_source: PathBuf,
+    target: PathBuf,
+    read_only: bool,
+    relabel_shared: bool,
+) -> Result<PreparedBindMount, RunnerError> {
+    let canonical_source = source.canonicalize().map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => RunnerError::MissingMountSource {
+            path: source.to_path_buf(),
+        },
+        _ => RunnerError::Io(error),
+    })?;
+    create_path_symlink(&canonical_source, &staged_source)?;
+    Ok(PreparedBindMount {
+        source: staged_source,
+        target,
+        read_only,
+        relabel_shared,
+    })
 }
 
 // Returns a base directory for session staging that is safe for podman
@@ -309,12 +352,37 @@ fn hex_encode(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{prepare_session_resources, unique_suffix_with};
+    use crate::audit::SessionAuditRecord;
     use crate::test_support::{
         CommandBehavior, CommandOutcome, FakePodmanFixture, FakePodmanScenario,
         capture_tracing_events, fake_podman_lock, test_session_spec,
     };
     use crate::{BindMount, ResolvedEnvironmentVariable, RunnerError, SessionInvocation};
     use std::path::PathBuf;
+
+    fn test_audit_record(session_id: &str) -> SessionAuditRecord {
+        let record_dir = std::env::temp_dir().join(format!("agentd-audit-record-{session_id}"));
+        let runa_dir = record_dir.join("runa");
+        let metadata_path = record_dir.join("agentd/session.json");
+        std::fs::create_dir_all(&runa_dir).expect("test runa dir should be created");
+        std::fs::create_dir_all(
+            metadata_path
+                .parent()
+                .expect("metadata path should have a parent"),
+        )
+        .expect("test metadata dir should be created");
+
+        SessionAuditRecord {
+            record_dir,
+            runa_dir,
+            metadata_path,
+            session_id: session_id.to_string(),
+            profile: "site-builder".to_string(),
+            repo_url: "https://example.com/repo.git".to_string(),
+            work_unit: None,
+            start_timestamp: "2026-04-16T00:00:00Z".to_string(),
+        }
+    }
 
     #[test]
     fn unique_suffix_with_encodes_eight_random_bytes_as_sixteen_lower_hex_characters() {
@@ -418,6 +486,7 @@ mod tests {
                     timeout: None,
                 },
                 &session_id,
+                test_audit_record(&session_id),
             )
         });
 
@@ -490,6 +559,7 @@ mod tests {
                     timeout: None,
                 },
                 &session_id,
+                test_audit_record(&session_id),
             )
         });
 
@@ -553,6 +623,7 @@ mod tests {
                 timeout: None,
             },
             &session_id,
+            test_audit_record(&session_id),
         );
 
         match result.expect_err("missing mount sources should be rejected") {

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -282,15 +282,7 @@ fn safe_staging_root() -> PathBuf {
         return temp_dir;
     }
 
-    #[cfg(unix)]
-    {
-        PathBuf::from("/tmp")
-    }
-
-    #[cfg(not(unix))]
-    {
-        temp_dir
-    }
+    PathBuf::from("/tmp")
 }
 
 fn path_requires_mount_staging_alias(path: &Path) -> bool {
@@ -310,19 +302,8 @@ fn create_podman_secret(secret_name: &str, value: &str) -> Result<(), RunnerErro
     .map(|_| ())
 }
 
-#[cfg(unix)]
 fn create_path_symlink(source: &Path, destination: &Path) -> Result<(), RunnerError> {
     std::os::unix::fs::symlink(source, destination).map_err(RunnerError::Io)
-}
-
-#[cfg(windows)]
-fn create_path_symlink(source: &Path, destination: &Path) -> Result<(), RunnerError> {
-    let metadata = source.metadata().map_err(RunnerError::Io)?;
-    if metadata.is_dir() {
-        std::os::windows::fs::symlink_dir(source, destination).map_err(RunnerError::Io)
-    } else {
-        std::os::windows::fs::symlink_file(source, destination).map_err(RunnerError::Io)
-    }
 }
 
 // Generates a 16-character hex string from 8 bytes of cryptographic randomness.

--- a/crates/agentd-runner/src/session_paths.rs
+++ b/crates/agentd-runner/src/session_paths.rs
@@ -2,6 +2,10 @@ use std::path::PathBuf;
 
 const HOME_ROOT_DIR: &str = "/home";
 const REPO_DIR_NAME: &str = "repo";
+const INTERNAL_AGENTD_DIR_NAME: &str = ".agentd";
+const INTERNAL_AUDIT_DIR_NAME: &str = "audit";
+const INTERNAL_AUDIT_RUNA_DIR_NAME: &str = "runa";
+const REPO_RUNA_DIR_NAME: &str = ".runa";
 
 pub(crate) fn session_home_dir(profile_name: &str) -> PathBuf {
     PathBuf::from(HOME_ROOT_DIR).join(profile_name)
@@ -9,4 +13,20 @@ pub(crate) fn session_home_dir(profile_name: &str) -> PathBuf {
 
 pub(crate) fn session_repo_dir(profile_name: &str) -> PathBuf {
     session_home_dir(profile_name).join(REPO_DIR_NAME)
+}
+
+pub(crate) fn session_internal_agentd_dir(profile_name: &str) -> PathBuf {
+    session_home_dir(profile_name).join(INTERNAL_AGENTD_DIR_NAME)
+}
+
+pub(crate) fn session_internal_audit_dir(profile_name: &str) -> PathBuf {
+    session_internal_agentd_dir(profile_name).join(INTERNAL_AUDIT_DIR_NAME)
+}
+
+pub(crate) fn session_internal_audit_runa_dir(profile_name: &str) -> PathBuf {
+    session_internal_audit_dir(profile_name).join(INTERNAL_AUDIT_RUNA_DIR_NAME)
+}
+
+pub(crate) fn session_repo_runa_dir(profile_name: &str) -> PathBuf {
+    session_repo_dir(profile_name).join(REPO_RUNA_DIR_NAME)
 }

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -491,6 +491,7 @@ impl FakePodmanFixture {
         unsafe {
             env::set_var("PATH", &fake_path);
             env::set_var("AGENTD_FAKE_PODMAN_LOG_DIR", &self.log_dir);
+            env::set_var("AGENTD_TEST_AUDIT_ROOT", self.root.join("audit-root"));
         }
 
         let result = run();
@@ -498,6 +499,7 @@ impl FakePodmanFixture {
         unsafe {
             env::set_var("PATH", original_path);
             env::remove_var("AGENTD_FAKE_PODMAN_LOG_DIR");
+            env::remove_var("AGENTD_TEST_AUDIT_ROOT");
         }
 
         result

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -17,6 +17,7 @@ pub(crate) fn test_session_spec() -> SessionSpec {
         profile_name: "site-builder".to_string(),
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
+        audit_root: std::env::temp_dir().join("agentd-runner-test-audit-root"),
         mounts: Vec::new(),
         command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),
@@ -491,7 +492,6 @@ impl FakePodmanFixture {
         unsafe {
             env::set_var("PATH", &fake_path);
             env::set_var("AGENTD_FAKE_PODMAN_LOG_DIR", &self.log_dir);
-            env::set_var("AGENTD_TEST_AUDIT_ROOT", self.root.join("audit-root"));
         }
 
         let result = run();
@@ -499,7 +499,6 @@ impl FakePodmanFixture {
         unsafe {
             env::set_var("PATH", original_path);
             env::remove_var("AGENTD_FAKE_PODMAN_LOG_DIR");
-            env::remove_var("AGENTD_TEST_AUDIT_ROOT");
         }
 
         result

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -113,6 +113,7 @@ impl Write for SharedBufferWriter {
 pub(crate) struct FakePodmanScenario {
     create: CommandBehavior,
     ps: CommandBehavior,
+    unshare: CommandBehavior,
     start: CommandBehavior,
     remove: CommandBehavior,
     secret_create: CommandBehavior,
@@ -130,6 +131,7 @@ impl FakePodmanScenario {
                     .set_container_state("created"),
             ),
             ps: CommandBehavior::from_outcome(CommandOutcome::new()),
+            unshare: CommandBehavior::from_outcome(CommandOutcome::new()),
             start: CommandBehavior::from_outcome(
                 CommandOutcome::new().set_container_state("running"),
             ),
@@ -159,6 +161,11 @@ impl FakePodmanScenario {
 
     pub(crate) fn with_start(mut self, behavior: CommandBehavior) -> Self {
         self.start = behavior;
+        self
+    }
+
+    pub(crate) fn with_unshare(mut self, behavior: CommandBehavior) -> Self {
+        self.unshare = behavior;
         self
     }
 
@@ -217,6 +224,7 @@ impl FakePodmanScenario {
 
         script.push_str(&render_command_branch("create", &self.create));
         script.push_str(&render_command_branch("ps", &self.ps));
+        script.push_str(&render_command_branch("unshare", &self.unshare));
         script.push_str(
             "    secret)\n\
                  subcommand=\"$1\"\n\

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -444,17 +444,14 @@ impl FakePodmanFixture {
         fs::write(&script_path, scenario.render_script())
             .expect("fake podman script should be written");
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::PermissionsExt;
 
-            let mut permissions = fs::metadata(&script_path)
-                .expect("fake podman script metadata should be available")
-                .permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&script_path, permissions)
-                .expect("fake podman script should be executable");
-        }
+        let mut permissions = fs::metadata(&script_path)
+            .expect("fake podman script metadata should be available")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions)
+            .expect("fake podman script should be executable");
     }
 
     pub(crate) fn create_methodology_dir(&self, name: &str) -> PathBuf {
@@ -741,21 +738,11 @@ pub(crate) fn unique_temp_dir(prefix: &str) -> PathBuf {
     ))
 }
 
-#[cfg(unix)]
 pub(crate) fn exit_status(code: i32) -> ExitStatus {
     use std::os::unix::process::ExitStatusExt;
 
     ExitStatusExt::from_raw(code << 8)
 }
-
-#[cfg(windows)]
-pub(crate) fn exit_status(code: i32) -> ExitStatus {
-    use std::os::windows::process::ExitStatusExt;
-
-    ExitStatusExt::from_raw(code as u32)
-}
-
-#[cfg(unix)]
 pub(crate) fn assert_process_is_reaped(pid: u32) {
     let output = Command::new("ps")
         .args(["-o", "stat=", "-p", &pid.to_string()])

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -33,6 +33,9 @@ pub struct SessionSpec {
     /// Host-side path to the methodology directory. Mounted read-only into
     /// the container at `/agentd/methodology`. Must contain `manifest.toml`.
     pub methodology_dir: PathBuf,
+    /// Host-side root where persistent audit records are created. The runner
+    /// stores each session under `<audit_root>/<profile>/<session_id>/`.
+    pub audit_root: PathBuf,
     /// Additional host bind mounts declared by the selected profile.
     pub mounts: Vec<BindMount>,
     /// Command array executed directly from the cloned repository after
@@ -299,6 +302,9 @@ pub enum RunnerError {
     /// The base image string is empty or has surrounding whitespace. Produced
     /// during spec validation.
     InvalidBaseImage,
+    /// The configured audit root path is not absolute. Produced during spec
+    /// validation.
+    InvalidAuditRoot { path: PathBuf },
     /// The repository URL is not a supported remote form (`https://`,
     /// `http://`, `git://`), embeds credentials, or is paired with
     /// `repo_token` without using `https://`. Produced during invocation
@@ -359,6 +365,9 @@ impl fmt::Display for RunnerError {
                 "profile_name must already be a unix username starting with a lowercase letter, containing only lowercase letters, digits, '_', or '-', be at most 32 characters, and not be one of the reserved system names root, nobody, daemon, bin, sys, man, or mail"
             ),
             RunnerError::InvalidBaseImage => write!(f, "base_image must not be empty"),
+            RunnerError::InvalidAuditRoot { path } => {
+                write!(f, "audit_root must be an absolute path: {}", path.display())
+            }
             RunnerError::InvalidRepoUrl { message } => write!(f, "repo_url {message}"),
             RunnerError::InvalidCommand => {
                 write!(f, "command must contain at least one argument")

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -33,6 +33,11 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     if spec.base_image.trim().is_empty() || spec.base_image != spec.base_image.trim() {
         return Err(RunnerError::InvalidBaseImage);
     }
+    if !spec.audit_root.is_absolute() {
+        return Err(RunnerError::InvalidAuditRoot {
+            path: spec.audit_root.clone(),
+        });
+    }
     if spec.command.is_empty() || spec.command.iter().any(|arg| arg.is_empty()) {
         return Err(RunnerError::InvalidCommand);
     }
@@ -451,6 +456,22 @@ mod tests {
                 matches!(error, RunnerError::InvalidBaseImage),
                 "expected InvalidBaseImage for {base_image:?}, got {error:?}"
             );
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_relative_audit_roots() {
+        let error = validate_spec(&SessionSpec {
+            audit_root: PathBuf::from("relative/audit-root"),
+            ..test_session_spec()
+        })
+        .expect_err("relative audit roots should be rejected");
+
+        match error {
+            RunnerError::InvalidAuditRoot { path } => {
+                assert_eq!(path, PathBuf::from("relative/audit-root"));
+            }
+            other => panic!("expected InvalidAuditRoot, got {other:?}"),
         }
     }
 

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -7,7 +7,7 @@
 //! configuration layer in the `agentd` crate.
 
 use crate::naming::is_daemon_instance_id;
-use crate::session_paths::{session_home_dir, session_repo_dir};
+use crate::session_paths::{session_home_dir, session_internal_agentd_dir, session_repo_dir};
 use crate::types::{
     BindMount, EnvironmentNameValidationError, MountOverlapError, MountTargetValidationError,
     ProfileNameValidationError, RunnerError, SessionInvocation, SessionSpec,
@@ -279,6 +279,7 @@ fn is_reserved_profile_name(name: &str) -> bool {
 
 fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     let home_dir = session_home_dir(profile_name);
+    let internal_agentd_dir = session_internal_agentd_dir(profile_name);
     let repo_dir = session_repo_dir(profile_name);
     let methodology_dir = Path::new(METHODOLOGY_MOUNT_PATH);
 
@@ -298,6 +299,14 @@ fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     // valid while reserving `/home/{profile}/repo`, its descendants, and its
     // ancestors.
     if target.starts_with(&repo_dir) || repo_dir.starts_with(target) {
+        return true;
+    }
+
+    // agentd's internal audit bridge under HOME is runner-owned. This keeps
+    // operator-declared mounts from colliding with the reserved `.agentd`
+    // subtree while still permitting other supported descendants like
+    // `.claude`.
+    if target.starts_with(&internal_agentd_dir) || internal_agentd_dir.starts_with(target) {
         return true;
     }
 
@@ -804,6 +813,26 @@ mod tests {
             ..test_session_spec()
         })
         .expect("mount targets under home outside runner-managed paths should be accepted");
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_under_internal_agentd_tree() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/var/lib/tesserine/audit"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit"),
+                read_only: false,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets under the internal .agentd tree should be reserved");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/home/site-builder/.agentd/audit"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -28,6 +28,37 @@ fn run_session_with_test_audit_root(
     run_session(spec, invocation)
 }
 
+fn wait_for_session_record_dir(
+    audit_root: &Path,
+    profile_name: &str,
+    timeout: Duration,
+) -> PathBuf {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let profile_root = audit_root.join(profile_name);
+        if let Ok(entries) = fs::read_dir(&profile_root) {
+            let entries = entries
+                .map(|entry| {
+                    entry
+                        .expect("session record entry should be readable")
+                        .path()
+                })
+                .filter(|path| path.is_dir())
+                .collect::<Vec<_>>();
+            if entries.len() == 1 {
+                return entries[0].clone();
+            }
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for session record under {}",
+            profile_root.display()
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
 #[test]
 fn succeeds_without_timeout_and_cleans_up_container() {
     if skip_if_podman_unavailable("succeeds_without_timeout_and_cleans_up_container") {
@@ -714,6 +745,109 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
     assert_eq!(runa_mode, 0o555);
     assert_eq!(workspace_mode, 0o555);
     assert_eq!(artifact_mode, 0o444);
+
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes() {
+    if skip_if_podman_unavailable(
+        "refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes",
+    ) {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-hard-link-run");
+    let image = fixture.build_image();
+    let host_mount = fixture.root.join("host-hard-link");
+    fs::create_dir_all(&host_mount).expect("hard-link host mount should be created");
+    fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
+        .expect("hard-link host mount should permit container writes");
+    let operator_file = host_mount.join("operator-state.txt");
+    fs::write(&operator_file, "operator managed\n").expect("operator file should be written");
+    fs::set_permissions(&operator_file, fs::Permissions::from_mode(0o666))
+        .expect("operator file should be writable");
+
+    let audit_root = fixture.audit_root();
+    let helper_audit_root = audit_root.clone();
+    let helper_operator_file = operator_file.clone();
+    let helper = thread::spawn(move || {
+        let record_dir = wait_for_session_record_dir(
+            &helper_audit_root,
+            "audit-hard-link-run",
+            Duration::from_secs(5),
+        );
+        fs::hard_link(
+            &helper_operator_file,
+            record_dir.join("runa/escaped-hard-link.txt"),
+        )
+        .expect("host should be able to plant a hard-linked audit entry");
+    });
+
+    let outcome = run_session_with_test_audit_root(
+        &audit_root,
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "audit-hard-link-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: audit_root.clone(),
+            mounts: vec![BindMount {
+                source: host_mount.clone(),
+                target: PathBuf::from("/home/audit-hard-link-run/shared"),
+                read_only: false,
+            }],
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "sleep-short".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            timeout: None,
+        },
+    )
+    .expect("session outcome should survive hard-link audit refusal");
+
+    helper.join().expect("hard-link helper should complete");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let operator_mode = fs::metadata(&operator_file)
+        .expect("operator file metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(operator_mode, 0o666);
+
+    let record_dir = fixture.only_session_record_dir();
+    let metadata: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/session.json"))
+            .expect("session metadata should persist"),
+    )
+    .expect("session metadata should be valid json");
+    assert!(
+        metadata.get("end_timestamp").is_none(),
+        "hard-link refusal must leave end_timestamp incomplete"
+    );
+    assert!(
+        metadata.get("outcome").is_none(),
+        "hard-link refusal must leave outcome incomplete"
+    );
+
+    let runa_mode = fs::metadata(record_dir.join("runa"))
+        .expect("runa dir metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(runa_mode, 0o777);
 
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -15,8 +15,24 @@ use agentd_runner::{
     BindMount, ResolvedEnvironmentVariable, SessionInvocation, SessionOutcome, SessionSpec,
     run_session,
 };
+use serde_json::Value;
 
 const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
+
+fn run_session_with_test_audit_root(
+    audit_root: &Path,
+    spec: SessionSpec,
+    invocation: SessionInvocation,
+) -> Result<SessionOutcome, agentd_runner::RunnerError> {
+    unsafe {
+        std::env::set_var("AGENTD_TEST_AUDIT_ROOT", audit_root);
+    }
+    let result = run_session(spec, invocation);
+    unsafe {
+        std::env::remove_var("AGENTD_TEST_AUDIT_ROOT");
+    }
+    result
+}
 
 #[test]
 fn succeeds_without_timeout_and_cleans_up_container() {
@@ -30,7 +46,8 @@ fn succeeds_without_timeout_and_cleans_up_container() {
     let fixture = SessionFixture::new("success-run");
     let image = fixture.build_image();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "success-run".to_string(),
@@ -80,7 +97,8 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
     let fixture = SessionFixture::new("mixed-env-run");
     let image = fixture.build_image();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "mixed-env-run".to_string(),
@@ -129,7 +147,8 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
     let fixture = SessionFixture::new("unset-work-unit-run");
     let image = fixture.build_image_with_agentd_work_unit("stale-from-image");
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "unset-work-unit-run".to_string(),
@@ -170,7 +189,8 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
     let fixture = SessionFixture::new("failure-run");
     let image = fixture.build_image();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "failure-run".to_string(),
@@ -217,7 +237,8 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
     let fixture = SessionFixture::new("failure-run-125");
     let image = fixture.build_image();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "failure-run-125".to_string(),
@@ -265,7 +286,8 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
     );
     let image = fixture.build_image();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "comma-methodology-run".to_string(),
@@ -321,7 +343,8 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
     )
     .expect("read-only host sentinel file should be written");
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "readonly-mount-run".to_string(),
@@ -392,7 +415,8 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             .expect("read-write host mount should permit container writes");
     }
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "readwrite-mount-run".to_string(),
@@ -469,7 +493,8 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
             .expect("nested host mount should permit container writes");
     }
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "nested-home-mount-run".to_string(),
@@ -517,7 +542,8 @@ fn preserves_session_user_access_to_preexisting_home_content() {
     let fixture = SessionFixture::new("preexisting-home-run");
     let image = fixture.build_image_with_preexisting_home_file();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "preexisting-home-run".to_string(),
@@ -545,6 +571,161 @@ fn preserves_session_user_access_to_preexisting_home_content() {
 }
 
 #[test]
+fn preserves_host_audit_record_after_successful_session_teardown() {
+    if skip_if_podman_unavailable("preserves_host_audit_record_after_successful_session_teardown") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-success-run");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "audit-success-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "write-repo-audit-state".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: Some("issue-76".to_string()),
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let record_dir = fixture.only_session_record_dir();
+    assert_eq!(
+        fs::read_to_string(record_dir.join("runa/workspace/session-artifact.txt"))
+            .expect("workspace artifact should persist"),
+        "persisted through repo bridge\n"
+    );
+    assert_eq!(
+        fs::read_to_string(record_dir.join("runa/store/executions/0001.json"))
+            .expect("execution record should persist"),
+        "{\"protocols\":[\"begin\"],\"postconditions\":[\"passed\"]}\n"
+    );
+
+    let metadata: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/session.json"))
+            .expect("session metadata should persist"),
+    )
+    .expect("session metadata should be valid json");
+    assert_eq!(metadata["profile"], "audit-success-run");
+    assert_eq!(metadata["repo_url"], fixture.repo_url());
+    assert_eq!(metadata["work_unit"], "issue-76");
+    assert_eq!(metadata["outcome"], "success");
+    assert_eq!(metadata["exit_code"], 0);
+    assert!(metadata["start_timestamp"].is_string());
+    assert!(metadata["end_timestamp"].is_string());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let runa_mode = fs::metadata(record_dir.join("runa"))
+            .expect("runa dir metadata should exist")
+            .permissions()
+            .mode();
+        let metadata_mode = fs::metadata(record_dir.join("agentd/session.json"))
+            .expect("session metadata permissions should exist")
+            .permissions()
+            .mode();
+        assert_eq!(
+            runa_mode & 0o222,
+            0,
+            "completed runa dir should be read-only"
+        );
+        assert_eq!(
+            metadata_mode & 0o222,
+            0,
+            "completed metadata file should be read-only"
+        );
+    }
+
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
+    if skip_if_podman_unavailable("preserves_failing_audit_trail_for_post_mortem_reconstruction") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-failure-run");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "audit-failure-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "write-failing-audit-trail".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: Some("issue-76".to_string()),
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::WorkFailed { exit_code: 5 });
+
+    let record_dir = fixture.only_session_record_dir();
+    let execution_record = fs::read_to_string(record_dir.join("runa/store/executions/0001.json"))
+        .expect("execution record should persist");
+    assert!(execution_record.contains("\"protocol\":\"begin\""));
+    assert!(execution_record.contains("\"protocol\":\"decompose\""));
+    assert!(execution_record.contains("\"postcondition\":\"passed\""));
+    assert!(execution_record.contains("\"postcondition\":\"failed\""));
+    assert!(execution_record.contains("\"artifact\":\"claim.md\""));
+    assert!(execution_record.contains("\"artifact\":\"plan.md\""));
+    assert_eq!(
+        fs::read_to_string(record_dir.join("runa/workspace/decompose/plan.md"))
+            .expect("workspace artifact should persist"),
+        "draft plan\n"
+    );
+
+    let metadata: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/session.json"))
+            .expect("session metadata should persist"),
+    )
+    .expect("session metadata should be valid json");
+    assert_eq!(metadata["outcome"], "work_failed");
+    assert_eq!(metadata["exit_code"], 5);
+    assert!(metadata["end_timestamp"].is_string());
+
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
 fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
     if skip_if_podman_unavailable("times_out_when_a_timeout_is_provided_and_cleans_up_container") {
         return;
@@ -556,7 +737,8 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
     let fixture = SessionFixture::new("timeout-run");
     let image = fixture.build_image();
 
-    let outcome = run_session(
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
             profile_name: "timeout-run".to_string(),
@@ -600,11 +782,13 @@ fn releases_session_secret_after_container_reaches_running_state() {
 
     let fixture = SessionFixture::new("running-secret-run");
     let image = fixture.build_image();
+    let audit_root = fixture.audit_root();
     let methodology_dir = fixture.methodology_dir();
     let repo_url = fixture.repo_url();
 
     let session = thread::spawn(move || {
-        run_session(
+        run_session_with_test_audit_root(
+            &audit_root,
             SessionSpec {
                 daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
                 profile_name: "running-secret-run".to_string(),
@@ -687,6 +871,30 @@ impl SessionFixture {
 
     fn methodology_dir(&self) -> PathBuf {
         self.root.join("methodology")
+    }
+
+    fn audit_root(&self) -> PathBuf {
+        self.root.join("audit-root")
+    }
+
+    fn only_session_record_dir(&self) -> PathBuf {
+        let profile_root = self.audit_root().join(&self.profile_name);
+        let entries = fs::read_dir(&profile_root)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", profile_root.display()))
+            .map(|entry| {
+                entry
+                    .expect("session record entry should be readable")
+                    .path()
+            })
+            .filter(|path| path.is_dir())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected exactly one session record under {}",
+            profile_root.display()
+        );
+        entries[0].clone()
     }
 
     fn repo_url(&self) -> String {
@@ -1185,6 +1393,25 @@ case "$command_name" in
             printf 'session write succeeded\n' > "${HOME}/.preexisting"
             [ "$(cat "${HOME}/.preexisting")" = "session write succeeded" ]
             exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-repo-audit-state" ]; then
+            [ -L "${HOME}/repo/.runa" ]
+            [ "$(readlink "${HOME}/repo/.runa")" = "${HOME}/.agentd/audit/runa" ]
+            mkdir -p "${HOME}/repo/.runa/workspace" "${HOME}/repo/.runa/store/executions"
+            printf 'persisted through repo bridge\n' > "${HOME}/repo/.runa/workspace/session-artifact.txt"
+            printf '{"protocols":["begin"],"postconditions":["passed"]}\n' > "${HOME}/repo/.runa/store/executions/0001.json"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-failing-audit-trail" ]; then
+            [ -L "${HOME}/repo/.runa" ]
+            mkdir -p "${HOME}/repo/.runa/workspace/decompose" "${HOME}/repo/.runa/store/executions"
+            printf 'draft plan\n' > "${HOME}/repo/.runa/workspace/decompose/plan.md"
+            cat > "${HOME}/repo/.runa/store/executions/0001.json" <<'EOF'
+{"events":[{"protocol":"begin","artifact":"claim.md","postcondition":"passed"},{"protocol":"decompose","artifact":"plan.md","postcondition":"failed"}]}
+EOF
+            exit 5
         fi
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "fail" ]; then

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -21,17 +21,11 @@ const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
 
 fn run_session_with_test_audit_root(
     audit_root: &Path,
-    spec: SessionSpec,
+    mut spec: SessionSpec,
     invocation: SessionInvocation,
 ) -> Result<SessionOutcome, agentd_runner::RunnerError> {
-    unsafe {
-        std::env::set_var("AGENTD_TEST_AUDIT_ROOT", audit_root);
-    }
-    let result = run_session(spec, invocation);
-    unsafe {
-        std::env::remove_var("AGENTD_TEST_AUDIT_ROOT");
-    }
-    result
+    spec.audit_root = audit_root.to_path_buf();
+    run_session(spec, invocation)
 }
 
 #[test]
@@ -53,6 +47,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             profile_name: "success-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec![
                 "site-builder".to_string(),
@@ -104,6 +99,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             profile_name: "mixed-env-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -154,6 +150,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             profile_name: "unset-work-unit-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -196,6 +193,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             profile_name: "failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -244,6 +242,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             profile_name: "failure-run-125".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -293,6 +292,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             profile_name: "comma-methodology-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -350,6 +350,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
             profile_name: "readonly-mount-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readonly-mount-run/.claude"),
@@ -422,6 +423,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             profile_name: "readwrite-mount-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readwrite-mount-run/.runa"),
@@ -500,6 +502,7 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
             profile_name: "nested-home-mount-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/nested-home-mount-run/.config/claude"),
@@ -549,6 +552,7 @@ fn preserves_session_user_access_to_preexisting_home_content() {
             profile_name: "preexisting-home-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -589,6 +593,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
             profile_name: "audit-success-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -679,6 +684,7 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
             profile_name: "audit-failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -744,6 +750,7 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             profile_name: "timeout-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
             mounts: Vec::new(),
             command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -794,6 +801,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 profile_name: "running-secret-run".to_string(),
                 base_image: image,
                 methodology_dir,
+                audit_root: audit_root.clone(),
                 mounts: Vec::new(),
                 command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
-#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -405,16 +405,10 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
     fs::create_dir_all(&host_mount).expect("read-write host mount should be created");
     fs::write(host_mount.join("sentinel.txt"), "host sentinel\n")
         .expect("read-write host sentinel should be written");
-    #[cfg(unix)]
     let sentinel_metadata_before =
         fs::metadata(host_mount.join("sentinel.txt")).expect("sentinel metadata should exist");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
-            .expect("read-write host mount should permit container writes");
-    }
+    fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
+        .expect("read-write host mount should permit container writes");
 
     let outcome = run_session_with_test_audit_root(
         &fixture.audit_root(),
@@ -455,21 +449,18 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             .expect("read-write host sentinel should remain readable"),
         "host sentinel\n"
     );
-    #[cfg(unix)]
-    {
-        let sentinel_metadata_after =
-            fs::metadata(host_mount.join("sentinel.txt")).expect("sentinel metadata should exist");
-        assert_eq!(
-            sentinel_metadata_after.uid(),
-            sentinel_metadata_before.uid(),
-            "runner setup must not re-own host-backed files under home mounts"
-        );
-        assert_eq!(
-            sentinel_metadata_after.gid(),
-            sentinel_metadata_before.gid(),
-            "runner setup must not re-own host-backed files under home mounts"
-        );
-    }
+    let sentinel_metadata_after =
+        fs::metadata(host_mount.join("sentinel.txt")).expect("sentinel metadata should exist");
+    assert_eq!(
+        sentinel_metadata_after.uid(),
+        sentinel_metadata_before.uid(),
+        "runner setup must not re-own host-backed files under home mounts"
+    );
+    assert_eq!(
+        sentinel_metadata_after.gid(),
+        sentinel_metadata_before.gid(),
+        "runner setup must not re-own host-backed files under home mounts"
+    );
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -487,13 +478,8 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
     let image = fixture.build_image();
     let host_mount = fixture.root.join("host-nested-claude");
     fs::create_dir_all(&host_mount).expect("nested host mount should be created");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
-            .expect("nested host mount should permit container writes");
-    }
+    fs::set_permissions(&host_mount, fs::Permissions::from_mode(0o777))
+        .expect("nested host mount should permit container writes");
 
     let outcome = run_session_with_test_audit_root(
         &fixture.audit_root(),
@@ -637,29 +623,97 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
     assert!(metadata["start_timestamp"].is_string());
     assert!(metadata["end_timestamp"].is_string());
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
+    let runa_mode = fs::metadata(record_dir.join("runa"))
+        .expect("runa dir metadata should exist")
+        .permissions()
+        .mode();
+    let metadata_mode = fs::metadata(record_dir.join("agentd/session.json"))
+        .expect("session metadata permissions should exist")
+        .permissions()
+        .mode();
+    assert_eq!(
+        runa_mode & 0o222,
+        0,
+        "completed runa dir should be read-only"
+    );
+    assert_eq!(
+        metadata_mode & 0o222,
+        0,
+        "completed metadata file should be read-only"
+    );
 
-        let runa_mode = fs::metadata(record_dir.join("runa"))
-            .expect("runa dir metadata should exist")
-            .permissions()
-            .mode();
-        let metadata_mode = fs::metadata(record_dir.join("agentd/session.json"))
-            .expect("session metadata permissions should exist")
-            .permissions()
-            .mode();
-        assert_eq!(
-            runa_mode & 0o222,
-            0,
-            "completed runa dir should be read-only"
-        );
-        assert_eq!(
-            metadata_mode & 0o222,
-            0,
-            "completed metadata file should be read-only"
-        );
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn preserves_host_readability_for_restrictive_container_written_audit_entries_after_teardown() {
+    if skip_if_podman_unavailable(
+        "preserves_host_readability_for_restrictive_container_written_audit_entries_after_teardown",
+    ) {
+        return;
     }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-restrictive-modes-run");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "audit-restrictive-modes-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "write-restrictive-repo-audit-state".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: Some("issue-76".to_string()),
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let record_dir = fixture.only_session_record_dir();
+    let artifact_path = record_dir.join("runa/workspace/private/session-artifact.txt");
+    assert_eq!(
+        fs::read_to_string(&artifact_path)
+            .expect("container-written restrictive audit artifact should remain host-readable"),
+        "host should still read this after teardown\n"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+
+    let runa_mode = fs::metadata(record_dir.join("runa"))
+        .expect("runa dir metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    let workspace_mode = fs::metadata(record_dir.join("runa/workspace/private"))
+        .expect("workspace dir metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    let artifact_mode = fs::metadata(&artifact_path)
+        .expect("artifact metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(runa_mode, 0o555);
+    assert_eq!(workspace_mode, 0o555);
+    assert_eq!(artifact_mode, 0o444);
 
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
@@ -1409,6 +1463,17 @@ case "$command_name" in
             mkdir -p "${HOME}/repo/.runa/workspace" "${HOME}/repo/.runa/store/executions"
             printf 'persisted through repo bridge\n' > "${HOME}/repo/.runa/workspace/session-artifact.txt"
             printf '{"protocols":["begin"],"postconditions":["passed"]}\n' > "${HOME}/repo/.runa/store/executions/0001.json"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-restrictive-repo-audit-state" ]; then
+            [ -L "${HOME}/repo/.runa" ]
+            mkdir -p "${HOME}/repo/.runa/workspace/private" "${HOME}/repo/.runa/store/executions"
+            chmod 0700 "${HOME}/repo/.runa/workspace/private" "${HOME}/repo/.runa/store" "${HOME}/repo/.runa/store/executions"
+            printf 'host should still read this after teardown\n' > "${HOME}/repo/.runa/workspace/private/session-artifact.txt"
+            chmod 0600 "${HOME}/repo/.runa/workspace/private/session-artifact.txt"
+            printf '{"protocols":["begin"],"postconditions":["passed"]}\n' > "${HOME}/repo/.runa/store/executions/0001.json"
+            chmod 0600 "${HOME}/repo/.runa/store/executions/0001.json"
             exit 0
         fi
 

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -11,6 +11,7 @@ agentd-runner.workspace = true
 agentd-scheduler.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 croner = "3.0.1"
+getrandom = "0.4.2"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+# Linux-only build enforcement lives in crates/agentd-runner/build.rs.
 agentd-runner.workspace = true
 agentd-scheduler.workspace = true
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/agentd/src/audit_root.rs
+++ b/crates/agentd/src/audit_root.rs
@@ -1,0 +1,36 @@
+use std::fs::{self, OpenOptions};
+use std::path::PathBuf;
+
+use crate::config::{ConfigError, DaemonConfig};
+
+pub(crate) fn prepare_audit_root(config: &DaemonConfig) -> Result<PathBuf, ConfigError> {
+    let audit_root = config.resolve_audit_root()?;
+    fs::create_dir_all(&audit_root).map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+
+    let probe_name = format!(
+        ".agentd-audit-root-probe-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after the unix epoch")
+            .as_nanos()
+    );
+    let probe_path = audit_root.join(probe_name);
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+        .map_err(|error| ConfigError::AuditRootNotWritable {
+            path: audit_root.clone(),
+            error,
+        })?;
+    fs::remove_file(&probe_path).map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+
+    Ok(audit_root)
+}

--- a/crates/agentd/src/audit_root.rs
+++ b/crates/agentd/src/audit_root.rs
@@ -1,5 +1,8 @@
 use std::fs::{self, OpenOptions};
+use std::io;
 use std::path::PathBuf;
+
+use getrandom::fill as fill_random_bytes;
 
 use crate::config::{ConfigError, DaemonConfig};
 
@@ -10,14 +13,11 @@ pub(crate) fn prepare_audit_root(config: &DaemonConfig) -> Result<PathBuf, Confi
         error,
     })?;
 
-    let probe_name = format!(
-        ".agentd-audit-root-probe-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time should be after the unix epoch")
-            .as_nanos()
-    );
+    let probe_name =
+        audit_root_probe_name().map_err(|error| ConfigError::AuditRootNotWritable {
+            path: audit_root.clone(),
+            error,
+        })?;
     let probe_path = audit_root.join(probe_name);
     OpenOptions::new()
         .write(true)
@@ -33,4 +33,73 @@ pub(crate) fn prepare_audit_root(config: &DaemonConfig) -> Result<PathBuf, Confi
     })?;
 
     Ok(audit_root)
+}
+
+fn audit_root_probe_name() -> io::Result<String> {
+    Ok(format!(
+        ".agentd-audit-root-probe-{}",
+        lower_hex_random_suffix_with(|bytes| fill_random_bytes(bytes).map_err(io::Error::other))?
+    ))
+}
+
+fn lower_hex_random_suffix_with<F>(fill_random: F) -> io::Result<String>
+where
+    F: FnOnce(&mut [u8]) -> io::Result<()>,
+{
+    let mut bytes = [0_u8; 8];
+    fill_random(&mut bytes)?;
+    Ok(hex_encode(&bytes))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+        encoded.push(HEX_DIGITS[(byte & 0x0f) as usize] as char);
+    }
+
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lower_hex_random_suffix_with;
+
+    #[test]
+    fn prepare_audit_root_does_not_derive_probe_names_from_process_id_or_system_time() {
+        let source = include_str!("audit_root.rs");
+        let implementation_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("audit_root.rs should contain implementation before tests");
+
+        assert!(
+            !implementation_source.contains("std::process::id()"),
+            "audit-root probe names must not derive uniqueness from process id"
+        );
+        assert!(
+            !implementation_source.contains("SystemTime::now()"),
+            "audit-root probe names must not derive uniqueness from system time"
+        );
+    }
+
+    #[test]
+    fn lower_hex_random_suffix_encodes_eight_random_bytes_as_sixteen_lower_hex_characters() {
+        let suffix = lower_hex_random_suffix_with(|bytes| {
+            bytes.copy_from_slice(&[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+            Ok(())
+        })
+        .expect("probe suffix generation should succeed");
+
+        assert_eq!(suffix, "0123456789abcdef");
+        assert_eq!(suffix.len(), 16);
+        assert!(
+            suffix
+                .bytes()
+                .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f')),
+            "probe suffix should be lowercase hex: {suffix}"
+        );
+    }
 }

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -410,6 +410,7 @@ impl CredentialConfig {
 pub struct DaemonConfig {
     socket_path: PathBuf,
     pid_file: PathBuf,
+    audit_root: Option<PathBuf>,
 }
 
 impl DaemonConfig {
@@ -433,6 +434,41 @@ impl DaemonConfig {
     /// Filesystem path for the daemon's PID file and advisory lock.
     pub fn pid_file(&self) -> &Path {
         &self.pid_file
+    }
+
+    /// Resolved host-side root for persistent session audit records.
+    ///
+    /// When `daemon.audit_root` is configured, that value is used. Otherwise
+    /// agentd defaults to `$XDG_STATE_HOME/tesserine/audit`, falling back to
+    /// `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset.
+    pub fn resolve_audit_root(&self) -> Result<PathBuf, ConfigError> {
+        if let Some(path) = &self.audit_root {
+            if path.is_absolute() {
+                return Ok(path.clone());
+            }
+
+            return Err(ConfigError::RelativeDaemonAuditRootPath { path: path.clone() });
+        }
+
+        if let Some(path) = std::env::var_os("XDG_STATE_HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+        {
+            if path.is_absolute() {
+                return Ok(path.join("tesserine/audit"));
+            }
+        }
+
+        if let Some(path) = std::env::var_os("HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+        {
+            if path.is_absolute() {
+                return Ok(path.join(".local/state/tesserine/audit"));
+            }
+        }
+
+        Err(ConfigError::MissingDaemonAuditRootDefault)
     }
 
     /// Stable daemon-instance identifier derived from the configured runtime
@@ -464,6 +500,10 @@ impl DaemonConfig {
         Ok(Self {
             socket_path: resolve_config_path(base_dir, &raw.socket_path),
             pid_file: resolve_config_path(base_dir, &raw.pid_file),
+            audit_root: raw
+                .audit_root
+                .as_deref()
+                .map(|path| resolve_config_path(base_dir, path)),
         })
     }
 
@@ -507,6 +547,15 @@ pub enum ConfigError {
     },
     /// Deriving the daemon instance id requires absolute daemon runtime paths.
     RelativeDaemonRuntimePath { field: &'static str, path: PathBuf },
+    /// Resolving the daemon audit root requires an absolute configured path.
+    RelativeDaemonAuditRootPath { path: PathBuf },
+    /// No usable default audit-root environment was available.
+    MissingDaemonAuditRootDefault,
+    /// The resolved daemon audit root could not be created or probed.
+    AuditRootNotWritable {
+        path: PathBuf,
+        error: std::io::Error,
+    },
     /// The `command` array is empty for a profile.
     EmptyCommand { profile: String },
     /// A profile declares a default repository URL the runner would reject.
@@ -602,6 +651,24 @@ impl fmt::Display for ConfigError {
                     path.display()
                 )
             }
+            ConfigError::RelativeDaemonAuditRootPath { path } => {
+                write!(
+                    f,
+                    "daemon audit root must be absolute before use: {}",
+                    path.display()
+                )
+            }
+            ConfigError::MissingDaemonAuditRootDefault => write!(
+                f,
+                "daemon audit root could not be resolved; set absolute XDG_STATE_HOME, set absolute HOME, or configure daemon.audit_root explicitly"
+            ),
+            ConfigError::AuditRootNotWritable { path, error } => {
+                write!(
+                    f,
+                    "daemon audit root is not writable: {} ({error})",
+                    path.display()
+                )
+            }
             ConfigError::EmptyCommand { profile } => {
                 write!(f, "profile '{profile}' must define a non-empty command")
             }
@@ -661,6 +728,7 @@ impl std::error::Error for ConfigError {
         match self {
             ConfigError::Io(error) => Some(error),
             ConfigError::Parse(error) => Some(error),
+            ConfigError::AuditRootNotWritable { error, .. } => Some(error),
             _ => None,
         }
     }
@@ -703,6 +771,7 @@ struct RawDaemonConfig {
     socket_path: String,
     #[serde(default = "default_daemon_pid_file")]
     pid_file: String,
+    audit_root: Option<String>,
 }
 
 impl Default for RawDaemonConfig {
@@ -710,6 +779,7 @@ impl Default for RawDaemonConfig {
         Self {
             socket_path: default_daemon_socket_path(),
             pid_file: default_daemon_pid_file(),
+            audit_root: None,
         }
     }
 }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -16,6 +16,7 @@ use agentd_runner::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::audit_root::prepare_audit_root;
 use crate::config::{Config, ConfigError, DaemonConfig};
 use crate::scheduler::{join_scheduler_thread, spawn_scheduler_thread};
 use crate::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
@@ -246,6 +247,7 @@ pub fn run_daemon_until_shutdown(
     shutdown: Arc<AtomicBool>,
 ) -> Result<(), DaemonError> {
     let daemon_instance_id = config.daemon().daemon_instance_id()?;
+    let _audit_root = prepare_audit_root(config.daemon())?;
     run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
         reconcile_startup_resources(&daemon_instance_id)
     })

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -5,6 +5,7 @@ use agentd_runner::{
     run_session,
 };
 
+use crate::audit_root::prepare_audit_root;
 use crate::config::{Config, ConfigError};
 
 /// Parameters for a daemon run request.
@@ -106,6 +107,7 @@ pub fn dispatch_run(
                 profile: request.profile.clone(),
             })?;
     let daemon_instance_id = config.daemon().daemon_instance_id()?;
+    let audit_root = prepare_audit_root(config.daemon())?;
 
     let environment = profile
         .credentials()
@@ -138,6 +140,7 @@ pub fn dispatch_run(
                 profile_name: profile.name().to_string(),
                 base_image: profile.base_image().to_string(),
                 methodology_dir: profile.methodology_dir().to_path_buf(),
+                audit_root,
                 mounts: profile
                     .mounts()
                     .iter()

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -4,6 +4,7 @@
 //! binary crate (`main.rs`) assembles runner and scheduler from the parsed
 //! configuration and starts the daemon.
 
+mod audit_root;
 pub mod config;
 pub mod daemon;
 pub mod dispatch;

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -1,8 +1,14 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::{Mutex, OnceLock};
 
 use agentd::config::{Config, ConfigError, DaemonConfig};
 use agentd_runner::MountTargetValidationError;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -518,6 +524,170 @@ command = ["site-builder", "exec"]
     assert_eq!(
         config.daemon().pid_file(),
         Path::new("/tmp/agentd-test.pid")
+    );
+}
+
+#[test]
+fn parses_explicit_daemon_audit_root() {
+    let config = Config::from_str(
+        r#"
+[daemon]
+socket_path = "/tmp/agentd-test.sock"
+pid_file = "/tmp/agentd-test.pid"
+audit_root = "/srv/agentd/audit"
+
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse explicit daemon paths");
+
+    assert_eq!(
+        config
+            .daemon()
+            .resolve_audit_root()
+            .expect("audit root should resolve"),
+        Path::new("/srv/agentd/audit")
+    );
+}
+
+#[test]
+fn loading_daemon_config_resolves_relative_audit_root_from_file_location() {
+    let path = write_temp_config(
+        "daemon-only-relative-audit-root",
+        r#"
+[daemon]
+socket_path = "runtime/agentd.sock"
+pid_file = "runtime/agentd.pid"
+audit_root = "state/audit"
+
+[[profiles]]
+name = "Site-Builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+"#,
+    );
+
+    let config = DaemonConfig::load(&path).expect("daemon config should parse");
+    let base_dir = path
+        .parent()
+        .expect("config file should have a parent directory");
+
+    assert_eq!(
+        config
+            .resolve_audit_root()
+            .expect("audit root should resolve"),
+        base_dir.join("state/audit")
+    );
+}
+
+#[test]
+fn daemon_audit_root_uses_xdg_state_home_before_home_fallback() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("XDG_STATE_HOME", "/tmp/xdg-state-home");
+        std::env::set_var("HOME", "/tmp/home-fallback");
+    }
+
+    let config = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .daemon()
+            .resolve_audit_root()
+            .expect("audit root should resolve"),
+        Path::new("/tmp/xdg-state-home/tesserine/audit")
+    );
+
+    unsafe {
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::remove_var("HOME");
+    }
+}
+
+#[test]
+fn daemon_audit_root_falls_back_to_home_local_state_when_xdg_state_home_is_unset() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::set_var("HOME", "/tmp/home-fallback");
+    }
+
+    let config = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(
+        config
+            .daemon()
+            .resolve_audit_root()
+            .expect("audit root should resolve"),
+        Path::new("/tmp/home-fallback/.local/state/tesserine/audit")
+    );
+
+    unsafe {
+        std::env::remove_var("HOME");
+    }
+}
+
+#[test]
+fn daemon_audit_root_requires_a_usable_default_when_not_explicitly_configured() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::remove_var("HOME");
+    }
+
+    let config = Config::from_str(
+        r#"
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+command = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse");
+
+    let error = config
+        .daemon()
+        .resolve_audit_root()
+        .expect_err("missing environment-backed audit root should fail");
+
+    assert!(
+        error.to_string().contains("audit root"),
+        "expected audit-root error, got {error}"
     );
 }
 

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::{fs, panic};
 
 use agentd::config::{Config, ConfigError};
 use agentd::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
@@ -11,6 +12,17 @@ use agentd_runner::{
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after the unix epoch")
+            .as_nanos()
+    ))
 }
 
 struct RecordingExecutor {
@@ -61,6 +73,27 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
+
+command = ["site-builder", "exec"]
+
+[[profiles.credentials]]
+name = "GITHUB_TOKEN"
+source = "AGENTD_GITHUB_TOKEN"
+"#
+    ))
+    .expect("config should parse")
+}
+
+fn config_with_audit_root(audit_root: &str) -> Config {
+    Config::from_str(&format!(
+        r#"
+[daemon]
+audit_root = "{audit_root}"
+
+[[profiles]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
 
 command = ["site-builder", "exec"]
 
@@ -138,6 +171,13 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
             .expect("daemon instance id should resolve")
     );
     assert_eq!(
+        spec.audit_root,
+        config
+            .daemon()
+            .resolve_audit_root()
+            .expect("audit root should resolve")
+    );
+    assert_eq!(
         spec.command,
         vec!["site-builder".to_string(), "exec".to_string()]
     );
@@ -156,6 +196,95 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
         std::env::remove_var("SITE_BUILDER_REPO_TOKEN");
+    }
+}
+
+#[test]
+fn dispatch_run_forwards_resolved_audit_root_into_session_spec() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let audit_root = unique_temp_dir("agentd-dispatch-audit-root");
+    let config = config_with_audit_root(
+        audit_root
+            .to_str()
+            .expect("temporary audit root should be valid utf-8"),
+    );
+    let request = RunRequest {
+        profile: "site-builder".to_string(),
+        repo_url: "https://example.com/repo.git".to_string(),
+        work_unit: None,
+    };
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    let result = panic::catch_unwind(|| {
+        dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
+
+        let state = state.lock().expect("recording state should lock");
+        let spec = state
+            .last_spec
+            .as_ref()
+            .expect("executor should receive spec");
+
+        assert_eq!(spec.audit_root, audit_root);
+    });
+
+    let _ = fs::remove_dir_all(&audit_root);
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+
+    result.expect("dispatch assertions should succeed");
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_run_rejects_an_unwritable_audit_root_before_session_execution() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let audit_root = unique_temp_dir("agentd-dispatch-unwritable-audit-root");
+    fs::create_dir_all(&audit_root).expect("audit root should be created");
+    fs::set_permissions(&audit_root, fs::Permissions::from_mode(0o555))
+        .expect("audit root should become read-only");
+
+    let config = config_with_audit_root(
+        audit_root
+            .to_str()
+            .expect("temporary audit root should be valid utf-8"),
+    );
+    let request = RunRequest {
+        profile: "site-builder".to_string(),
+        repo_url: "https://example.com/repo.git".to_string(),
+        work_unit: None,
+    };
+    let (executor, _state) =
+        RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    let error = dispatch_run(&config, &request, &executor)
+        .expect_err("unwritable audit root should fail dispatch");
+
+    match error {
+        DispatchError::Config(ConfigError::AuditRootNotWritable { path, .. }) => {
+            assert_eq!(path, audit_root);
+        }
+        other => panic!("expected audit-root config error, got {other:?}"),
+    }
+
+    fs::set_permissions(&audit_root, fs::Permissions::from_mode(0o755))
+        .expect("audit root should become writable again");
+    fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
     }
 }
 

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -120,3 +120,38 @@ fn workspace_docs_declare_same_build_socket_policy() {
         "architecture should declare the same-build daemon/CLI requirement"
     );
 }
+
+#[test]
+fn workspace_docs_describe_persistent_audit_record_contract() {
+    let readme = read_workspace_file("README.md");
+    let architecture = read_workspace_file("ARCHITECTURE.md");
+
+    assert!(
+        readme.contains("/var/lib/tesserine/audit"),
+        "README should describe the persistent audit record root"
+    );
+    assert!(
+        architecture.contains("/var/lib/tesserine/audit"),
+        "architecture should describe the persistent audit record root"
+    );
+    assert!(
+        architecture.contains("artifacts_dir"),
+        "architecture should document the artifacts_dir audit scope boundary"
+    );
+    assert!(
+        architecture.contains("accumulate") && architecture.contains("indefinitely"),
+        "architecture should document the lack of retention policy"
+    );
+    assert!(
+        architecture.contains("single-tenant"),
+        "architecture should document the host security assumption"
+    );
+    assert!(
+        architecture.contains("incomplete"),
+        "architecture should explain incomplete session records"
+    );
+    assert!(
+        architecture.contains("must not contain a `.runa` entry"),
+        "architecture should describe the repo-root .runa contract"
+    );
+}

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -151,6 +151,11 @@ fn workspace_docs_describe_persistent_audit_record_contract() {
         "architecture should explain incomplete session records"
     );
     assert!(
+        architecture.contains("runner.lifecycle_failure")
+            && architecture.contains("session audit finalization"),
+        "architecture should explain tracing-based disambiguation for incomplete session records"
+    );
+    assert!(
         architecture.contains("must not contain a `.runa` entry"),
         "architecture should describe the repo-root .runa contract"
     );

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -1,6 +1,14 @@
 # Static profile registry for agentd.
 # A profile can carry its own default repo and optional schedule.
 
+#[daemon]
+# Optional explicit host path for persistent audit records. Rootless installs
+# default to $XDG_STATE_HOME/tesserine/audit, falling back to
+# $HOME/.local/state/tesserine/audit when XDG_STATE_HOME is unset.
+# Root-owned system installs should typically point this at
+# /var/lib/tesserine/audit.
+#audit_root = "/var/lib/tesserine/audit"
+
 [[profiles]]
 # Stable operator-facing profile name used for lookup and container identity.
 name = "site-builder"


### PR DESCRIPTION
## Summary

- persist each session's audit record on the host under `/var/lib/tesserine/audit/<profile>/<session_id>/` so runa state and agentd metadata survive container teardown
- bridge repo-root `.runa` into runner-managed audit storage and seal completed records read-only for post-mortem inspection
- document the new audit contract in `README.md` and `ARCHITECTURE.md`, including scope boundaries and host-operational assumptions

## Changes

- add runner audit-record allocation/finalization in `crates/agentd-runner/src/audit.rs`, including `agentd/session.json`, outcome finalization, and host-side sealing
- reserve `/home/{profile}/.agentd`, add the internal audit mount, and create the repo-root `.runa -> /home/{profile}/.agentd/audit/runa` bridge during container setup
- reject cloned repos that already contain a repo-root `.runa` entry because that path is now runner-reserved
- extend fake-podman, unit, workspace-contract, and real Podman integration coverage for successful preservation, failing-session reconstructability, and sealed completed records
- update architecture and operator docs to describe the host layout, lifecycle, partial-record state, retention posture, and security assumptions

## Design Decisions

- internal audit `runa/` mount uses `relabel=shared`; operator-declared mounts still do not relabel. The audit mount is runner-owned like the methodology mount, and this relabeling is required for correctness on SELinux-enforcing Fedora CoreOS hosts.
- `/home/{profile}/.agentd` and `/home/{profile}/.agentd/audit` stay on the session-user ownership path; the mounted `runa` leaf is runner-owned host storage. The host `runa/` subtree is writable during the active session and sealed read-only afterward.
- `agentd/session.json` is written at session start and finalized after execution. Missing `end_timestamp` and `outcome` means the record is incomplete because `agentd` stopped before finalization.
- cloned repos must not contain a repo-root `.runa` entry. agentd now reserves that path for the persistent audit bridge.
- audit coverage is intentionally scoped to the repo-root `.runa/` tree. This always captures `.runa/store/` and the default `.runa/workspace/`, but a methodology that sets `artifacts_dir` outside `.runa/` places that workspace outside the audit mount.
- retention is intentionally out of scope. Records accumulate indefinitely under `/var/lib/tesserine/audit/` until operators prune them.
- the active-session permission model assumes a single-tenant host. While a session is running, the mounted `runa/` subtree is opened with host mode `0o777`, so multi-tenant deployments would need a different permission model.

## Issue(s)

Closes #76

## Test Plan

- `cargo fmt --all --check`
- `cargo test -p agentd-runner`
- `cargo test -p agentd`
- `cargo clippy --workspace --all-targets -- -D warnings`
