### PR TITLE
feat(invocation): support per-invocation work input

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,7 +130,9 @@ The runner prepares the execution environment:
 5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, or `gosu` are not supported.
 6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{profile}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
 7. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets, the runner-owned audit leaf `/home/{username}/.agentd/audit/runa`, and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself, `/home/{username}/.agentd` plus its descendants, and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
-8. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
+8. When manual invocation includes operator input, reads the active methodology's `manifest.toml` plus `schemas/<type>.schema.json` on the host, validates the input there, stages the final JSON under a runner-managed bind mount at `/agentd/invocation-input`, and rejects unsupported request canonical versions before any container is created. In `v0.1.x`, request-text input supports canonical request version `1.0.0` only, keyed by `x-tesserine-canonical.version`.
+9. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
+10. When staged invocation input is present, copies it into `.runa/workspace/<type>/<id>.json` before dropping privileges and launching the profile command.
 
 ### Phase 3: Execution (`agentd-runner`)
 
@@ -170,6 +172,7 @@ agentd runs sessions in ephemeral Podman containers so agents remain separated f
 | Mount or Injection | Purpose | Need Served |
 |---|---|---|
 | Read-only methodology directory | Expose the configured methodology manifest and protocol assets without allowing mutation | Context |
+| Read-only invocation input mount at `/agentd/invocation-input` | Carry validated operator-supplied JSON into the container so the runner can materialize it in `.runa/workspace` before the profile command starts | Mission |
 | Runner-owned audit bind mount at `/home/{username}/.agentd/audit/runa` | Persist runa state on the host while keeping agentd metadata distinct in the same session record | Context, Mission |
 | Profile-declared bind mounts | Expose host-managed state such as subscription auth or persistent artifact storage with per-mount read-only vs read-write policy | Context, Credentials |
 | Credentials | Authenticate to external systems without baking secrets into images | Credentials |
@@ -179,6 +182,7 @@ From inside the environment, an agent should see:
 - identity-related environment variables
 - `$HOME` set to `/home/{username}`
 - a read-only methodology mount rooted at `manifest.toml`
+- a read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied
 - a runner-managed audit bridge at `/home/{username}/repo/.runa -> /home/{username}/.agentd/audit/runa`
 - any additional bind mounts declared by the selected profile
 - a fresh writable repository checkout at `/home/{username}/repo`
@@ -195,6 +199,11 @@ consumer of this mechanism; persistent audit storage in `#76` builds on the
 same path with read-write mounts. Additional mounts are not relabelled; on
 SELinux-enabled hosts, operators must pre-label those host paths with a
 container-compatible context.
+
+The invocation-input mount is runner-owned, not operator-owned. Its target
+`/agentd/invocation-input` is reserved alongside `/agentd/methodology`, so
+profile-declared mounts cannot collide with the pre-command input-materialization
+path.
 
 The internal audit mount is different from operator-declared mounts. It is
 runner-owned, not operator-owned, and agentd applies `relabel=shared` to that

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,10 +226,8 @@ layout:
   directory
 
 Coverage is intentionally scoped to the repo-root `.runa/` tree. That captures
-`runa`'s non-configurable `.runa/store/` and the default `.runa/workspace/`.
-If a methodology sets `artifacts_dir` outside `.runa/` in `.runa/config.toml`,
-that workspace path is outside the audit mount and will not be preserved.
-Groundwork uses the default `.runa/workspace/` layout and is fully covered.
+`runa`'s non-configurable `.runa/store/` and `.runa/workspace/`, so persisted
+runtime state stays inside the audit mount.
 
 Retention is intentionally out of scope here. Audit records accumulate
 indefinitely under the resolved audit root; pruning and retention policy are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
+- `agentd run` now accepts one per-invocation work surface without profile edits: `--work-unit <id>`, `--request <text>`, or `--artifact-type <type> --artifact-file <path>`. Request text is synthesized into `.runa/workspace/request/operator-input.json`, while artifact-file input places validated JSON at `.runa/workspace/<type>/<file-stem>.json`.
 - `agentd-runner` now declares its real platform contract at compile time: the crate targets Linux only, and downstream non-Linux builds now fail explicitly instead of compiling dead fallback code into a non-functional binary.
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
 - Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completed session outcomes now remain caller-visible when only audit finalization fails after teardown cleanup succeeds.
 - Audit sealing now refuses multi-linked entries before rewriting metadata, preventing host file mode changes through hard-linked audit aliases.
 - Allocation rollback failure now preserves the incomplete audit-record signal instead of finalizing `agentd/session.json` after leaked cleanup state.
+- Manual request-text input now rejects methodologies that do not declare canonical request support or that advertise an unsupported canonical request version, instead of synthesizing unchecked workspace content.
 
 ## [0.1.0] — 2026-04-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "agentd-scheduler",
  "clap",
  "croner",
- "getrandom",
+ "getrandom 0.4.2",
  "libc",
  "serde",
  "serde_json",
@@ -25,7 +25,8 @@ dependencies = [
 name = "agentd-runner"
 version = "0.1.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
+ "jsonschema",
  "serde",
  "serde_json",
  "time",
@@ -43,6 +44,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +65,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -123,6 +144,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,10 +174,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
@@ -290,6 +338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +394,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,10 +430,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -374,6 +470,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,13 +497,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -402,7 +528,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -410,6 +536,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -442,6 +573,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +665,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -488,6 +722,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +765,21 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -527,6 +803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,10 +818,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -563,10 +915,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -604,9 +1000,73 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-automata"
@@ -630,6 +1090,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -742,6 +1208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +1249,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -817,6 +1300,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -941,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,10 +1452,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "valuable"
@@ -969,6 +1484,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wasip2"
@@ -1230,6 +1751,109 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ visibility.
 Profiles may now declare a default repository and an optional cron schedule.
 Manual runs still flow through `agentd run`, and scheduled runs dispatch
 through the same daemon socket intake without introducing a separate job type.
+Manual runs may also carry per-invocation work input without modifying the
+profile: request text can be synthesized into a canonical request artifact, and
+complete JSON artifacts can be placed directly into the session workspace when
+the active methodology declares the relevant artifact type and schema.
 Profiles may also declare additional bind mounts for host-managed state such as
 subscription auth directories. Independently of profile mounts, agentd now
 persists each session's audit record under the rootless default
@@ -186,12 +190,43 @@ Trigger a session through the running daemon:
 agentd run site-builder --work-unit issue-42
 ```
 
+Manual invocation supports exactly one intent surface at a time:
+
+- `--work-unit <ID>` targets existing queued work
+- `--request <TEXT>` synthesizes a canonical request artifact at
+  `.runa/workspace/request/operator-input.json`
+- `--artifact-type <TYPE> --artifact-file <PATH>` validates and places a
+  complete JSON artifact at `.runa/workspace/<TYPE>/<file-stem>.json`
+
+`--work-unit`, `--request`, and `--artifact-file` are mutually exclusive.
+
 `agentd run` reads the same config file and connects to the socket path defined
 there. When the profile declares `repo`, the CLI can omit the positional repo
 argument; an explicit repo still overrides the configured default:
 
 ```bash
 agentd run site-builder https://github.com/pentaxis93/agentd.git --work-unit issue-42
+```
+
+Text input is methodology-gated. `--request` is available only when the active
+methodology declares artifact type `request`, ships `schemas/request.schema.json`,
+and that schema advertises a supported canonical request version through
+`x-tesserine-canonical.version`. In `agentd v0.1.x`, the supported set is
+`1.0.0` only. Unsupported or undeclared request support is rejected before the
+container is created.
+
+Artifact-file input is generic. The CLI reads the file locally, requires UTF-8
+JSON, derives the artifact id from the file stem, and sends structured JSON to
+the daemon. The runner accepts that input only when the methodology declares
+the artifact type in `manifest.toml` and ships a matching
+`schemas/<type>.schema.json`.
+
+Examples:
+
+```bash
+agentd run site-builder --request "Add a status page"
+agentd run site-builder --artifact-type claim --artifact-file ./claim.json
+agentd run site-builder https://github.com/pentaxis93/agentd.git --request "Review the last release candidate"
 ```
 
 Both manual and scheduled dispatches use the same daemon socket intake. Inside
@@ -201,9 +236,11 @@ the container, the agent sees:
 - A fresh clone of the repository at `/home/site-builder/repo`
 - Repo-root `.runa` bridged to persistent audit storage
 - Read-only methodology mount at `/agentd/methodology`
+- A runner-managed read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied
 - Any operator-declared additional bind mounts, read-only or read-write per profile
 - Credentials injected as environment variables
 - `AGENTD_WORK_UNIT` when the invocation includes one
+- A pre-materialized artifact under `.runa/workspace/...` when the invocation includes `--request` or `--artifact-file`
 - The configured session command executing from the repo directory
 
 The container is force-removed on completion. The session's audit record

--- a/crates/agentd-runner/Cargo.toml
+++ b/crates/agentd-runner/Cargo.toml
@@ -8,11 +8,12 @@ build = "build.rs"
 
 [dependencies]
 getrandom = "0.4.2"
+jsonschema = { version = "0.46.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.44", features = ["formatting"] }
+toml = "0.8"
 tracing = "0.1.41"
 
 [dev-dependencies]
-toml = "0.8"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "json"] }

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -506,6 +506,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: Some("issue-76".to_string()),
+                input: None,
                 timeout: None,
             },
         )
@@ -621,6 +622,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -664,6 +666,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -746,6 +749,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -797,6 +801,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -839,6 +844,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -893,6 +899,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -8,6 +8,7 @@
 //! --attach` is ambiguous (podman infrastructure error vs. container process)
 //! and requires container state inspection to disambiguate.
 
+use crate::input::{INVOCATION_INPUT_MOUNT_PATH, ResolvedInvocationInput};
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::podman::{run_podman_command, run_podman_command_until};
 use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
@@ -34,8 +35,15 @@ pub(crate) fn create_container(
     resources: &SessionResources,
     spec: &SessionSpec,
     invocation: &SessionInvocation,
+    resolved_input: Option<&ResolvedInvocationInput>,
 ) -> Result<(), RunnerError> {
-    run_podman_command(build_create_container_args(resources, spec, invocation)).map(|_| ())
+    run_podman_command(build_create_container_args(
+        resources,
+        spec,
+        invocation,
+        resolved_input,
+    ))
+    .map(|_| ())
 }
 
 pub(crate) fn run_container_to_completion(
@@ -145,7 +153,11 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 // and `exec`s the configured session command as the unprivileged profile user
 // from the cloned repository. `set -eu` at the top ensures any setup failure
 // aborts immediately rather than continuing with a broken workspace.
-fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) -> String {
+fn build_container_script(
+    spec: &SessionSpec,
+    invocation: &SessionInvocation,
+    resolved_input: Option<&ResolvedInvocationInput>,
+) -> String {
     let username = &spec.profile_name;
     let home_dir_path = session_home_dir(username);
     let home_dir = home_dir_path.display().to_string();
@@ -195,6 +207,21 @@ fn build_container_script(spec: &SessionSpec, invocation: &SessionInvocation) ->
     script.push_str(&shell_quote(&internal_audit_runa_dir));
     script.push(' ');
     script.push_str(&shell_quote(&repo_runa_dir));
+    if let Some(resolved_input) = resolved_input {
+        let workspace_dir = format!("{repo_runa_dir}/workspace/{}", resolved_input.artifact_type);
+        let artifact_path = format!("{workspace_dir}/{}.json", resolved_input.artifact_id);
+        let staged_document_path = format!("{INVOCATION_INPUT_MOUNT_PATH}/document.json");
+        script.push_str("\nmkdir -p ");
+        script.push_str(&shell_quote(&workspace_dir));
+        script.push_str("\ncp ");
+        script.push_str(&shell_quote(&staged_document_path));
+        script.push(' ');
+        script.push_str(&shell_quote(&artifact_path));
+        script.push_str("\nchown -R ");
+        script.push_str(&shell_quote(&user_group));
+        script.push(' ');
+        script.push_str(&shell_quote(&workspace_dir));
+    }
     script.push_str("\nexport HOME=");
     script.push_str(&shell_quote(&home_dir));
     if let Some(work_unit) = &invocation.work_unit {
@@ -291,6 +318,7 @@ fn build_create_container_args(
     resources: &SessionResources,
     spec: &SessionSpec,
     invocation: &SessionInvocation,
+    resolved_input: Option<&ResolvedInvocationInput>,
 ) -> Vec<String> {
     let mut args = vec![
         "create".to_string(),
@@ -311,6 +339,16 @@ fn build_create_container_args(
         resources.audit_mount.target.display(),
         resources.audit_mount.read_only
     ));
+
+    if let Some(mount) = &resources.invocation_input_mount {
+        args.push("--mount".to_string());
+        args.push(format!(
+            "type=bind,src={},target={},ro={},relabel=shared",
+            mount.source.display(),
+            mount.target.display(),
+            mount.read_only
+        ));
+    }
 
     for mount in &resources.additional_mounts {
         args.push("--mount".to_string());
@@ -370,7 +408,7 @@ fn build_create_container_args(
     args.push("/bin/sh".to_string());
     args.push(spec.base_image.clone());
     args.push("-lc".to_string());
-    args.push(build_container_script(spec, invocation));
+    args.push(build_container_script(spec, invocation, resolved_input));
 
     args
 }

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -44,6 +44,7 @@ fn create_container_args_include_shared_relabel_for_methodology_mount() {
                 read_only: false,
                 relabel_shared: true,
             },
+            invocation_input_mount: None,
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
@@ -53,8 +54,10 @@ fn create_container_args_include_shared_relabel_for_methodology_mount() {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     let mount_value = argument_value(&args.join(" "), "--mount")
@@ -80,6 +83,7 @@ fn create_container_args_force_root_user_and_entrypoint_before_image_argument() 
                 read_only: false,
                 relabel_shared: true,
             },
+            invocation_input_mount: None,
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
@@ -89,8 +93,10 @@ fn create_container_args_force_root_user_and_entrypoint_before_image_argument() 
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     let user_index = args
@@ -121,6 +127,7 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
         repo_url: VALID_REMOTE_REPO_URL.to_string(),
         repo_token: None,
         work_unit: None,
+        input: None,
         timeout: None,
     };
     let args = build_create_container_args(
@@ -135,14 +142,16 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
                 read_only: false,
                 relabel_shared: true,
             },
+            invocation_input_mount: None,
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
             repo_token_secret_binding: None,
         },
         &spec,
         &invocation,
+        None,
     );
-    let expected_script = build_container_script(&spec, &invocation);
+    let expected_script = build_container_script(&spec, &invocation, None);
 
     let image_index = args
         .iter()
@@ -169,6 +178,7 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
                 read_only: false,
                 relabel_shared: true,
             },
+            invocation_input_mount: None,
             additional_mounts: vec![
                 PreparedBindMount {
                     source: PathBuf::from("/tmp/staging/mount-0"),
@@ -191,8 +201,10 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     let mount_values = argument_values(&args, "--mount");
@@ -228,8 +240,10 @@ fn build_container_script_terminates_git_clone_options_before_repo_url() {
             repo_url: "-repo.git".to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     assert!(script.contains("git clone --no-hardlinks -- '-repo.git' '/home/site-builder/repo'"));
@@ -243,8 +257,10 @@ fn build_container_script_disables_git_terminal_prompts() {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     assert!(script.contains("GIT_TERMINAL_PROMPT=0 git clone --no-hardlinks -- "));
@@ -262,8 +278,10 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: Some("task-42".to_string()),
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     assert!(script.contains("useradd --create-home --home-dir '/home/myprofile' --shell /bin/sh --user-group 'myprofile'"));
@@ -335,8 +353,10 @@ fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_t
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     assert!(
@@ -379,8 +399,10 @@ fn build_container_script_does_not_emit_intermediate_home_chown_commands() {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
@@ -404,8 +426,10 @@ fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
+        None,
     );
 
     assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
@@ -427,6 +451,7 @@ fn clone_command_passes_repo_token_to_git_via_environment_not_argv() {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: Some("test-token".to_string()),
             work_unit: None,
+            input: None,
             timeout: None,
         },
         "/tmp/repo",
@@ -474,6 +499,7 @@ fn clone_command_omits_git_auth_environment_when_repo_token_is_absent() {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
         "/tmp/repo",
@@ -874,6 +900,7 @@ fn run_session_does_not_pass_repo_token_via_podman_create_arguments() {
                 repo_url: VALID_REMOTE_REPO_URL.to_string(),
                 repo_token: Some("repo-secret-token".to_string()),
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -1363,6 +1390,7 @@ fn run_session_returns_run_error_when_cleanup_after_run_also_fails() {
                     repo_url: VALID_REMOTE_REPO_URL.to_string(),
                     repo_token: None,
                     work_unit: None,
+                    input: None,
                     timeout: None,
                 },
             )

--- a/crates/agentd-runner/src/input.rs
+++ b/crates/agentd-runner/src/input.rs
@@ -1,0 +1,186 @@
+use crate::types::{InvocationInput, RunnerError};
+use jsonschema::validator_for;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) const INVOCATION_INPUT_MOUNT_PATH: &str = "/agentd/invocation-input";
+const REQUEST_ARTIFACT_TYPE: &str = "request";
+const REQUEST_ARTIFACT_ID: &str = "operator-input";
+const REQUEST_SOURCE: &str = "operator";
+const SUPPORTED_REQUEST_CANONICAL_VERSIONS: &[&str] = &["1.0.0"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedInvocationInput {
+    pub(crate) artifact_type: String,
+    pub(crate) artifact_id: String,
+    pub(crate) document_json: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct MethodologyManifest {
+    #[serde(default)]
+    artifact_types: Vec<DeclaredArtifactType>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeclaredArtifactType {
+    name: String,
+}
+
+pub(crate) fn resolve_invocation_input(
+    methodology_dir: &Path,
+    input: Option<&InvocationInput>,
+) -> Result<Option<ResolvedInvocationInput>, RunnerError> {
+    let Some(input) = input else {
+        return Ok(None);
+    };
+
+    let manifest = load_manifest(methodology_dir)?;
+    match input {
+        InvocationInput::RequestText { description } => {
+            let schema_path = methodology_dir.join("schemas/request.schema.json");
+            ensure_declared_artifact_type(&manifest, REQUEST_ARTIFACT_TYPE).map_err(|message| {
+                RunnerError::InvalidInvocationInput {
+                    message: format!(
+                        "methodology does not support operator request input: {message}"
+                    ),
+                }
+            })?;
+            let schema = load_schema(&schema_path).map_err(|message| {
+                RunnerError::InvalidInvocationInput {
+                    message: format!(
+                        "methodology does not support operator request input: {message}"
+                    ),
+                }
+            })?;
+            ensure_supported_request_version(&schema).map_err(|message| {
+                RunnerError::InvalidInvocationInput {
+                    message: format!(
+                        "methodology does not support operator request input: {message}"
+                    ),
+                }
+            })?;
+
+            let document = json!({
+                "description": description,
+                "source": REQUEST_SOURCE,
+            });
+            validate_document(&schema, &document, REQUEST_ARTIFACT_TYPE)?;
+
+            Ok(Some(ResolvedInvocationInput {
+                artifact_type: REQUEST_ARTIFACT_TYPE.to_string(),
+                artifact_id: REQUEST_ARTIFACT_ID.to_string(),
+                document_json: render_document(&document)?,
+            }))
+        }
+        InvocationInput::Artifact {
+            artifact_type,
+            artifact_id,
+            document,
+        } => {
+            ensure_declared_artifact_type(&manifest, artifact_type)
+                .map_err(|message| RunnerError::InvalidInvocationInput { message })?;
+            if artifact_id.is_empty() {
+                return Err(RunnerError::InvalidInvocationInput {
+                    message: format!(
+                        "artifact input for type '{artifact_type}' must include a non-empty artifact id"
+                    ),
+                });
+            }
+
+            let schema = load_schema(&schema_path(methodology_dir, artifact_type))
+                .map_err(|message| RunnerError::InvalidInvocationInput { message })?;
+            validate_document(&schema, document, artifact_type)?;
+
+            Ok(Some(ResolvedInvocationInput {
+                artifact_type: artifact_type.clone(),
+                artifact_id: artifact_id.clone(),
+                document_json: render_document(document)?,
+            }))
+        }
+    }
+}
+
+fn load_manifest(methodology_dir: &Path) -> Result<MethodologyManifest, RunnerError> {
+    let manifest_path = methodology_dir.join("manifest.toml");
+    let manifest = fs::read_to_string(&manifest_path).map_err(RunnerError::Io)?;
+    toml::from_str(&manifest).map_err(|error| RunnerError::InvalidInvocationInput {
+        message: format!(
+            "failed to parse methodology manifest {}: {error}",
+            manifest_path.display()
+        ),
+    })
+}
+
+fn ensure_declared_artifact_type(
+    manifest: &MethodologyManifest,
+    artifact_type: &str,
+) -> Result<(), String> {
+    if manifest
+        .artifact_types
+        .iter()
+        .any(|declared| declared.name == artifact_type)
+    {
+        return Ok(());
+    }
+
+    Err(format!(
+        "artifact type '{artifact_type}' is not declared in the methodology manifest"
+    ))
+}
+
+fn schema_path(methodology_dir: &Path, artifact_type: &str) -> PathBuf {
+    methodology_dir
+        .join("schemas")
+        .join(format!("{artifact_type}.schema.json"))
+}
+
+fn load_schema(path: &Path) -> Result<Value, String> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read schema {}: {error}", path.display()))?;
+    serde_json::from_str(&contents)
+        .map_err(|error| format!("schema {} must contain valid JSON: {error}", path.display()))
+}
+
+fn ensure_supported_request_version(schema: &Value) -> Result<(), String> {
+    let version = schema
+        .get("x-tesserine-canonical")
+        .and_then(|value| value.get("version"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| "request schema must declare x-tesserine-canonical.version".to_string())?;
+    if SUPPORTED_REQUEST_CANONICAL_VERSIONS.contains(&version) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "canonical request version {version} is not supported"
+    ))
+}
+
+fn validate_document(
+    schema: &Value,
+    document: &Value,
+    artifact_type: &str,
+) -> Result<(), RunnerError> {
+    let validator = validator_for(schema).map_err(|error| RunnerError::InvalidInvocationInput {
+        message: format!("schema for artifact type '{artifact_type}' is invalid: {error}"),
+    })?;
+    let mut errors = validator.iter_errors(document);
+    if let Some(error) = errors.next() {
+        return Err(RunnerError::InvalidInvocationInput {
+            message: format!(
+                "artifact input for type '{artifact_type}' does not match the methodology schema: {error}"
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn render_document(document: &Value) -> Result<String, RunnerError> {
+    serde_json::to_string(document).map_err(|error| RunnerError::InvalidInvocationInput {
+        message: format!("failed to serialize invocation input document: {error}"),
+    })
+}

--- a/crates/agentd-runner/src/input.rs
+++ b/crates/agentd-runner/src/input.rs
@@ -3,7 +3,7 @@ use jsonschema::validator_for;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 pub(crate) const INVOCATION_INPUT_MOUNT_PATH: &str = "/agentd/invocation-input";
 const REQUEST_ARTIFACT_TYPE: &str = "request";
@@ -80,15 +80,10 @@ pub(crate) fn resolve_invocation_input(
             artifact_id,
             document,
         } => {
+            ensure_single_path_segment(artifact_type, "artifact type")?;
+            ensure_single_path_segment(artifact_id, "artifact id")?;
             ensure_declared_artifact_type(&manifest, artifact_type)
                 .map_err(|message| RunnerError::InvalidInvocationInput { message })?;
-            if artifact_id.is_empty() {
-                return Err(RunnerError::InvalidInvocationInput {
-                    message: format!(
-                        "artifact input for type '{artifact_type}' must include a non-empty artifact id"
-                    ),
-                });
-            }
 
             let schema = load_schema(&schema_path(methodology_dir, artifact_type))
                 .map_err(|message| RunnerError::InvalidInvocationInput { message })?;
@@ -129,6 +124,24 @@ fn ensure_declared_artifact_type(
     Err(format!(
         "artifact type '{artifact_type}' is not declared in the methodology manifest"
     ))
+}
+
+fn ensure_single_path_segment(value: &str, field_name: &str) -> Result<(), RunnerError> {
+    if value.is_empty() || value.contains('/') || value.contains('\\') || value.contains('\0') {
+        return Err(invalid_single_path_segment_error(field_name));
+    }
+
+    let mut components = Path::new(value).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(invalid_single_path_segment_error(field_name)),
+    }
+}
+
+fn invalid_single_path_segment_error(field_name: &str) -> RunnerError {
+    RunnerError::InvalidInvocationInput {
+        message: format!("{field_name} must be a single path segment"),
+    }
 }
 
 fn schema_path(methodology_dir: &Path, artifact_type: &str) -> PathBuf {
@@ -183,4 +196,130 @@ fn render_document(document: &Value) -> Result<String, RunnerError> {
     serde_json::to_string(document).map_err(|error| RunnerError::InvalidInvocationInput {
         message: format!("failed to serialize invocation input document: {error}"),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_invocation_input;
+    use crate::types::{InvocationInput, RunnerError};
+    use serde_json::json;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn resolve_invocation_input_accepts_single_segment_artifact_names() {
+        let methodology_dir = unique_methodology_dir("single-segment");
+        write_methodology_fixture(&methodology_dir, "claim");
+
+        let resolved = resolve_invocation_input(
+            &methodology_dir,
+            Some(&InvocationInput::Artifact {
+                artifact_type: "claim".to_string(),
+                artifact_id: "claim-42".to_string(),
+                document: json!({ "summary": "Ship it" }),
+            }),
+        )
+        .expect("single-segment artifact names should be accepted")
+        .expect("artifact input should resolve");
+
+        assert_eq!(resolved.artifact_type, "claim");
+        assert_eq!(resolved.artifact_id, "claim-42");
+
+        fs::remove_dir_all(&methodology_dir).expect("temporary methodology dir should be removed");
+    }
+
+    #[test]
+    fn resolve_invocation_input_rejects_non_segment_artifact_names() {
+        for invalid_artifact_name in [
+            "",
+            ".",
+            "..",
+            "claim/child",
+            "/absolute",
+            r"claim\escape",
+            "claim\0escape",
+        ] {
+            let methodology_dir = unique_methodology_dir("invalid-segment");
+            write_methodology_fixture(&methodology_dir, "claim");
+
+            let error = resolve_invocation_input(
+                &methodology_dir,
+                Some(&InvocationInput::Artifact {
+                    artifact_type: invalid_artifact_name.to_string(),
+                    artifact_id: "claim-42".to_string(),
+                    document: json!({ "summary": "Ship it" }),
+                }),
+            )
+            .expect_err("invalid artifact type should be rejected");
+
+            assert_invalid_invocation_input(error, invalid_artifact_name);
+
+            let error = resolve_invocation_input(
+                &methodology_dir,
+                Some(&InvocationInput::Artifact {
+                    artifact_type: "claim".to_string(),
+                    artifact_id: invalid_artifact_name.to_string(),
+                    document: json!({ "summary": "Ship it" }),
+                }),
+            )
+            .expect_err("invalid artifact id should be rejected");
+
+            assert_invalid_invocation_input(error, invalid_artifact_name);
+
+            fs::remove_dir_all(&methodology_dir)
+                .expect("temporary methodology dir should be removed");
+        }
+    }
+
+    fn assert_invalid_invocation_input(error: RunnerError, invalid_artifact_name: &str) {
+        let message = error.to_string();
+        assert!(
+            matches!(error, RunnerError::InvalidInvocationInput { .. }),
+            "expected InvalidInvocationInput for {invalid_artifact_name:?}, got {error:?}"
+        );
+        assert!(
+            message.contains("single path segment"),
+            "expected single-path-segment guidance for {invalid_artifact_name:?}, got {message}"
+        );
+    }
+
+    fn write_methodology_fixture(methodology_dir: &Path, artifact_type: &str) {
+        fs::create_dir_all(methodology_dir.join("schemas"))
+            .expect("methodology schemas dir should be created");
+        fs::write(
+            methodology_dir.join("manifest.toml"),
+            format!("[[artifact_types]]\nname = \"{artifact_type}\"\n"),
+        )
+        .expect("methodology manifest should be written");
+        fs::write(
+            methodology_dir
+                .join("schemas")
+                .join(format!("{artifact_type}.schema.json")),
+            r#"{
+  "type": "object",
+  "properties": {
+    "summary": { "type": "string" }
+  },
+  "required": ["summary"],
+  "additionalProperties": false
+}"#,
+        )
+        .expect("artifact schema should be written");
+    }
+
+    fn unique_methodology_dir(name: &str) -> PathBuf {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+        std::env::temp_dir().join(format!(
+            "agentd-runner-input-test-{name}-{}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be after unix epoch")
+                .as_nanos(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed),
+        ))
+    }
 }

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod audit;
 mod container;
+mod input;
 mod lifecycle;
 mod naming;
 mod podman;
@@ -27,9 +28,9 @@ pub(crate) mod test_support;
 
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
-    BindMount, EnvironmentNameValidationError, MountOverlapError, MountTargetValidationError,
-    ProfileNameValidationError, ResolvedEnvironmentVariable, RunnerError, SessionInvocation,
-    SessionOutcome, SessionSpec, StartupReconciliationReport,
+    BindMount, EnvironmentNameValidationError, InvocationInput, MountOverlapError,
+    MountTargetValidationError, ProfileNameValidationError, ResolvedEnvironmentVariable,
+    RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
 pub use validation::{
     validate_environment_name, validate_mount_overlap, validate_mount_target,
@@ -38,6 +39,7 @@ pub use validation::{
 
 use audit::{SessionAuditCompletion, finalize_session_audit_record, prepare_session_audit_record};
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
+use input::resolve_invocation_input;
 use lifecycle::{
     LifecycleFailureKind, log_lifecycle_failure, log_session_error, log_session_outcome,
     log_session_started, log_session_teardown,
@@ -67,6 +69,8 @@ pub fn run_session(
 ) -> Result<SessionOutcome, RunnerError> {
     validate_spec(&spec)?;
     validate_invocation(&invocation)?;
+    let resolved_input =
+        resolve_invocation_input(&spec.methodology_dir, invocation.input.as_ref())?;
     let session_id = unique_suffix()?;
 
     let container_name =
@@ -105,6 +109,7 @@ pub fn run_session(
         &invocation,
         &session_id,
         audit_record.clone(),
+        resolved_input.as_ref(),
     ) {
         Ok(resources) => resources,
         Err(ResourceAllocationFailure {
@@ -140,7 +145,7 @@ pub fn run_session(
         }
     };
 
-    if let Err(error) = create_container(&resources, &spec, &invocation) {
+    if let Err(error) = create_container(&resources, &spec, &invocation, resolved_input.as_ref()) {
         let cleanup_result = cleanup_session_resources(&resources);
         let audit_result = finalize_session_audit_record_if_cleanup_succeeded(
             &cleanup_result,
@@ -425,6 +430,7 @@ mod tests {
                         repo_url: "https://example.com/agentd.git".to_string(),
                         repo_token: None,
                         work_unit: None,
+                        input: None,
                         timeout: None,
                     },
                 )
@@ -500,6 +506,7 @@ mod tests {
                             repo_url: "https://example.com/agentd.git".to_string(),
                             repo_token: None,
                             work_unit: None,
+                            input: None,
                             timeout: None,
                         },
                     )
@@ -582,6 +589,7 @@ mod tests {
                         repo_url: "https://example.com/agentd.git".to_string(),
                         repo_token: None,
                         work_unit: None,
+                        input: None,
                         timeout: None,
                     },
                 )
@@ -661,6 +669,7 @@ mod tests {
                         repo_url: "https://example.com/agentd.git".to_string(),
                         repo_token: None,
                         work_unit: None,
+                        input: None,
                         timeout: None,
                     },
                 )
@@ -782,6 +791,7 @@ mod tests {
                         repo_url: "https://example.com/agentd.git".to_string(),
                         repo_token: None,
                         work_unit: None,
+                        input: None,
                         timeout: None,
                     },
                 )
@@ -896,6 +906,7 @@ mod tests {
                         repo_url: "https://example.com/agentd.git".to_string(),
                         repo_token: None,
                         work_unit: None,
+                        input: None,
                         timeout: None,
                     },
                 )

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -6,6 +6,7 @@
 //! secrets or stale staging directories when resource creation fails midway.
 
 use crate::audit::SessionAuditRecord;
+use crate::input::{INVOCATION_INPUT_MOUNT_PATH, ResolvedInvocationInput};
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::naming::{SESSION_ID_LEN, format_secret_name};
 use crate::podman::run_podman_command_with_input;
@@ -17,6 +18,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const METHODOLOGY_STAGE_LINK_NAME: &str = "methodology";
+const INVOCATION_INPUT_STAGE_DIR_NAME: &str = "invocation-input";
+const INVOCATION_INPUT_FILE_NAME: &str = "document.json";
 const AUDIT_RUNA_STAGE_LINK_NAME: &str = "audit-runa";
 const ADDITIONAL_MOUNT_STAGE_PREFIX: &str = "mount-";
 const SESSION_STAGE_PREFIX: &str = "agentd-session-stage-";
@@ -42,6 +45,7 @@ pub(crate) struct SessionResources {
     pub(crate) methodology_mount_source: PathBuf,
     pub(crate) audit_record: SessionAuditRecord,
     pub(crate) audit_mount: PreparedBindMount,
+    pub(crate) invocation_input_mount: Option<PreparedBindMount>,
     pub(crate) additional_mounts: Vec<PreparedBindMount>,
     pub(crate) environment_secret_bindings: Vec<SecretBinding>,
     pub(crate) repo_token_secret_binding: Option<SecretBinding>,
@@ -92,6 +96,7 @@ pub(crate) fn prepare_session_resources(
     invocation: &SessionInvocation,
     session_id: &str,
     audit_record: SessionAuditRecord,
+    resolved_input: Option<&ResolvedInvocationInput>,
 ) -> Result<SessionResources, ResourceAllocationFailure> {
     let manifest_path = spec.methodology_dir.join("manifest.toml");
     if !manifest_path.is_file() {
@@ -116,6 +121,18 @@ pub(crate) fn prepare_session_resources(
         }
     };
     let methodology_mount_source = methodology_staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
+    let invocation_input_mount =
+        match create_invocation_input_mount(resolved_input, &methodology_staging_dir) {
+            Ok(mount) => mount,
+            Err(error) => {
+                return Err(rollback_failed_staging_dir_allocation(
+                    container_name,
+                    session_id,
+                    &methodology_staging_dir,
+                    error,
+                ));
+            }
+        };
     let additional_mounts = match create_additional_mounts(&spec.mounts, &methodology_staging_dir) {
         Ok(mounts) => mounts,
         Err(error) => {
@@ -133,6 +150,7 @@ pub(crate) fn prepare_session_resources(
         methodology_mount_source,
         audit_record,
         audit_mount,
+        invocation_input_mount,
         additional_mounts,
         environment_secret_bindings: Vec::new(),
         repo_token_secret_binding: None,
@@ -306,6 +324,29 @@ fn create_audit_mount(
         false,
         true,
     )
+}
+
+fn create_invocation_input_mount(
+    resolved_input: Option<&ResolvedInvocationInput>,
+    staging_dir: &Path,
+) -> Result<Option<PreparedBindMount>, RunnerError> {
+    let Some(resolved_input) = resolved_input else {
+        return Ok(None);
+    };
+
+    let staged_dir = staging_dir.join(INVOCATION_INPUT_STAGE_DIR_NAME);
+    fs::create_dir_all(&staged_dir)?;
+    fs::write(
+        staged_dir.join(INVOCATION_INPUT_FILE_NAME),
+        &resolved_input.document_json,
+    )?;
+
+    Ok(Some(PreparedBindMount {
+        source: staged_dir,
+        target: PathBuf::from(INVOCATION_INPUT_MOUNT_PATH),
+        read_only: true,
+        relabel_shared: true,
+    }))
 }
 
 fn create_prepared_bind_mount(
@@ -623,10 +664,12 @@ mod tests {
                     repo_url: "https://example.com/repo.git".to_string(),
                     repo_token: None,
                     work_unit: None,
+                    input: None,
                     timeout: None,
                 },
                 &session_id,
                 test_audit_record(&session_id),
+                None,
             )
         });
 
@@ -699,10 +742,12 @@ mod tests {
                     repo_url: "https://example.com/repo.git".to_string(),
                     repo_token: Some("repo-token".to_string()),
                     work_unit: None,
+                    input: None,
                     timeout: None,
                 },
                 &session_id,
                 test_audit_record(&session_id),
+                None,
             )
         });
 
@@ -766,10 +811,12 @@ mod tests {
                 repo_url: "https://example.com/repo.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
             &session_id,
             test_audit_record(&session_id),
+            None,
         );
 
         match result

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -481,6 +481,7 @@ impl FakePodmanFixture {
                     repo_url: VALID_REMOTE_REPO_URL.to_string(),
                     repo_token: None,
                     work_unit: None,
+                    input: None,
                     timeout: None,
                 },
             )

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -93,8 +93,9 @@ pub enum InvocationInput {
 /// Per-invocation parameters for a session launch.
 ///
 /// Describes the repository to clone, optional clone-only repository
-/// authentication, an optional work unit, and an optional timeout. Validated
-/// by [`run_session`](crate::run_session) before any resources are allocated.
+/// authentication, at most one manual intent surface (`work_unit` or `input`),
+/// and an optional timeout. Validated by [`run_session`](crate::run_session)
+/// before any resources are allocated.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionInvocation {
     /// Remote repository URL cloned into the container workspace. Must use
@@ -108,9 +109,12 @@ pub struct SessionInvocation {
     pub repo_token: Option<String>,
     /// Optional work unit identifier exposed to the session command through
     /// the runner-managed `AGENTD_WORK_UNIT` environment variable when set.
+    /// Mutually exclusive with [`Self::input`].
     pub work_unit: Option<String>,
     /// Optional operator-supplied input to materialize into the repo
-    /// workspace before the session command runs.
+    /// workspace before the session command runs. Artifact names supplied
+    /// through [`InvocationInput::Artifact`] must each be a single path
+    /// segment. Mutually exclusive with [`Self::work_unit`].
     pub input: Option<InvocationInput>,
     /// Optional session timeout. When set, the runner force-removes the
     /// container after this duration and returns

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -5,6 +5,8 @@
 //! [`run_session`](crate::run_session) operates on. Validation error types
 //! for the standalone validators are also defined here.
 
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
@@ -75,6 +77,19 @@ pub struct ResolvedEnvironmentVariable {
     pub value: String,
 }
 
+/// Typed operator-supplied input materialized into the session workspace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InvocationInput {
+    /// Convenience text input synthesized into a canonical request artifact.
+    RequestText { description: String },
+    /// A complete JSON artifact supplied by the operator.
+    Artifact {
+        artifact_type: String,
+        artifact_id: String,
+        document: Value,
+    },
+}
+
 /// Per-invocation parameters for a session launch.
 ///
 /// Describes the repository to clone, optional clone-only repository
@@ -94,6 +109,9 @@ pub struct SessionInvocation {
     /// Optional work unit identifier exposed to the session command through
     /// the runner-managed `AGENTD_WORK_UNIT` environment variable when set.
     pub work_unit: Option<String>,
+    /// Optional operator-supplied input to materialize into the repo
+    /// workspace before the session command runs.
+    pub input: Option<InvocationInput>,
     /// Optional session timeout. When set, the runner force-removes the
     /// container after this duration and returns
     /// [`SessionOutcome::TimedOut`].
@@ -310,6 +328,9 @@ pub enum RunnerError {
     /// `repo_token` without using `https://`. Produced during invocation
     /// validation.
     InvalidRepoUrl { message: String },
+    /// The operator-supplied invocation input is unsupported by the
+    /// methodology, malformed, or does not match the methodology schema.
+    InvalidInvocationInput { message: String },
     /// The command array is empty or contains an empty element.
     /// Produced during spec validation.
     InvalidCommand,
@@ -369,6 +390,7 @@ impl fmt::Display for RunnerError {
                 write!(f, "audit_root must be an absolute path: {}", path.display())
             }
             RunnerError::InvalidRepoUrl { message } => write!(f, "repo_url {message}"),
+            RunnerError::InvalidInvocationInput { message } => write!(f, "{message}"),
             RunnerError::InvalidCommand => {
                 write!(f, "command must contain at least one argument")
             }

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -6,6 +6,7 @@
 //! [`validate_mount_target`], [`validate_mount_overlap`]) are also used by the
 //! configuration layer in the `agentd` crate.
 
+use crate::input::INVOCATION_INPUT_MOUNT_PATH;
 use crate::naming::is_daemon_instance_id;
 use crate::session_paths::{session_home_dir, session_internal_agentd_dir, session_repo_dir};
 use crate::types::{
@@ -287,6 +288,7 @@ fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     let internal_agentd_dir = session_internal_agentd_dir(profile_name);
     let repo_dir = session_repo_dir(profile_name);
     let methodology_dir = Path::new(METHODOLOGY_MOUNT_PATH);
+    let invocation_input_dir = Path::new(INVOCATION_INPUT_MOUNT_PATH);
 
     // Each rule states the invariant for one runner-owned path. Intentional
     // overlap is part of the contract: targets like `/home` or `/` can
@@ -296,6 +298,10 @@ fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     // Target and runner-owned methodology path must be disjoint by path
     // components: neither may be a prefix of the other.
     if target.starts_with(methodology_dir) || methodology_dir.starts_with(target) {
+        return true;
+    }
+
+    if target.starts_with(invocation_input_dir) || invocation_input_dir.starts_with(target) {
         return true;
     }
 
@@ -577,6 +583,26 @@ mod tests {
         match error {
             RunnerError::ReservedMountTarget { target } => {
                 assert_eq!(target, PathBuf::from("/agentd/methodology/manifest.toml"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_collide_with_invocation_input_mount() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/agentd/invocation-input"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets must not collide with the invocation input mount");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/agentd/invocation-input"));
             }
             other => panic!("expected ReservedMountTarget, got {other:?}"),
         }
@@ -1116,6 +1142,7 @@ mod tests {
                 repo_url: repo_url.to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             })
             .unwrap_or_else(|error| panic!("expected {repo_url} to be accepted, got {error}"));
@@ -1132,6 +1159,7 @@ mod tests {
                 repo_url: repo_url.to_string(),
                 repo_token: Some("repo-token".to_string()),
                 work_unit: None,
+                input: None,
                 timeout: None,
             })
             .unwrap_or_else(|error| panic!("expected {repo_url} to be accepted, got {error}"));
@@ -1148,6 +1176,7 @@ mod tests {
                 repo_url: repo_url.to_string(),
                 repo_token: Some("repo-token".to_string()),
                 work_unit: None,
+                input: None,
                 timeout: None,
             })
             .expect_err("repo_token should be rejected for non-https repo URLs");
@@ -1199,6 +1228,7 @@ mod tests {
                 repo_url: repo_url.to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             })
             .expect_err("non-remote repo URL should be rejected");
@@ -1216,6 +1246,7 @@ mod tests {
             repo_url: "https://user:token@example.com/repo.git".to_string(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         })
         .expect_err("credential-bearing repo URLs should be rejected");
@@ -1242,6 +1273,7 @@ mod tests {
                 repo_url: "/srv/test-repo.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -1264,6 +1296,7 @@ mod tests {
                 repo_url: "https://user:token@example.com/repo.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -1296,6 +1329,7 @@ mod tests {
                     repo_url: repo_url.to_string(),
                     repo_token: Some("repo-token".to_string()),
                     work_unit: None,
+                    input: None,
                     timeout: None,
                 },
             )
@@ -1326,6 +1360,7 @@ mod tests {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -149,6 +149,11 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
     if invocation.repo_token.is_some() && !invocation.repo_url.starts_with("https://") {
         return Err(repo_token_requires_https_error());
     }
+    if invocation.work_unit.is_some() && invocation.input.is_some() {
+        return Err(RunnerError::InvalidInvocationInput {
+            message: "manual invocation must specify at most one of work_unit or input".to_string(),
+        });
+    }
 
     Ok(())
 }
@@ -371,7 +376,9 @@ fn is_valid_unix_username(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BindMount, ResolvedEnvironmentVariable, test_support::test_session_spec};
+    use crate::{
+        BindMount, InvocationInput, ResolvedEnvironmentVariable, test_support::test_session_spec,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -1346,6 +1353,57 @@ mod tests {
                 "expected repo_token https-only message for {repo_url}, got {error}"
             );
         }
+    }
+
+    #[test]
+    fn validate_invocation_accepts_zero_or_one_manual_intent_surface() {
+        for (work_unit, input) in [
+            (None, None),
+            (Some("issue-42".to_string()), None),
+            (
+                None,
+                Some(InvocationInput::RequestText {
+                    description: "Add a status page".to_string(),
+                }),
+            ),
+        ] {
+            validate_invocation(&SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit,
+                input,
+                timeout: None,
+            })
+            .expect("zero or one manual intent surface should be accepted");
+        }
+    }
+
+    #[test]
+    fn validate_invocation_rejects_conflicting_manual_intent_surfaces() {
+        let error = validate_invocation(&SessionInvocation {
+            repo_url: "https://example.com/agentd.git".to_string(),
+            repo_token: None,
+            work_unit: Some("issue-42".to_string()),
+            input: Some(InvocationInput::RequestText {
+                description: "Add a status page".to_string(),
+            }),
+            timeout: None,
+        })
+        .expect_err("conflicting work_unit and input should be rejected");
+
+        assert!(
+            matches!(error, RunnerError::InvalidInvocationInput { .. }),
+            "expected InvalidInvocationInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("work_unit"),
+            "expected work_unit guidance in message, got {message}"
+        );
+        assert!(
+            message.contains("input"),
+            "expected input guidance in message, got {message}"
+        );
     }
 
     #[test]

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -12,8 +12,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use agentd_runner::{
-    BindMount, ResolvedEnvironmentVariable, SessionInvocation, SessionOutcome, SessionSpec,
-    run_session,
+    BindMount, InvocationInput, ResolvedEnvironmentVariable, SessionInvocation, SessionOutcome,
+    SessionSpec, run_session,
 };
 use serde_json::Value;
 
@@ -59,6 +59,64 @@ fn wait_for_session_record_dir(
     }
 }
 
+fn write_methodology_manifest(path: &Path, artifact_types: &[&str]) {
+    let mut manifest = String::from("name = \"test-methodology\"\n");
+    for artifact_type in artifact_types {
+        manifest.push_str("\n[[artifact_types]]\nname = \"");
+        manifest.push_str(artifact_type);
+        manifest.push_str("\"\n");
+    }
+    fs::write(path.join("manifest.toml"), manifest)
+        .expect("methodology manifest should be written");
+}
+
+fn install_request_schema(path: &Path, version: &str) {
+    let schema_dir = path.join("schemas");
+    fs::create_dir_all(&schema_dir).expect("schema dir should be created");
+    fs::write(
+        schema_dir.join("request.schema.json"),
+        format!(
+            r#"{{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-tesserine-canonical": {{
+    "version": "{version}",
+    "schema_url": "https://example.com/request.schema.json",
+    "prose_url": "https://example.com/REQUEST.md"
+  }},
+  "type": "object",
+  "required": ["description", "source"],
+  "additionalProperties": false,
+  "properties": {{
+    "description": {{ "type": "string", "minLength": 1 }},
+    "source": {{ "type": "string", "minLength": 1 }},
+    "context": {{ "type": "string" }}
+  }}
+}}
+"#
+        ),
+    )
+    .expect("request schema should be written");
+}
+
+fn install_claim_schema(path: &Path) {
+    let schema_dir = path.join("schemas");
+    fs::create_dir_all(&schema_dir).expect("schema dir should be created");
+    fs::write(
+        schema_dir.join("claim.schema.json"),
+        r#"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["summary"],
+  "additionalProperties": false,
+  "properties": {
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}
+"#,
+    )
+    .expect("claim schema should be written");
+}
+
 #[test]
 fn succeeds_without_timeout_and_cleans_up_container() {
     if skip_if_podman_unavailable("succeeds_without_timeout_and_cleans_up_container") {
@@ -101,6 +159,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: Some("task-42".to_string()),
+            input: None,
             timeout: None,
         },
     )
@@ -109,6 +168,149 @@ fn succeeds_without_timeout_and_cleans_up_container() {
     assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn materializes_request_text_input_before_session_command_runs() {
+    if skip_if_podman_unavailable("materializes_request_text_input_before_session_command_runs") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("request-input-run");
+    write_methodology_manifest(&fixture.methodology_dir(), &["request"]);
+    install_request_schema(&fixture.methodology_dir(), "1.0.0");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "request-input-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "assert-request-input-present".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            input: Some(InvocationInput::RequestText {
+                description: "Add a status page".to_string(),
+            }),
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn materializes_generic_artifact_input_before_session_command_runs() {
+    if skip_if_podman_unavailable("materializes_generic_artifact_input_before_session_command_runs")
+    {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("artifact-input-run");
+    write_methodology_manifest(&fixture.methodology_dir(), &["claim"]);
+    install_claim_schema(&fixture.methodology_dir());
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "artifact-input-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "assert-claim-input-present".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            input: Some(InvocationInput::Artifact {
+                artifact_type: "claim".to_string(),
+                artifact_id: "claim".to_string(),
+                document: serde_json::json!({ "summary": "Ship it" }),
+            }),
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn rejects_request_text_when_methodology_declares_an_unsupported_request_version() {
+    if skip_if_podman_unavailable(
+        "rejects_request_text_when_methodology_declares_an_unsupported_request_version",
+    ) {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("unsupported-request-version-run");
+    write_methodology_manifest(&fixture.methodology_dir(), &["request"]);
+    install_request_schema(&fixture.methodology_dir(), "2.0.0");
+    let image = fixture.build_image();
+
+    let error = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            profile_name: "unsupported-request-version-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: Vec::new(),
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            input: Some(InvocationInput::RequestText {
+                description: "Add a status page".to_string(),
+            }),
+            timeout: None,
+        },
+    )
+    .expect_err("unsupported request version should fail before session start");
+
+    assert!(
+        error
+            .to_string()
+            .contains("canonical request version 2.0.0 is not supported"),
+        "expected unsupported-version error, got: {error}"
+    );
 }
 
 #[test]
@@ -152,6 +354,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: Some("task-42".to_string()),
+            input: None,
             timeout: None,
         },
     )
@@ -193,6 +396,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -242,6 +446,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -291,6 +496,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -341,6 +547,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: Some("task-42".to_string()),
+            input: None,
             timeout: None,
         },
     )
@@ -397,6 +604,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -464,6 +672,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -535,6 +744,7 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -581,6 +791,7 @@ fn preserves_session_user_access_to_preexisting_home_content() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -622,6 +833,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: Some("issue-76".to_string()),
+            input: None,
             timeout: None,
         },
     )
@@ -710,6 +922,7 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: Some("issue-76".to_string()),
+            input: None,
             timeout: None,
         },
     )
@@ -811,6 +1024,7 @@ fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes(
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: None,
         },
     )
@@ -884,6 +1098,7 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: Some("issue-76".to_string()),
+            input: None,
             timeout: None,
         },
     )
@@ -956,6 +1171,7 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             repo_url: fixture.repo_url(),
             repo_token: None,
             work_unit: None,
+            input: None,
             timeout: Some(Duration::from_secs(1)),
         },
     )
@@ -1007,6 +1223,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 repo_url,
                 repo_token: None,
                 work_unit: None,
+                input: None,
                 timeout: None,
             },
         )
@@ -1556,6 +1773,19 @@ case "$command_name" in
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "success-without-work-unit" ]; then
             [ "${AGENTD_WORK_UNIT+set}" != "set" ]
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "assert-request-input-present" ]; then
+            [ -f "${HOME}/repo/.runa/workspace/request/operator-input.json" ]
+            grep -F '"description":"Add a status page"' "${HOME}/repo/.runa/workspace/request/operator-input.json"
+            grep -F '"source":"operator"' "${HOME}/repo/.runa/workspace/request/operator-input.json"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "assert-claim-input-present" ]; then
+            [ -f "${HOME}/repo/.runa/workspace/claim/claim.json" ]
+            grep -F '"summary":"Ship it"' "${HOME}/repo/.runa/workspace/claim/claim.json"
             exit 0
         fi
 

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -12,7 +12,8 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use agentd_runner::{
-    RunnerError, SessionOutcome, StartupReconciliationReport, reconcile_startup_resources,
+    InvocationInput, RunnerError, SessionOutcome, StartupReconciliationReport,
+    reconcile_startup_resources,
 };
 use serde::{Deserialize, Serialize};
 
@@ -126,6 +127,7 @@ enum RequestMessage {
         profile: String,
         repo_url: String,
         work_unit: Option<String>,
+        input: Option<InvocationInput>,
     },
 }
 
@@ -429,6 +431,7 @@ pub fn request_run(
             profile: request.profile.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
+            input: request.input.clone(),
         },
     )? {
         ResponseMessage::SessionOutcome { outcome } => Ok(outcome.into()),
@@ -449,6 +452,7 @@ pub(crate) fn request_run_without_waiting(
             profile: request.profile.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
+            input: request.input.clone(),
         },
     )
 }
@@ -552,12 +556,14 @@ fn handle_connection_inner(
             profile,
             repo_url,
             work_unit,
+            input,
         } => match dispatch_run(
             config,
             &RunRequest {
                 profile: profile.clone(),
                 repo_url,
                 work_unit: work_unit.clone(),
+                input,
             },
             executor,
         ) {

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -13,7 +13,9 @@ use crate::config::{Config, ConfigError};
 pub struct RunRequest {
     pub profile: String,
     pub repo_url: String,
+    /// Optional manual work-unit target. Mutually exclusive with `input`.
     pub work_unit: Option<String>,
+    /// Optional manual invocation input. Mutually exclusive with `work_unit`.
     pub input: Option<InvocationInput>,
 }
 

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use agentd_runner::{
-    ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
-    run_session,
+    InvocationInput, ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
+    SessionSpec, run_session,
 };
 
 use crate::audit_root::prepare_audit_root;
@@ -14,6 +14,7 @@ pub struct RunRequest {
     pub profile: String,
     pub repo_url: String,
     pub work_unit: Option<String>,
+    pub input: Option<InvocationInput>,
 }
 
 /// Errors produced while mapping a run request into a runner session.
@@ -153,6 +154,7 @@ pub fn dispatch_run(
                 repo_url: request.repo_url.clone(),
                 repo_token,
                 work_unit: request.work_unit.clone(),
+                input: request.input.clone(),
                 timeout: None,
             },
         )

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -8,6 +8,7 @@ use agentd::config::{Config, DaemonConfig};
 use agentd::{
     RunRequest, RunnerSessionExecutor, configure_tracing, request_run, run_daemon_until_shutdown,
 };
+use agentd_runner::InvocationInput;
 use clap::{Parser, Subcommand};
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 
@@ -16,8 +17,26 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
 #[derive(Debug)]
 enum RunCommandError {
     Outcome(agentd_runner::SessionOutcome),
-    UnknownProfile { profile: String },
-    MissingRepo { profile: String },
+    UnknownProfile {
+        profile: String,
+    },
+    MissingRepo {
+        profile: String,
+    },
+    ArtifactFileUnreadable {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+    ArtifactFileNonUtf8 {
+        path: PathBuf,
+    },
+    ArtifactFileInvalidJson {
+        path: PathBuf,
+        error: serde_json::Error,
+    },
+    ArtifactFileMissingStem {
+        path: PathBuf,
+    },
 }
 
 impl fmt::Display for RunCommandError {
@@ -43,6 +62,34 @@ impl fmt::Display for RunCommandError {
                 f,
                 "profile '{profile}' requires a repo argument or configured profile repo"
             ),
+            Self::ArtifactFileUnreadable { path, error } => {
+                write!(
+                    f,
+                    "failed to read artifact file {}: {error}",
+                    path.display()
+                )
+            }
+            Self::ArtifactFileNonUtf8 { path } => {
+                write!(
+                    f,
+                    "artifact file must be valid UTF-8 JSON: {}",
+                    path.display()
+                )
+            }
+            Self::ArtifactFileInvalidJson { path, error } => {
+                write!(
+                    f,
+                    "artifact file must contain valid JSON {}: {error}",
+                    path.display()
+                )
+            }
+            Self::ArtifactFileMissingStem { path } => {
+                write!(
+                    f,
+                    "artifact file must have a non-empty UTF-8 file stem: {}",
+                    path.display()
+                )
+            }
         }
     }
 }
@@ -66,8 +113,18 @@ enum Command {
     Run {
         profile: String,
         repo: Option<String>,
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["request", "artifact_file"])]
         work_unit: Option<String>,
+        #[arg(long, conflicts_with_all = ["work_unit", "artifact_file"])]
+        request: Option<String>,
+        #[arg(
+                long,
+                requires = "artifact_type",
+                conflicts_with_all = ["work_unit", "request"]
+            )]
+        artifact_file: Option<PathBuf>,
+        #[arg(long, requires = "artifact_file")]
+        artifact_type: Option<String>,
     },
 }
 
@@ -95,7 +152,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             profile,
             repo,
             work_unit,
-        }) => run_client(&cli.config, profile, repo, work_unit),
+            request,
+            artifact_file,
+            artifact_type,
+        }) => run_client(
+            &cli.config,
+            profile,
+            repo,
+            work_unit,
+            request,
+            artifact_file,
+            artifact_type,
+        ),
     }
 }
 
@@ -122,8 +190,12 @@ fn run_client(
     profile: String,
     repo: Option<String>,
     work_unit: Option<String>,
+    request: Option<String>,
+    artifact_file: Option<PathBuf>,
+    artifact_type: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let repo = resolve_run_repo(config_path, &profile, repo)?;
+    let input = resolve_invocation_input(request, artifact_file, artifact_type)?;
     let daemon_config = DaemonConfig::load(config_path)?;
     let outcome = request_run(
         &daemon_config,
@@ -131,6 +203,7 @@ fn run_client(
             profile,
             repo_url: repo,
             work_unit,
+            input,
         },
     )?;
 
@@ -140,6 +213,51 @@ fn run_client(
     } else {
         Err(Box::new(RunCommandError::Outcome(outcome)))
     }
+}
+
+fn resolve_invocation_input(
+    request: Option<String>,
+    artifact_file: Option<PathBuf>,
+    artifact_type: Option<String>,
+) -> Result<Option<InvocationInput>, Box<dyn std::error::Error>> {
+    if let Some(description) = request {
+        return Ok(Some(InvocationInput::RequestText { description }));
+    }
+
+    let Some(path) = artifact_file else {
+        return Ok(None);
+    };
+    let artifact_type = artifact_type.expect("clap should require artifact_type");
+    let bytes = std::fs::read(&path).map_err(|error| {
+        Box::new(RunCommandError::ArtifactFileUnreadable {
+            path: path.clone(),
+            error,
+        }) as Box<dyn std::error::Error>
+    })?;
+    let contents = String::from_utf8(bytes).map_err(|_| {
+        Box::new(RunCommandError::ArtifactFileNonUtf8 { path: path.clone() })
+            as Box<dyn std::error::Error>
+    })?;
+    let document = serde_json::from_str(&contents).map_err(|error| {
+        Box::new(RunCommandError::ArtifactFileInvalidJson {
+            path: path.clone(),
+            error,
+        }) as Box<dyn std::error::Error>
+    })?;
+    let artifact_id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| {
+            Box::new(RunCommandError::ArtifactFileMissingStem { path: path.clone() })
+                as Box<dyn std::error::Error>
+        })?;
+
+    Ok(Some(InvocationInput::Artifact {
+        artifact_type,
+        artifact_id: artifact_id.to_string(),
+        document,
+    }))
 }
 
 fn resolve_run_repo(

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -80,6 +80,7 @@ impl Dispatcher for SocketDispatcher {
                         profile: request.profile.clone(),
                         repo_url: request.repo_url.clone(),
                         work_unit: None,
+                        input: None,
                     },
                 ) {
                     tracing::warn!(
@@ -311,6 +312,7 @@ command = ["site-builder", "exec"]
                 "profile": "site-builder",
                 "repo_url": "https://example.com/site.git",
                 "work_unit": null,
+                "input": null,
             })
         );
 

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -8,7 +8,8 @@ use std::time::{Duration, Instant};
 
 use agentd::config::Config;
 use agentd::{SessionExecutor, run_daemon_until_shutdown};
-use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use agentd_runner::{InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use serde_json::json;
 
 type DaemonHandle = thread::JoinHandle<Result<(), agentd::DaemonError>>;
 type RecordedInvocations = Arc<Mutex<Vec<SessionInvocation>>>;
@@ -383,6 +384,225 @@ fn binary_run_command_prefers_explicit_repo_over_profile_default_repo() {
     assert_eq!(
         invocations.lock().expect("invocations should lock")[0].repo_url,
         explicit_repo
+    );
+}
+
+#[test]
+fn binary_run_command_rejects_request_when_work_unit_is_also_supplied() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-request-work-unit-conflict-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-request-work-unit-conflict",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+            "--work-unit",
+            "issue-81",
+            "--request",
+            "Add a status page",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        !output.status.success(),
+        "run command should reject conflicting request/work-unit flags"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert!(
+        stderr.contains("--request") && stderr.contains("--work-unit"),
+        "expected clap conflict mentioning both flags, got: {stderr}"
+    );
+}
+
+#[test]
+fn binary_run_command_requires_artifact_type_when_artifact_file_is_supplied() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-artifact-type-required-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-artifact-type-required",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+    let artifact_path = runtime_dir.join("request.json");
+    std::fs::write(
+        &artifact_path,
+        r#"{"description":"Add a status page","source":"operator"}"#,
+    )
+    .expect("artifact file should be written");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+            "--artifact-file",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be utf-8"),
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        !output.status.success(),
+        "run command should reject artifact files without an artifact type"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert!(
+        stderr.contains("--artifact-type"),
+        "expected missing-artifact-type error, got: {stderr}"
+    );
+}
+
+#[test]
+fn binary_run_command_forwards_request_text_as_typed_invocation_input() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-request-input-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-request-input",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+    let (shutdown, handle, _config, invocations) =
+        start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+            "--request",
+            "Add a status page",
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should succeed with request input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocation = invocations.lock().expect("invocations should lock")[0].clone();
+    assert_eq!(
+        invocation.input,
+        Some(InvocationInput::RequestText {
+            description: "Add a status page".to_string(),
+        })
+    );
+}
+
+#[test]
+fn binary_run_command_reads_artifact_file_and_forwards_structured_input() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-artifact-input-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-artifact-input",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+    let artifact_path = runtime_dir.join("request.json");
+    std::fs::write(
+        &artifact_path,
+        r#"{"description":"Add a status page","source":"operator"}"#,
+    )
+    .expect("artifact file should be written");
+    let (shutdown, handle, _config, invocations) =
+        start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "run",
+            "site-builder",
+            "https://example.com/repo.git",
+            "--artifact-type",
+            "request",
+            "--artifact-file",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be utf-8"),
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should succeed with artifact input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocation = invocations.lock().expect("invocations should lock")[0].clone();
+    assert_eq!(
+        invocation.input,
+        Some(InvocationInput::Artifact {
+            artifact_type: "request".to_string(),
+            artifact_id: "request".to_string(),
+            document: json!({
+                "description": "Add a status page",
+                "source": "operator",
+            }),
+        })
     );
 }
 

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -8,7 +8,8 @@ use std::time::{Duration, Instant};
 
 use agentd::config::{Config, ConfigError};
 use agentd::{
-    ClientError, DaemonError, RunRequest, SessionExecutor, request_run, run_daemon_until_shutdown,
+    ClientError, DaemonError, RunRequest, RunnerSessionExecutor, SessionExecutor, request_run,
+    run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
 use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
@@ -314,6 +315,61 @@ fn daemon_round_trips_typed_invocation_input_through_the_socket_protocol() {
             document: json!({ "summary": "Ship it" }),
         })
     );
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn daemon_rejects_conflicting_work_unit_and_input_from_socket_callers() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("conflicting-manual-intent");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown(daemon_config, RunnerSessionExecutor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let error = request_run(
+        config.daemon(),
+        &RunRequest {
+            profile: "site-builder".to_string(),
+            repo_url: "https://example.com/repo.git".to_string(),
+            work_unit: Some("issue-42".to_string()),
+            input: Some(InvocationInput::RequestText {
+                description: "Add a status page".to_string(),
+            }),
+        },
+    )
+    .expect_err("conflicting work_unit and input should be rejected");
+
+    match error {
+        ClientError::Server { message } => {
+            assert!(
+                message.contains("work_unit"),
+                "expected work_unit guidance in server message, got {message}"
+            );
+            assert!(
+                message.contains("input"),
+                "expected input guidance in server message, got {message}"
+            );
+        }
+        other => panic!("expected server-side validation error, got {other:?}"),
+    }
 
     shutdown.store(true, Ordering::Release);
     handle

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -10,7 +10,9 @@ use agentd::config::{Config, ConfigError};
 use agentd::{
     ClientError, DaemonError, RunRequest, SessionExecutor, request_run, run_daemon_until_shutdown,
 };
+use agentd_runner::InvocationInput;
 use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use serde_json::json;
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -28,6 +30,39 @@ impl SessionExecutor for FixedOutcomeExecutor {
         _spec: SessionSpec,
         _invocation: SessionInvocation,
     ) -> Result<SessionOutcome, RunnerError> {
+        Ok(self.outcome.clone())
+    }
+}
+
+#[derive(Clone)]
+struct RecordingInvocationExecutor {
+    outcome: SessionOutcome,
+    invocations: Arc<Mutex<Vec<SessionInvocation>>>,
+}
+
+impl RecordingInvocationExecutor {
+    fn new(outcome: SessionOutcome) -> (Self, Arc<Mutex<Vec<SessionInvocation>>>) {
+        let invocations = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                outcome,
+                invocations: Arc::clone(&invocations),
+            },
+            invocations,
+        )
+    }
+}
+
+impl SessionExecutor for RecordingInvocationExecutor {
+    fn run_session(
+        &self,
+        _spec: SessionSpec,
+        invocation: SessionInvocation,
+    ) -> Result<SessionOutcome, RunnerError> {
+        self.invocations
+            .lock()
+            .expect("recorded invocations should lock")
+            .push(invocation);
         Ok(self.outcome.clone())
     }
 }
@@ -194,6 +229,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
             profile: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("task-42".to_string()),
+            input: None,
         },
     )
     .expect("client request should succeed");
@@ -221,6 +257,7 @@ fn client_reports_clear_error_when_daemon_is_not_running() {
             profile: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: None,
+            input: None,
         },
     )
     .expect_err("missing daemon should be reported");
@@ -230,6 +267,61 @@ fn client_reports_clear_error_when_daemon_is_not_running() {
             assert_eq!(path, config.daemon().socket_path());
         }
         other => panic!("expected daemon-not-running error, got {other:?}"),
+    }
+}
+
+#[test]
+fn daemon_round_trips_typed_invocation_input_through_the_socket_protocol() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("typed-input");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (executor, invocations) =
+        RecordingInvocationExecutor::new(SessionOutcome::Success { exit_code: 0 });
+    let handle =
+        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    wait_for_path(config.daemon().socket_path());
+
+    let outcome = request_run(
+        config.daemon(),
+        &RunRequest {
+            profile: "site-builder".to_string(),
+            repo_url: "https://example.com/repo.git".to_string(),
+            work_unit: None,
+            input: Some(InvocationInput::Artifact {
+                artifact_type: "claim".to_string(),
+                artifact_id: "claim".to_string(),
+                document: json!({ "summary": "Ship it" }),
+            }),
+        },
+    )
+    .expect("client request should succeed");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    let invocation = invocations.lock().expect("invocations should lock")[0].clone();
+    assert_eq!(
+        invocation.input,
+        Some(InvocationInput::Artifact {
+            artifact_type: "claim".to_string(),
+            artifact_id: "claim".to_string(),
+            document: json!({ "summary": "Ship it" }),
+        })
+    );
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
     }
 }
 
@@ -349,6 +441,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
                 profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("first".to_string()),
+                input: None,
             },
         )
     });
@@ -363,6 +456,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
                 profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("second".to_string()),
+                input: None,
             },
         );
         second_tx
@@ -442,6 +536,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
                 profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("shutdown".to_string()),
+                input: None,
             },
         )
     });
@@ -505,6 +600,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
                 profile: "site-builder".to_string(),
                 repo_url: "https://example.com/repo.git".to_string(),
                 work_unit: Some("draining".to_string()),
+                input: None,
             },
         )
     });
@@ -519,6 +615,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
             profile: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: Some("rejected".to_string()),
+            input: None,
         },
     )
     .expect_err("new run should be rejected once shutdown begins");

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -6,8 +6,10 @@ use std::{fs, panic};
 use agentd::config::{Config, ConfigError};
 use agentd::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 use agentd_runner::{
-    ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
+    InvocationInput, ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
+    SessionSpec,
 };
+use serde_json::json;
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -143,6 +145,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: Some("task-42".to_string()),
+        input: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
@@ -217,6 +220,7 @@ fn dispatch_run_forwards_resolved_audit_root_into_session_spec() {
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
@@ -265,6 +269,7 @@ fn dispatch_run_rejects_an_unwritable_audit_root_before_session_execution() {
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, _state) =
         RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
@@ -302,6 +307,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_missing() {
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
@@ -334,6 +340,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
@@ -367,6 +374,7 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, _state) =
         RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
@@ -413,6 +421,7 @@ command = ["site-builder", "exec"]
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, _state) =
         RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
@@ -436,6 +445,7 @@ fn dispatch_run_forwards_profile_mounts_into_session_spec() {
         profile: "site-builder".to_string(),
         repo_url: "https://example.com/repo.git".to_string(),
         work_unit: None,
+        input: None,
     };
     let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
 
@@ -462,4 +472,39 @@ fn dispatch_run_forwards_profile_mounts_into_session_spec() {
             },
         ]
     );
+}
+
+#[test]
+fn dispatch_run_forwards_typed_invocation_input_into_session_invocation() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
+    let request = RunRequest {
+        profile: "site-builder".to_string(),
+        repo_url: "https://example.com/repo.git".to_string(),
+        work_unit: None,
+        input: Some(InvocationInput::Artifact {
+            artifact_type: "claim".to_string(),
+            artifact_id: "claim".to_string(),
+            document: json!({ "summary": "Ship it" }),
+        }),
+    };
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
+
+    let state = state.lock().expect("recording state should lock");
+    let invocation = state
+        .last_invocation
+        .as_ref()
+        .expect("executor should receive invocation");
+    assert_eq!(invocation.input, request.input);
+
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
 }

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -135,8 +135,12 @@ fn workspace_docs_describe_persistent_audit_record_contract() {
         "architecture should describe the persistent audit record root"
     );
     assert!(
-        architecture.contains("artifacts_dir"),
-        "architecture should document the artifacts_dir audit scope boundary"
+        architecture.contains("non-configurable `.runa/store/` and `.runa/workspace/`"),
+        "architecture should document full audit coverage for runa's fixed workspace layout"
+    );
+    assert!(
+        !architecture.contains("artifacts_dir"),
+        "architecture should not describe removed artifacts_dir configurability"
     );
     assert!(
         architecture.contains("accumulate") && architecture.contains("indefinitely"),


### PR DESCRIPTION
## Summary

- add per-invocation input surfaces to `agentd run` for request text and JSON artifact files without requiring profile edits
- validate operator input against methodology-declared artifact schemas before container creation, with request-text support gated by `x-tesserine-canonical.version` and `1.0.0` as the only supported canonical request version in `v0.1.x`
- materialize validated input into `.runa/workspace/...` before the profile command starts and document the CLI, runner contract, and mount reservation

## Changes

- add typed invocation input to the CLI, daemon socket protocol, dispatch layer, and runner invocation model
- stage validated invocation input through a runner-owned `/agentd/invocation-input` mount and copy it into `.runa/workspace/<type>/<id>.json` during container setup
- extend behavioral coverage for CLI forwarding, daemon round-tripping, request-version rejection, generic artifact validation, and in-container materialization
- update README, architecture notes, and changelog entries to describe the new operator-input behavior and version policy

## GitHub Issue(s)

Closes #81

## Test plan

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`
