### PR TITLE
feat(runner,config): compose declarative agent sessions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,10 +235,10 @@ Host audit records live under the resolved audit root, by default
 layout:
 
 - `runa/` — preserved runa state written naturally by the runtime
-- `agentd/session.json` — agentd-written metadata (`session_id`, `agent`,
-  `repo_url`, optional `work_unit`, timestamps, outcome, exit code when
-  applicable) written by atomic temp-file replacement within the record
-  directory
+- `agentd/session.json` — agentd-written metadata (`schema_version: 2`,
+  `session_id`, `agent`, `repo_url`, optional `work_unit`, timestamps, outcome,
+  exit code when applicable) written by atomic temp-file replacement within the
+  record directory
 
 Coverage is intentionally scoped to the repo-root `.runa/` tree. That captures
 `runa`'s non-configurable `.runa/store/` and `.runa/workspace/`, so persisted

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,8 +24,8 @@ mapping semantics are all part of the supported execution model.
 
 ### Terminology
 
-- **Profile**: a named, reusable environment specification in the daemon config — base image, methodology, optional default repo, optional schedule, credentials, and command. What the operator declares.
-- **Session**: a single execution created from a profile plus invocation parameters (repo, work unit, timeout). What the runner manages.
+- **Agent**: a named, reusable environment specification in the daemon config — base image, methodology, optional default repo, optional schedule, credentials, and command. What the operator declares.
+- **Session**: a single execution created from an agent plus invocation parameters (repo, work unit, timeout). What the runner manages.
 
 ## 2. Agent Capability Needs
 
@@ -41,13 +41,13 @@ Every structural decision in the workspace traces to a capability an agent sessi
 
 **Need:** agents authenticate to those external services.
 
-**Constraint:** credentials are injected at session setup and remain scoped to the owning profile.
+**Constraint:** credentials are injected at session setup and remain scoped to the owning agent.
 
 ### Identity
 
 **Need:** agents know who they are and can be distinguished clearly per session.
 
-**Constraint:** each session receives stable identity variables and a profile-derived container name inside an ephemeral runtime.
+**Constraint:** each session receives stable identity variables and an agent-derived container name inside an ephemeral runtime.
 
 ### Mission
 
@@ -81,11 +81,11 @@ The workspace contains three crates because there are three distinct rates of ch
 
 ## 4. Session Lifecycle
 
-A session is one execution created from a profile, spanning trigger to teardown.
+A session is one execution created from an agent, spanning trigger to teardown.
 
 Before the daemon accepts any session trigger, it first reconciles stale
 runner-managed Podman resources from prior runs of the same daemon instance.
-Dead session containers named `agentd-{daemon8}-{profile}-{session16}` are
+Dead session containers named `agentd-{daemon8}-{agent}-{session16}` are
 removed, then orphaned runner-managed secrets named
 `agentd-{daemon8}-{session16}-{suffix}` whose session container no longer
 exists are removed. The daemon instance id is derived from the configured
@@ -112,7 +112,7 @@ before `/run/agentd/agentd.sock`; for root XDG-unset clients it bypasses the
 and mode `0700`. A default candidate is selected only after it answers the
 agentd socket protocol `Ping` request with `Pong`; unrelated listeners and
 ambiguous probe failures are skipped so later defaults can be considered.
-Profile lookup and default-repo resolution happen daemon-side after the socket
+Agent lookup and default-repo resolution happen daemon-side after the socket
 request is received, so client and daemon responsibility boundaries stay clean.
 
 Operational visibility for that lifecycle uses structured tracing events written
@@ -126,7 +126,7 @@ environment configuration.
 ### Phase 1: Scheduling (`agentd-scheduler`)
 
 The scheduler determines when a session should run. Today it evaluates each
-profile's optional cron schedule in daemon-local time. When scheduling decides
+agent's optional cron schedule in daemon-local time. When scheduling decides
 to start a session, the scheduler is a socket client: it dispatches a run
 request through the daemon's Unix socket, using the same intake path as manual
 CLI invocation. The scheduler does not call the runner directly. Missed
@@ -137,20 +137,21 @@ do not influence later schedule evaluation.
 
 The runner prepares the execution environment:
 
-1. Creates an ephemeral Podman container from the profile's configured base image. That image must provide a POSIX-compatible shell at `/bin/sh` because the runner's container entrypoint executes through that path.
-2. Sets identity inside the container, including `PROFILE_NAME` and a unique container name derived from the profile.
+1. Creates an ephemeral Podman container from the agent's configured base image. That image must provide a POSIX-compatible shell at `/bin/sh` because the runner's container entrypoint executes through that path.
+2. Sets identity inside the container, including `AGENT_NAME` and a unique container name derived from the agent.
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
-5. Creates an unprivileged unix user whose username is the configured profile name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before the session command starts. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, or `gosu` are not supported.
-6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{profile}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
+5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before `runa init` and the agent command start. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, `gosu`, or `runa` are not supported.
+6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{agent}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
 7. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets, the runner-owned audit leaf `/home/{username}/.agentd/audit/runa`, and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself, `/home/{username}/.agentd` plus its descendants, and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
 8. When manual invocation includes operator input, reads the active methodology's `manifest.toml` plus `schemas/<type>.schema.json` on the host, validates the input there, stages the final JSON under a runner-managed bind mount at `/agentd/invocation-input`, and rejects unsupported request canonical versions before any container is created. In `v0.1.x`, request-text input supports canonical request version `1.0.0` only, keyed by `x-tesserine-canonical.version`.
-9. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
-10. When staged invocation input is present, copies it into `.runa/workspace/<type>/<id>.json` before dropping privileges and launching the profile command.
+9. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`, then makes the audit-backed runa directory writable by the session user. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
+10. Invokes `runa init --methodology /agentd/methodology/manifest.toml` as the session user. Runa owns `.runa/` file formats; agentd does not write `.runa/config.toml` or an `[agent]` section.
+11. When staged invocation input is present, copies it into `.runa/workspace/<type>/<id>.json` after runa initialization and before launching the agent command.
 
 ### Phase 3: Execution (`agentd-runner`)
 
-The runner drops privileges with `gosu` and launches the profile's configured session command as the unprivileged session user from `/home/{username}/repo`, exporting `AGENTD_WORK_UNIT` when the invocation includes one, then supervises the container until natural completion or an optional timeout. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange.
+The runner drops privileges with `gosu` and launches `runa run [--work-unit <id>] --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange.
 
 ### Phase 4: Teardown (`agentd-runner`)
 
@@ -162,7 +163,7 @@ read-only on the host, then publishes a read-only `session.json` as the final
 commit point. Ancestor directories remain writable because the atomic replace
 requires a writable parent directory. The ephemeral container workspace still
 disappears, but the host audit record remains at
-`{audit_root}/{profile}/{session_id}/`.
+`{audit_root}/{agent}/{session_id}/`.
 
 If agentd is interrupted after writing start metadata but before finalization,
 if teardown cleanup fails before finalization can begin, or if audit
@@ -186,9 +187,9 @@ agentd runs sessions in ephemeral Podman containers so agents remain separated f
 | Mount or Injection | Purpose | Need Served |
 |---|---|---|
 | Read-only methodology directory | Expose the configured methodology manifest and protocol assets without allowing mutation | Context |
-| Read-only invocation input mount at `/agentd/invocation-input` | Carry validated operator-supplied JSON into the container so the runner can materialize it in `.runa/workspace` before the profile command starts | Mission |
+| Read-only invocation input mount at `/agentd/invocation-input` | Carry validated operator-supplied JSON into the container so the runner can materialize it in `.runa/workspace` after `runa init` and before `runa run` | Mission |
 | Runner-owned audit bind mount at `/home/{username}/.agentd/audit/runa` | Persist runa state on the host while keeping agentd metadata distinct in the same session record | Context, Mission |
-| Profile-declared bind mounts | Expose host-managed state such as subscription auth or persistent artifact storage with per-mount read-only vs read-write policy | Context, Credentials |
+| Agent-declared bind mounts | Expose host-managed state such as subscription auth or persistent artifact storage with per-mount read-only vs read-write policy | Context, Credentials |
 | Credentials | Authenticate to external systems without baking secrets into images | Credentials |
 | Home workspace at `/home/{username}` with repo at `/home/{username}/repo` | Give the session a writable standard Linux home and a clean project workspace that starts fresh each run | Mission, Tool Availability, Identity |
 
@@ -198,14 +199,14 @@ From inside the environment, an agent should see:
 - a read-only methodology mount rooted at `manifest.toml`
 - a read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied
 - a runner-managed audit bridge at `/home/{username}/repo/.runa -> /home/{username}/.agentd/audit/runa`
-- any additional bind mounts declared by the selected profile
+- any additional bind mounts declared by the selected agent
 - a fresh writable repository checkout at `/home/{username}/repo`
-- any runtime-managed state the configured session command creates inside the repo or home directory
+- any runtime-managed state runa or the configured agent command creates inside the repo or home directory
 - the tools and runtime configuration needed for its assigned work
 
-Additional bind mounts are declared in profile configuration as `source`,
+Additional bind mounts are declared in agent configuration as `source`,
 `target`, and `read_only`. agentd validates absolute container targets plus a
-per-profile disjointness invariant: target paths must be unique and no target
+per-agent disjointness invariant: target paths must be unique and no target
 may be a path-component prefix of another. It then stages canonical host
 sources through runner-managed symlinks before calling Podman so host paths
 containing commas remain mountable. Subscription auth is the first read-only
@@ -216,7 +217,7 @@ container-compatible context.
 
 The invocation-input mount is runner-owned, not operator-owned. Its target
 `/agentd/invocation-input` is reserved alongside `/agentd/methodology`, so
-profile-declared mounts cannot collide with the pre-command input-materialization
+agent-declared mounts cannot collide with the pre-command input-materialization
 path.
 
 The internal audit mount is different from operator-declared mounts. It is
@@ -227,14 +228,14 @@ mounted into the container; it stays host-only so runa-written state and
 agentd-written metadata are distinguishable on disk without disambiguation.
 
 Host audit records live under the resolved audit root, by default
-`$XDG_STATE_HOME/tesserine/audit/<profile>/<session_id>/` or
-`$HOME/.local/state/tesserine/audit/<profile>/<session_id>/` when
+`$XDG_STATE_HOME/tesserine/audit/<agent>/<session_id>/` or
+`$HOME/.local/state/tesserine/audit/<agent>/<session_id>/` when
 `XDG_STATE_HOME` is unset. Root-owned system installs should set
 `daemon.audit_root = "/var/lib/tesserine/audit"`. Each record has this
 layout:
 
 - `runa/` — preserved runa state written naturally by the runtime
-- `agentd/session.json` — agentd-written metadata (`session_id`, `profile`,
+- `agentd/session.json` — agentd-written metadata (`session_id`, `agent`,
   `repo_url`, optional `work_unit`, timestamps, outcome, exit code when
   applicable) written by atomic temp-file replacement within the record
   directory
@@ -268,7 +269,7 @@ model. If probe-file creation succeeds but probe-file removal fails, the audit
 root can retain that uniquely named probe file as leftover cruft.
 
 Session ids are 16 lowercase hex characters generated from `getrandom`, giving
-roughly `2^64` possible values per profile and a birthday bound near `2^32`
+roughly `2^64` possible values per agent and a birthday bound near `2^32`
 sessions before collisions become materially likely. On collision,
 `create_dir_all` would silently reuse the existing directory tree and merge two
 records. That is not an operational concern at current scale, but operators
@@ -277,26 +278,26 @@ risk envelope.
 
 ## 6. Credential Flow
 
-Credentials are declared by profile configuration as daemon-side environment variable names. For each configured credential, the daemon resolves `source` with `std::env::var(source)` from its own process environment before calling `agentd-runner`. Operators provide those values through normal host mechanisms such as systemd `EnvironmentFile=`, shell exports, or container environment injection. During session setup, the runner receives only the already-resolved credential values, creates Podman-managed ephemeral secrets for non-empty values, and injects those values into the execution environment as environment variables without placing the secret values on the Podman command line. Empty assignments are injected directly as `NAME=` because Podman secrets reject zero-byte payloads. Once the container reaches the running state, the runner removes the backing Podman secret objects and relies on the in-container environment copy for the rest of the session.
+Credentials are declared by agent configuration as daemon-side environment variable names. For each configured credential, the daemon resolves `source` with `std::env::var(source)` from its own process environment before calling `agentd-runner`. Operators provide those values through normal host mechanisms such as systemd `EnvironmentFile=`, shell exports, or container environment injection. During session setup, the runner receives only the already-resolved credential values, creates Podman-managed ephemeral secrets for non-empty values, and injects those values into the execution environment as environment variables without placing the secret values on the Podman command line. Empty assignments are injected directly as `NAME=` because Podman secrets reject zero-byte payloads. Once the container reaches the running state, the runner removes the backing Podman secret objects and relies on the in-container environment copy for the rest of the session.
 
 Because startup reconciliation is scoped per daemon instance rather than to the
 whole Podman namespace, the daemon removes only runner-managed resources whose
 names carry its own derived daemon id: dead
-`agentd-{daemon8}-{profile}-{session16}` containers are removed first, then
+`agentd-{daemon8}-{agent}-{session16}` containers are removed first, then
 orphaned `agentd-{daemon8}-{session16}-{suffix}` secrets whose session
 container is gone.
 
-Repository clone authentication is a separate invocation concern rather than an agent runtime credential. When a profile declares `repo_token_source`, the daemon resolves that environment variable at dispatch time and, when the resolved value is non-empty, maps it to `SessionInvocation.repo_token`. The runner then injects that bearer token through its own ephemeral secret, uses it only for the `git clone` invocation, and unsets the internal token variable before the session command starts so the token does not persist in git config or the agent runtime environment.
+Repository clone authentication is a separate invocation concern rather than an agent runtime credential. When an agent declares `repo_token_source`, the daemon resolves that environment variable at dispatch time and, when the resolved value is non-empty, maps it to `SessionInvocation.repo_token`. The runner then injects that bearer token through its own ephemeral secret, uses it only for the `git clone` invocation, and unsets the internal token variable before `runa init` or the agent command starts so the token does not persist in git config or the agent runtime environment.
 
-Isolation is per profile: one profile receives only its own declared credentials. Sharing access to the same external service still requires separate credential declarations per profile so compromise remains scoped.
+Isolation is per agent: one agent receives only its own declared credentials. Sharing access to the same external service still requires separate credential declarations per agent so compromise remains scoped.
 
 ## 7. Verification Matrix
 
 | Need | Architectural Decision | Workspace Evidence | Failure if Violated |
 |---|---|---|---|
 | Network | Session environments receive deployment-controlled network access | `agentd-runner` owns session setup | Agents cannot reach external services |
-| Credentials | Secrets are injected at launch, not stored in code or images | `agentd` resolves configured environment-variable sources and `agentd-runner` accepts the resolved values | Sessions cannot authenticate or credentials leak across profiles |
-| Identity | Each session receives stable in-container identity variables and container naming | `agentd-runner` session contract and Podman lifecycle | Operators cannot distinguish which profile a session belongs to |
+| Credentials | Secrets are injected at launch, not stored in code or images | `agentd` resolves configured environment-variable sources and `agentd-runner` accepts the resolved values | Sessions cannot authenticate or credentials leak across agents |
+| Identity | Each session receives stable in-container identity variables and container naming | `agentd-runner` session contract and Podman lifecycle | Operators cannot distinguish which agent a session belongs to |
 | Mission | Scheduling or CLI invocation hands repo and optional work unit into session launch | `agentd-scheduler` plus `agentd-runner` boundary | Agents run without a reason or target |
 | Tool Availability | Tools are provided through the environment; MCP remains a runtime concern | Three-crate workspace with no transport crate | agentd would absorb protocol work it does not need |
 | Context | Methodology assets are mounted read-only into sessions and the repo is freshly cloned per run | `agentd-runner` boundary and crate intent | Agents operate without local awareness |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{agent}`, and `/home/{agent}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
 - Agent-declared bind mounts now reject overlapping container targets within the same agent, so nested targets fail validation before startup instead of reaching the container setup script.
 - Persistent audit records now default to `$XDG_STATE_HOME/tesserine/audit/<agent>/<session_id>/`, falling back to `$HOME/.local/state/tesserine/audit/<agent>/<session_id>/` for rootless installs, with `daemon.audit_root` available as an explicit override for root-owned system installs such as `/var/lib/tesserine/audit/`.
+- Audit metadata now uses `schema_version: 2` for the breaking identity field rename from `profile` to `agent`.
 - Completed audit records now seal directories to `0555` and non-symlink entries to `0444`, skip symlinks while sealing, and update `agentd/session.json` through atomic temp-file replacement instead of truncate-and-write.
 - `agentd_runner::SessionSpec` now requires an explicit `audit_root` field, making the audit-record destination part of the runner API instead of an implicit process-environment override.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
-- `agentd run` no longer reads `agentd.toml`: it now accepts `--socket-path <PATH>`, otherwise discovers the daemon socket through `$XDG_RUNTIME_DIR/agentd/agentd.sock` first when `XDG_RUNTIME_DIR` is set; for rootless XDG-unset clients it falls back to `/tmp/agentd-$UID/agentd.sock` with ownership and `0700` checks before `/run/agentd/agentd.sock`, while root XDG-unset clients use `/run/agentd/agentd.sock` directly; profile lookup and default-repo resolution now happen daemon-side.
-- `agentd run` now accepts one per-invocation work surface without profile edits: `--work-unit <id>`, `--request <text>`, or `--artifact-type <type> --artifact-file <path>`. Request text is synthesized into `.runa/workspace/request/operator-input.json`, while artifact-file input places validated JSON at `.runa/workspace/<type>/<file-stem>.json`.
+- Agent configuration is now declarative and uses `[[agents]]` with `[agents.command].argv`; the old profile-table vocabulary and shell-wrapper command shape are removed as a pre-1.0 breaking change. agentd now composes `runa init` and `runa run --agent-command -- <argv>` itself, leaving runa-owned `.runa/` config formats to runa.
+- `agentd run` no longer reads `agentd.toml`: it now accepts `--socket-path <PATH>`, otherwise discovers the daemon socket through `$XDG_RUNTIME_DIR/agentd/agentd.sock` first when `XDG_RUNTIME_DIR` is set; for rootless XDG-unset clients it falls back to `/tmp/agentd-$UID/agentd.sock` with ownership and `0700` checks before `/run/agentd/agentd.sock`, while root XDG-unset clients use `/run/agentd/agentd.sock` directly; agent lookup and default-repo resolution now happen daemon-side.
+- `agentd run` now accepts one per-invocation work surface without agent edits: `--work-unit <id>`, `--request <text>`, or `--artifact-type <type> --artifact-file <path>`. Request text is synthesized into `.runa/workspace/request/operator-input.json`, while artifact-file input places validated JSON at `.runa/workspace/<type>/<file-stem>.json`.
 - `agentd-runner` now declares its real platform contract at compile time: the crate targets Linux only, and downstream non-Linux builds now fail explicitly instead of compiling dead fallback code into a non-functional binary.
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
-- Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{profile}`, and `/home/{profile}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
-- Profile-declared bind mounts now reject overlapping container targets within the same profile, so nested targets fail validation before startup instead of reaching the container setup script.
-- Persistent audit records now default to `$XDG_STATE_HOME/tesserine/audit/<profile>/<session_id>/`, falling back to `$HOME/.local/state/tesserine/audit/<profile>/<session_id>/` for rootless installs, with `daemon.audit_root` available as an explicit override for root-owned system installs such as `/var/lib/tesserine/audit/`.
+- Additional bind mounts now reserve only runner-owned targets (`/agentd/methodology`, `/home/{agent}`, and `/home/{agent}/repo` plus descendants), allowing supported read-only and read-write mounts elsewhere under `$HOME` without runner setup mutating host-backed data.
+- Agent-declared bind mounts now reject overlapping container targets within the same agent, so nested targets fail validation before startup instead of reaching the container setup script.
+- Persistent audit records now default to `$XDG_STATE_HOME/tesserine/audit/<agent>/<session_id>/`, falling back to `$HOME/.local/state/tesserine/audit/<agent>/<session_id>/` for rootless installs, with `daemon.audit_root` available as an explicit override for root-owned system installs such as `/var/lib/tesserine/audit/`.
 - Completed audit records now seal directories to `0555` and non-symlink entries to `0444`, skip symlinks while sealing, and update `agentd/session.json` through atomic temp-file replacement instead of truncate-and-write.
 - `agentd_runner::SessionSpec` now requires an explicit `audit_root` field, making the audit-record destination part of the runner API instead of an implicit process-environment override.
 
@@ -48,16 +49,16 @@ methodology governance.
 ### Operator interface
 
 - Unix socket API for session dispatch.
-- `agentd run <profile>` for manual single-session execution.
-- Optional `repo` argument overrides the profile's configured default.
+- `agentd run <agent>` for manual single-session execution.
+- Optional `repo` argument overrides the agent's configured default.
 
-### Profiles
+### Agents
 
 - Static TOML configuration: base image, methodology directory, credentials,
-  and session command per profile.
-- Profile names validated as safe unix usernames (used for in-container
+  and session command per agent.
+- Agent names validated as safe unix usernames (used for in-container
   unprivileged execution via `gosu`).
-- Optional profile-level `repo` default and cron `schedule` for automated
+- Optional agent-level `repo` default and cron `schedule` for automated
   dispatch.
 - `methodology_dir` paths resolve relative to the config file's directory.
 
@@ -69,7 +70,7 @@ methodology governance.
 - Fresh repository clone into the container workspace. HTTPS-only URL
   validation; SSH and local paths rejected.
 - Unprivileged execution: session command runs as a non-root user via
-  `gosu`, with the profile name as the unix username.
+  `gosu`, with the agent name as the unix username.
 - Optional per-session timeout with forced teardown on expiry.
 
 ### Credentials
@@ -83,6 +84,6 @@ methodology governance.
 
 ### Scheduling
 
-- Cron-based profile scheduling evaluated in daemon-local time.
+- Cron-based agent scheduling evaluated in daemon-local time.
 - Scheduled sessions dispatch through the daemon's Unix socket, sharing the
   same execution path as manual `agentd run` invocations.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ credential injection, workspace setup, identity management. Operators building
 this ad-hoc re-solve the same problems for each agent and each deployment.
 
 agentd is the self-hosted runtime layer. The operator declares *what* through
-profile configuration — which image, which credentials, which methodology.
+agent configuration — which image, which credentials, which methodology.
 agentd owns *how* — container lifecycle, privilege management, resource cleanup.
 The agent gets an isolated, ephemeral workspace with exactly what it needs and
 nothing more.
@@ -27,20 +27,20 @@ nothing more.
 
 v0.1.0 — early development.
 
-The session lifecycle works end-to-end: profile configuration, foreground daemon
+The session lifecycle works end-to-end: agent configuration, foreground daemon
 startup, operator-triggered sessions, ephemeral Podman containers, credential
 injection, execution, and teardown. Startup reconciliation cleans stale
 resources from prior runs. Structured JSON tracing provides operational
 visibility.
-Profiles may now declare a default repository and an optional cron schedule.
+Agents may now declare a default repository and an optional cron schedule.
 Manual runs still flow through `agentd run`, and scheduled runs dispatch
 through the same daemon socket intake without introducing a separate job type.
 Manual runs may also carry per-invocation work input without modifying the
-profile: request text can be synthesized into a canonical request artifact, and
+agent: request text can be synthesized into a canonical request artifact, and
 complete JSON artifacts can be placed directly into the session workspace when
 the active methodology declares the relevant artifact type and schema.
-Profiles may also declare additional bind mounts for host-managed state such as
-subscription auth directories. Independently of profile mounts, agentd now
+Agents may also declare additional bind mounts for host-managed state such as
+subscription auth directories. Independently of agent mounts, agentd now
 persists each session's audit record under the rootless default
 `$XDG_STATE_HOME/tesserine/audit/`, falling back to
 `$HOME/.local/state/tesserine/audit/`, with `daemon.audit_root` available as an
@@ -48,15 +48,15 @@ explicit override for root-owned installs such as `/var/lib/tesserine/audit/`.
 
 ## Configuration
 
-A profile is a named environment specification: base image, methodology
+An agent is a named environment specification: base image, methodology
 directory, optional additional bind mounts, optional default repo, optional
-cron schedule, credentials, and runtime command. Define profiles in a TOML
+cron schedule, credentials, and exact command argv. Define agents in a TOML
 config file — start from
 [`examples/agentd.toml`](examples/agentd.toml):
 
 ```toml
-# Static profile registry for agentd.
-# A profile can carry its own default repo and optional schedule.
+# Static agent registry for agentd.
+# An agent can carry its own default repo and optional schedule.
 
 #[daemon]
 # Optional explicit host path for persistent audit records. Rootless installs
@@ -66,80 +66,53 @@ config file — start from
 # /var/lib/tesserine/audit.
 #audit_root = "/var/lib/tesserine/audit"
 
-[[profiles]]
-# Stable operator-facing profile name used for lookup and container identity.
+[[agents]]
+# Stable operator-facing agent name used for lookup and container identity.
 name = "site-builder"
 # Prebuilt image containing the agent runtime and runa.
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
-# and for every scheduled run of this profile.
+# and for every scheduled run of this agent.
 repo = "https://github.com/pentaxis93/agentd.git"
 # Optional five-field cron expression in daemon-local time.
 schedule = "*/15 * * * *"
-# Static session command executed from the cloned repository. This profile is
-# tightly bound to one app, so the session repo is the project being built.
-command = [
-  "/bin/sh",
-  "-lc",
-  '''
-runa init --methodology /agentd/methodology/manifest.toml
-cat > .runa/config.toml <<'EOF'
-[agent]
-command = ["site-builder", "exec"]
-EOF
-if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
-  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
-fi
-exec runa run
-''',
-]
 # Optional environment variable name resolved by the daemon for clone-only
 # repository authentication. This value does not flow into the agent runtime.
 repo_token_source = "SITE_BUILDER_REPO_TOKEN"
+# Exact argv for the agent process. agentd handles runa init and runa run.
+[agents.command]
+argv = ["site-builder", "exec"]
 
-#[[profiles.mounts]]
-# Additional host bind mounts are declared explicitly per profile.
+#[[agents.mounts]]
+# Additional host bind mounts are declared explicitly per agent.
 # `source` must be an absolute host path and must already exist.
 # `target` must be an absolute path inside the container and must not
-# duplicate or overlap another mount target in the same profile.
+# duplicate or overlap another mount target in the same agent.
 # `read_only = true` is appropriate for host-managed auth directories.
 #source = "/home/core/.claude"
 #target = "/home/site-builder/.claude"
 #read_only = true
 
-[[profiles.credentials]]
+[[agents.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"
 # Environment variable name read from the daemon's own process environment.
 source = "AGENTD_GITHUB_TOKEN"
 
-[[profiles]]
+[[agents]]
 # A home-repo review agent that carries its own review configuration and scans
 # repositories beyond the repo used to launch the session.
 name = "code-reviewer"
 base_image = "ghcr.io/example/code-reviewer:latest"
 methodology_dir = "../groundwork"
 repo = "https://github.com/pentaxis93/agentd.git"
-command = [
-  "/bin/sh",
-  "-lc",
-  '''
-runa init --methodology /agentd/methodology/manifest.toml
-cat > .runa/config.toml <<'EOF'
-[agent]
-command = ["code-reviewer", "exec"]
-EOF
-if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
-  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
-fi
-exec runa run
-''',
-]
 repo_token_source = "CODE_REVIEWER_REPO_TOKEN"
+[agents.command]
+argv = ["code-reviewer", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 ```
@@ -148,15 +121,15 @@ Credential `source` fields name environment variables in the daemon's process
 environment — export them before starting the daemon. Additional `mounts`
 entries are bind mounts: `source` must be an absolute existing host path,
 `target` must be an absolute container path, targets must be unique within the
-profile, and runner-managed targets are reserved: `/agentd/methodology`,
-`/home/{profile}`, `/home/{profile}/.agentd`, and `/home/{profile}/repo` plus
+agent, and runner-managed targets are reserved: `/agentd/methodology`,
+`/home/{agent}`, `/home/{agent}/.agentd`, and `/home/{agent}/repo` plus
 their descendants. Other
-targets under `/home/{profile}` remain supported, including read-only auth
+targets under `/home/{agent}` remain supported, including read-only auth
 mounts such as `/home/site-builder/.claude`. Additional mounts are not
 relabelled; on SELinux-enabled hosts, operators must ensure each host path
 already has a container-compatible label. The base image must provide
-`/bin/sh`, `find`, `git`, `useradd`, `gosu`, and whatever binaries the
-configured session command uses. When a profile declares `schedule`, it must
+`/bin/sh`, `find`, `git`, `useradd`, `gosu`, `runa`, and whatever binaries the
+declared agent command uses. When an agent declares `schedule`, it must
 also declare `repo`. Schedules are evaluated in daemon-local time and missed
 fires are not backfilled after downtime. Persistent audit records default to
 `$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set
@@ -228,8 +201,8 @@ When the `/tmp/agentd-$UID/` fallback exists, the client requires that
 directory to be user-owned and mode `0700`; otherwise it refuses with an
 actionable error instead of trusting an insecure `/tmp` path.
 
-Profile lookup and default-repo resolution now happen daemon-side. The client
-may omit the positional repo argument when the named profile declares `repo`,
+Agent lookup and default-repo resolution now happen daemon-side. The client
+may omit the positional repo argument when the named agent declares `repo`,
 and an explicit repo still overrides the configured default:
 
 ```bash
@@ -266,15 +239,15 @@ the container, the agent sees:
 - Repo-root `.runa` bridged to persistent audit storage
 - Read-only methodology mount at `/agentd/methodology`
 - A runner-managed read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied
-- Any operator-declared additional bind mounts, read-only or read-write per profile
+- Any operator-declared additional bind mounts, read-only or read-write per agent
 - Credentials injected as environment variables
 - `AGENTD_WORK_UNIT` when the invocation includes one
 - A pre-materialized artifact under `.runa/workspace/...` when the invocation includes `--request` or `--artifact-file`
-- The configured session command executing from the repo directory
+- `runa init` state followed by `runa run --agent-command -- <argv>` from the repo directory
 
 The container is force-removed on completion. The session's audit record
 persists on the host under the resolved audit root
-`<audit_root>/<profile>/<session_id>/`, with runa state in `runa/` and agentd
+`<audit_root>/<agent>/<session_id>/`, with runa state in `runa/` and agentd
 metadata in `agentd/session.json`. If teardown cleanup fails, or if audit
 finalization attempts closeout and fails, that metadata remains intentionally
 incomplete with no `end_timestamp` or `outcome`. On successful finalization,
@@ -288,9 +261,9 @@ cause.
 
 ## Scheduled Runs
 
-Profiles with `schedule` run autonomously while the daemon is up. The scheduler
+Agents with `schedule` run autonomously while the daemon is up. The scheduler
 evaluates cron expressions in daemon-local time and opens the same Unix-socket
-client path that `agentd run` uses. Multiple scheduled profiles may overlap,
+client path that `agentd run` uses. Multiple scheduled agents may overlap,
 and their sessions dispatch independently. Session outcomes do not affect later
 schedule evaluation: the next occurrence runs at its next scheduled time.
 
@@ -301,7 +274,7 @@ schedule evaluation: the next occurrence runs at its next scheduled time.
   system is built and why.
 - **[AGENTS.md](AGENTS.md)** — development discipline, BDD workflow, commit and
   branch conventions. Read this before contributing.
-- **[examples/agentd.toml](examples/agentd.toml)** — annotated profile
+- **[examples/agentd.toml](examples/agentd.toml)** — annotated agent
   configuration. Starting point for writing your own.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ nothing more.
 
 ## Status
 
-v0.1.0 — early development.
+v0.1.1 — early development.
 
 The session lifecycle works end-to-end: agent configuration, foreground daemon
 startup, operator-triggered sessions, ephemeral Podman containers, credential

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-const METADATA_SCHEMA_VERSION: u32 = 1;
+const METADATA_SCHEMA_VERSION: u32 = 2;
 const ACTIVE_AUDIT_DIRECTORY_MODE: u32 = 0o755;
 const SEALED_FILE_MODE: u32 = 0o444;
 const SEALED_DIRECTORY_MODE: u32 = 0o555;
@@ -516,7 +516,7 @@ mod tests {
             .expect("initial session metadata should be readable");
         let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
 
-        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["schema_version"], 2);
         assert_eq!(json["session_id"], "0123456789abcdef");
         assert_eq!(json["agent"], "site-builder");
         assert_eq!(json["repo_url"], "https://example.com/agentd.git");

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -27,7 +27,7 @@ pub(crate) struct SessionAuditRecord {
     pub(crate) runa_dir: PathBuf,
     pub(crate) metadata_path: PathBuf,
     pub(crate) session_id: String,
-    pub(crate) profile: String,
+    pub(crate) agent: String,
     pub(crate) repo_url: String,
     pub(crate) work_unit: Option<String>,
     pub(crate) start_timestamp: String,
@@ -42,7 +42,7 @@ pub(crate) enum SessionAuditCompletion<'a> {
 struct SessionAuditMetadata<'a> {
     schema_version: u32,
     session_id: &'a str,
-    profile: &'a str,
+    agent: &'a str,
     repo_url: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     work_unit: Option<&'a str>,
@@ -69,8 +69,8 @@ fn prepare_session_audit_record_at(
     spec: &SessionSpec,
     invocation: &SessionInvocation,
 ) -> Result<SessionAuditRecord, RunnerError> {
-    let profile_dir = host_root.join(&spec.profile_name);
-    let record_dir = profile_dir.join(session_id);
+    let agent_dir = host_root.join(&spec.agent_name);
+    let record_dir = agent_dir.join(session_id);
     let runa_dir = record_dir.join("runa");
     let agentd_dir = record_dir.join("agentd");
     let metadata_path = agentd_dir.join("session.json");
@@ -79,7 +79,7 @@ fn prepare_session_audit_record_at(
     fs::create_dir_all(&agentd_dir)?;
 
     rollback_record_dir_on_error(&record_dir, || {
-        set_active_audit_directory_permissions(&profile_dir)?;
+        set_active_audit_directory_permissions(&agent_dir)?;
         set_active_audit_directory_permissions(&record_dir)?;
         set_active_audit_directory_permissions(&agentd_dir)?;
         set_active_runa_permissions(&runa_dir)?;
@@ -90,7 +90,7 @@ fn prepare_session_audit_record_at(
             runa_dir: runa_dir.clone(),
             metadata_path: metadata_path.clone(),
             session_id: session_id.to_string(),
-            profile: spec.profile_name.clone(),
+            agent: spec.agent_name.clone(),
             repo_url: invocation.repo_url.clone(),
             work_unit: invocation.work_unit.clone(),
             start_timestamp,
@@ -156,7 +156,7 @@ fn write_session_audit_metadata_with_mode(
     let metadata = SessionAuditMetadata {
         schema_version: METADATA_SCHEMA_VERSION,
         session_id: &record.session_id,
-        profile: &record.profile,
+        agent: &record.agent,
         repo_url: &record.repo_url,
         work_unit: record.work_unit.as_deref(),
         start_timestamp: &record.start_timestamp,
@@ -518,7 +518,7 @@ mod tests {
 
         assert_eq!(json["schema_version"], 1);
         assert_eq!(json["session_id"], "0123456789abcdef");
-        assert_eq!(json["profile"], "site-builder");
+        assert_eq!(json["agent"], "site-builder");
         assert_eq!(json["repo_url"], "https://example.com/agentd.git");
         assert_eq!(json["work_unit"], "issue-76");
         assert!(json.get("end_timestamp").is_none());
@@ -646,13 +646,13 @@ mod tests {
     fn prepare_session_audit_record_normalizes_runner_managed_audit_dirs_to_host_traversable_modes()
     {
         let root = unique_test_dir("agentd-audit-dir-normalization");
-        let profile_root = root.join("site-builder");
-        let record_dir = profile_root.join("dir-normalization");
+        let agent_root = root.join("site-builder");
+        let record_dir = agent_root.join("dir-normalization");
         let agentd_dir = record_dir.join("agentd");
 
         fs::create_dir_all(&agentd_dir).expect("audit dir tree should be created");
-        fs::set_permissions(&profile_root, fs::Permissions::from_mode(0o700))
-            .expect("profile dir should become private");
+        fs::set_permissions(&agent_root, fs::Permissions::from_mode(0o700))
+            .expect("agent dir should become private");
         fs::set_permissions(&record_dir, fs::Permissions::from_mode(0o700))
             .expect("record dir should become private");
         fs::set_permissions(&agentd_dir, fs::Permissions::from_mode(0o700))
@@ -672,8 +672,8 @@ mod tests {
         )
         .expect("audit record should be created");
 
-        let profile_mode = fs::metadata(&profile_root)
-            .expect("profile dir metadata should exist")
+        let agent_mode = fs::metadata(&agent_root)
+            .expect("agent dir metadata should exist")
             .permissions()
             .mode();
         let record_mode = fs::metadata(&record.record_dir)
@@ -689,7 +689,7 @@ mod tests {
             .permissions()
             .mode();
 
-        assert_eq!(profile_mode & 0o777, 0o755);
+        assert_eq!(agent_mode & 0o777, 0o755);
         assert_eq!(record_mode & 0o777, 0o755);
         assert_eq!(agentd_mode & 0o777, 0o755);
         assert_eq!(runa_mode & 0o777, 0o777);

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -3,7 +3,7 @@
 //! Manages the podman container lifecycle: building the entrypoint script,
 //! assembling `podman create` arguments, running the container in attached
 //! mode, and classifying the exit result. The container runs as root (UID 0)
-//! for privileged setup, then drops to an unprivileged profile user via `gosu`
+//! for privileged setup, then drops to an unprivileged agent user via `gosu`
 //! before executing the command. Exit code 125 from `podman start
 //! --attach` is ambiguous (podman infrastructure error vs. container process)
 //! and requires container state inspection to disambiguate.
@@ -29,6 +29,7 @@ use std::time::{Duration, Instant};
 const ATTACHED_STDERR_TAIL_LIMIT: usize = 64 * 1024;
 const ATTACHED_STDERR_TRUNCATION_NOTICE: &str = "[stderr truncated to last 65536 bytes]\n";
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
+const METHODOLOGY_MANIFEST_PATH: &str = "/agentd/methodology/manifest.toml";
 const PODMAN_INFRASTRUCTURE_ERROR_EXIT_CODE: i32 = 125;
 
 pub(crate) fn create_container(
@@ -146,19 +147,19 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 
 // Generates the shell script passed as the container entrypoint via
 // `/bin/sh -lc`. The script runs as root (UID 0) to perform privileged setup:
-// creating the profile's unix user, recursively re-owning pre-existing home
+// creating the agent's unix user, recursively re-owning pre-existing home
 // content while preserving host-backed mount targets, cloning the repository,
 // and transferring repository ownership. It then drops privileges permanently
 // via `gosu`
-// and `exec`s the configured session command as the unprivileged profile user
-// from the cloned repository. `set -eu` at the top ensures any setup failure
-// aborts immediately rather than continuing with a broken workspace.
+// then invokes runa as the unprivileged agent user. `set -eu` at the top
+// ensures any setup failure aborts immediately rather than continuing with a
+// broken workspace.
 fn build_container_script(
     spec: &SessionSpec,
     invocation: &SessionInvocation,
     resolved_input: Option<&ResolvedInvocationInput>,
 ) -> String {
-    let username = &spec.profile_name;
+    let username = &spec.agent_name;
     let home_dir_path = session_home_dir(username);
     let home_dir = home_dir_path.display().to_string();
     let internal_audit_dir_path = session_internal_audit_dir(username);
@@ -207,6 +208,22 @@ fn build_container_script(
     script.push_str(&shell_quote(&internal_audit_runa_dir));
     script.push(' ');
     script.push_str(&shell_quote(&repo_runa_dir));
+    script.push_str("\nchown -R ");
+    script.push_str(&shell_quote(&user_group));
+    script.push(' ');
+    script.push_str(&shell_quote(&internal_audit_runa_dir));
+    script.push_str("\nexport HOME=");
+    script.push_str(&shell_quote(&home_dir));
+    if let Some(work_unit) = &invocation.work_unit {
+        script.push_str("\nexport AGENTD_WORK_UNIT=");
+        script.push_str(&shell_quote(work_unit));
+    } else {
+        script.push_str("\nunset AGENTD_WORK_UNIT");
+    }
+    script.push_str("\ngosu ");
+    script.push_str(&shell_quote(&user_group));
+    script.push_str(" runa init --methodology ");
+    script.push_str(&shell_quote(METHODOLOGY_MANIFEST_PATH));
     if let Some(resolved_input) = resolved_input {
         let workspace_dir = format!("{repo_runa_dir}/workspace/{}", resolved_input.artifact_type);
         let artifact_path = format!("{workspace_dir}/{}.json", resolved_input.artifact_id);
@@ -222,18 +239,15 @@ fn build_container_script(
         script.push(' ');
         script.push_str(&shell_quote(&workspace_dir));
     }
-    script.push_str("\nexport HOME=");
-    script.push_str(&shell_quote(&home_dir));
-    if let Some(work_unit) = &invocation.work_unit {
-        script.push_str("\nexport AGENTD_WORK_UNIT=");
-        script.push_str(&shell_quote(work_unit));
-    } else {
-        script.push_str("\nunset AGENTD_WORK_UNIT");
-    }
     script.push_str("\nexec gosu ");
     script.push_str(&shell_quote(&user_group));
-    script.push(' ');
-    script.push_str(&shell_join(&spec.command));
+    script.push_str(" runa run");
+    if let Some(work_unit) = &invocation.work_unit {
+        script.push_str(" --work-unit ");
+        script.push_str(&shell_quote(work_unit));
+    }
+    script.push_str(" --agent-command -- ");
+    script.push_str(&shell_join(&spec.agent_command));
 
     script
 }

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -23,7 +23,7 @@ fn test_audit_record() -> SessionAuditRecord {
             "/tmp/audit/site-builder/0123456789abcdef/agentd/session.json",
         ),
         session_id: "0123456789abcdef".to_string(),
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: VALID_REMOTE_REPO_URL.to_string(),
         work_unit: None,
         start_timestamp: "2026-04-16T00:00:00Z".to_string(),
@@ -267,11 +267,16 @@ fn build_container_script_disables_git_terminal_prompts() {
 }
 
 #[test]
-fn build_container_script_creates_home_workspace_and_execs_profile_command_from_repo_as_unprivileged_user()
- {
+fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent_command() {
     let script = build_container_script(
         &crate::SessionSpec {
-            profile_name: "myprofile".to_string(),
+            agent_name: "myagent".to_string(),
+            agent_command: vec![
+                "site-builder".to_string(),
+                "exec".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ],
             ..test_session_spec()
         },
         &SessionInvocation {
@@ -284,61 +289,63 @@ fn build_container_script_creates_home_workspace_and_execs_profile_command_from_
         None,
     );
 
-    assert!(script.contains("useradd --create-home --home-dir '/home/myprofile' --shell /bin/sh --user-group 'myprofile'"));
-    assert!(script.contains("\nmkdir -p '/home/myprofile/.agentd/audit'\n"));
     assert!(script.contains(
-        "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/.agentd/audit/runa' -o -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
+        "useradd --create-home --home-dir '/home/myagent' --shell /bin/sh --user-group 'myagent'"
+    ));
+    assert!(script.contains("\nmkdir -p '/home/myagent/.agentd/audit'\n"));
+    assert!(script.contains(
+        "\nfind '/home/myagent' -mindepth 0 \\( -path '/home/myagent/.agentd/audit/runa' -o -path '/home/myagent/repo' \\) -prune -o -exec chown 'myagent:myagent' {} +\n"
     ));
     assert!(script.contains(
-        "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/myprofile/repo'"
+        "git clone --no-hardlinks -- 'https://example.com/agentd.git' '/home/myagent/repo'"
     ));
-    assert!(script.contains("\ncd '/home/myprofile/repo'\n"));
-    assert!(script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile/repo'\n"));
+    assert!(script.contains("\ncd '/home/myagent/repo'\n"));
+    assert!(script.contains("\nchown -R 'myagent:myagent' '/home/myagent/repo'\n"));
     assert!(
         script.contains(
-            "if [ -e '/home/myprofile/repo/.runa' ] || [ -L '/home/myprofile/repo/.runa' ]; then"
+            "if [ -e '/home/myagent/repo/.runa' ] || [ -L '/home/myagent/repo/.runa' ]; then"
         ),
         "{script}"
     );
     assert!(
-        script.contains(
-            "\nln -s '/home/myprofile/.agentd/audit/runa' '/home/myprofile/repo/.runa'\n"
-        )
+        script.contains("\nln -s '/home/myagent/.agentd/audit/runa' '/home/myagent/repo/.runa'\n")
     );
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
-    assert!(!script.contains("\nchown -R 'myprofile:myprofile' '/home/myprofile'\n"));
-    assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
-    assert!(script.contains("\nexport AGENTD_WORK_UNIT='task-42'\n"));
-    assert!(script.contains("exec gosu 'myprofile:myprofile' 'site-builder' 'exec'"));
-    assert!(!script.contains("runa init"));
+    assert!(!script.contains("\nchown 'myagent:myagent' '/home/myagent'\n"));
+    assert!(!script.contains("\nchown -R 'myagent:myagent' '/home/myagent'\n"));
+    assert!(script.contains("\nexport HOME='/home/myagent'\n"));
+    assert!(script.contains(
+        "\ngosu 'myagent:myagent' runa init --methodology '/agentd/methodology/manifest.toml'\n"
+    ));
     assert!(!script.contains(".runa/config.toml"));
-    assert!(!script.contains("runa run"));
+    assert!(script.contains(
+        "\nexec gosu 'myagent:myagent' runa run --work-unit 'task-42' --agent-command -- 'site-builder' 'exec' '--sandbox' 'workspace-write'"
+    ));
 }
 
 #[test]
 fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_targets() {
     let script = build_container_script(
         &crate::SessionSpec {
-            profile_name: "myprofile".to_string(),
+            agent_name: "myagent".to_string(),
             mounts: vec![
                 crate::BindMount {
                     source: PathBuf::from("/srv/claude"),
-                    target: PathBuf::from("/home/myprofile/.claude"),
+                    target: PathBuf::from("/home/myagent/.claude"),
                     read_only: true,
                 },
                 crate::BindMount {
                     source: PathBuf::from("/srv/claude-config"),
-                    target: PathBuf::from("/home/myprofile/.config/claude workspace"),
+                    target: PathBuf::from("/home/myagent/.config/claude workspace"),
                     read_only: false,
                 },
                 crate::BindMount {
                     source: PathBuf::from("/srv/git-config"),
-                    target: PathBuf::from("/home/myprofile/.config/git (session)"),
+                    target: PathBuf::from("/home/myagent/.config/git (session)"),
                     read_only: false,
                 },
                 crate::BindMount {
                     source: PathBuf::from("/srv/deep-tree"),
-                    target: PathBuf::from("/home/myprofile/a/b/c"),
+                    target: PathBuf::from("/home/myagent/a/b/c"),
                     read_only: false,
                 },
                 crate::BindMount {
@@ -361,12 +368,12 @@ fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_t
 
     assert!(
         script.contains(
-            "\nfind '/home/myprofile' -mindepth 0 \\( -path '/home/myprofile/.claude' -o -path '/home/myprofile/.config/claude workspace' -o -path '/home/myprofile/.config/git (session)' -o -path '/home/myprofile/a/b/c' -o -path '/home/myprofile/.agentd/audit/runa' -o -path '/home/myprofile/repo' \\) -prune -o -exec chown 'myprofile:myprofile' {} +\n"
+            "\nfind '/home/myagent' -mindepth 0 \\( -path '/home/myagent/.claude' -o -path '/home/myagent/.config/claude workspace' -o -path '/home/myagent/.config/git (session)' -o -path '/home/myagent/a/b/c' -o -path '/home/myagent/.agentd/audit/runa' -o -path '/home/myagent/repo' \\) -prune -o -exec chown 'myagent:myagent' {} +\n"
         ),
         "home ownership should be repaired with one find traversal that prunes mounts and the repo: {script}"
     );
     assert_eq!(
-        script.matches("-path '/home/myprofile/repo'").count(),
+        script.matches("-path '/home/myagent/repo'").count(),
         1,
         "the repo prune should be emitted exactly once"
     );
@@ -380,16 +387,16 @@ fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_t
 fn build_container_script_does_not_emit_intermediate_home_chown_commands() {
     let script = build_container_script(
         &crate::SessionSpec {
-            profile_name: "myprofile".to_string(),
+            agent_name: "myagent".to_string(),
             mounts: vec![
                 crate::BindMount {
                     source: PathBuf::from("/srv/claude"),
-                    target: PathBuf::from("/home/myprofile/.config/claude"),
+                    target: PathBuf::from("/home/myagent/.config/claude"),
                     read_only: true,
                 },
                 crate::BindMount {
                     source: PathBuf::from("/srv/git-config"),
-                    target: PathBuf::from("/home/myprofile/.config/git"),
+                    target: PathBuf::from("/home/myagent/.config/git"),
                     read_only: false,
                 },
             ],
@@ -405,12 +412,12 @@ fn build_container_script_does_not_emit_intermediate_home_chown_commands() {
         None,
     );
 
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile'\n"));
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config'\n"));
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config/claude'\n"));
-    assert!(!script.contains("\nchown 'myprofile:myprofile' '/home/myprofile/.config/git'\n"));
+    assert!(!script.contains("\nchown 'myagent:myagent' '/home/myagent'\n"));
+    assert!(!script.contains("\nchown 'myagent:myagent' '/home/myagent/.config'\n"));
+    assert!(!script.contains("\nchown 'myagent:myagent' '/home/myagent/.config/claude'\n"));
+    assert!(!script.contains("\nchown 'myagent:myagent' '/home/myagent/.config/git'\n"));
     assert!(
-        script.contains("\nfind '/home/myprofile' -mindepth 0 "),
+        script.contains("\nfind '/home/myagent' -mindepth 0 "),
         "the find traversal should replace standalone home ownership chown lines: {script}"
     );
 }
@@ -419,7 +426,7 @@ fn build_container_script_does_not_emit_intermediate_home_chown_commands() {
 fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
     let script = build_container_script(
         &crate::SessionSpec {
-            profile_name: "myprofile".to_string(),
+            agent_name: "myagent".to_string(),
             ..test_session_spec()
         },
         &SessionInvocation {
@@ -432,9 +439,11 @@ fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
         None,
     );
 
-    assert!(script.contains("\nexport HOME='/home/myprofile'\n"));
+    assert!(script.contains("\nexport HOME='/home/myagent'\n"));
     assert!(script.contains("\nunset AGENTD_WORK_UNIT\n"));
-    assert!(script.contains("\nexec gosu 'myprofile:myprofile' 'site-builder' 'exec'"));
+    assert!(script.contains(
+        "\nexec gosu 'myagent:myagent' runa run --agent-command -- 'site-builder' 'exec'"
+    ));
 }
 
 #[test]
@@ -979,11 +988,11 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let fixture = FakePodmanFixture::new();
     fixture.install(&FakePodmanScenario::new());
-    let profile_name = "myprofile";
+    let agent_name = "myagent";
 
     let methodology_dir = fixture.create_methodology_dir("runner-methodology");
     let outcome = fixture.run_with_fake_podman(crate::SessionSpec {
-        profile_name: profile_name.to_string(),
+        agent_name: agent_name.to_string(),
         methodology_dir,
         environment: vec![ResolvedEnvironmentVariable {
             name: "GITHUB_TOKEN".to_string(),
@@ -1015,10 +1024,10 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
         .expect("secret create should include a secret name");
 
     let daemon_instance_id = test_session_spec().daemon_instance_id;
-    let container_prefix = format!("agentd-{daemon_instance_id}-{profile_name}-");
+    let container_prefix = format!("agentd-{daemon_instance_id}-{agent_name}-");
     let session_id = container_name
         .strip_prefix(&container_prefix)
-        .expect("container name should include daemon and profile prefix");
+        .expect("container name should include daemon and agent prefix");
     let stage_suffix = stage_dir_name
         .strip_prefix("agentd-session-stage-")
         .expect("staging dir should include session stage prefix");

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -28,13 +28,13 @@ pub(crate) mod test_support;
 
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
-    BindMount, EnvironmentNameValidationError, InvocationInput, MountOverlapError,
-    MountTargetValidationError, ProfileNameValidationError, ResolvedEnvironmentVariable,
-    RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    AgentNameValidationError, BindMount, EnvironmentNameValidationError, InvocationInput,
+    MountOverlapError, MountTargetValidationError, ResolvedEnvironmentVariable, RunnerError,
+    SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
 pub use validation::{
-    validate_environment_name, validate_mount_overlap, validate_mount_target,
-    validate_profile_name, validate_repo_url,
+    validate_agent_name, validate_environment_name, validate_mount_overlap, validate_mount_target,
+    validate_repo_url,
 };
 
 use audit::{SessionAuditCompletion, finalize_session_audit_record, prepare_session_audit_record};
@@ -74,11 +74,11 @@ pub fn run_session(
     let session_id = unique_suffix()?;
 
     let container_name =
-        format_container_name(&spec.daemon_instance_id, &spec.profile_name, &session_id);
+        format_container_name(&spec.daemon_instance_id, &spec.agent_name, &session_id);
     log_session_started(
         &session_id,
         &container_name,
-        &spec.profile_name,
+        &spec.agent_name,
         invocation.work_unit.is_some(),
         invocation.timeout,
     );
@@ -292,10 +292,10 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    fn only_session_record_dir(audit_root: &Path, profile_name: &str) -> PathBuf {
-        let profile_root = audit_root.join(profile_name);
-        let entries = fs::read_dir(&profile_root)
-            .unwrap_or_else(|error| panic!("failed to read {}: {error}", profile_root.display()))
+    fn only_session_record_dir(audit_root: &Path, agent_name: &str) -> PathBuf {
+        let agent_root = audit_root.join(agent_name);
+        let entries = fs::read_dir(&agent_root)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", agent_root.display()))
             .map(|entry| {
                 entry
                     .expect("session record entry should be readable")
@@ -307,7 +307,7 @@ mod tests {
             entries.len(),
             1,
             "expected exactly one session record under {}",
-            profile_root.display()
+            agent_root.display()
         );
         entries[0].clone()
     }
@@ -965,12 +965,12 @@ file find -P {root} ! -type d ! -type l ! -path {metadata_path} -exec chmod 444 
 
     fn wait_for_only_session_record_dir(
         audit_root: &Path,
-        profile_name: &str,
+        agent_name: &str,
         deadline: Instant,
     ) -> PathBuf {
         loop {
-            let profile_root = audit_root.join(profile_name);
-            if let Ok(entries) = fs::read_dir(&profile_root) {
+            let agent_root = audit_root.join(agent_name);
+            if let Ok(entries) = fs::read_dir(&agent_root) {
                 let entries = entries
                     .map(|entry| {
                         entry
@@ -987,7 +987,7 @@ file find -P {root} ! -type d ! -type l ! -path {metadata_path} -exec chmod 444 
             assert!(
                 Instant::now() < deadline,
                 "timed out waiting for session record under {}",
-                profile_root.display()
+                agent_root.display()
             );
             thread::sleep(Duration::from_millis(25));
         }

--- a/crates/agentd-runner/src/lifecycle.rs
+++ b/crates/agentd-runner/src/lifecycle.rs
@@ -58,7 +58,7 @@ pub(crate) fn log_lifecycle_failure<E>(
 pub(crate) fn log_session_started(
     session_id: &str,
     container_name: &str,
-    profile_name: &str,
+    agent_name: &str,
     work_unit_present: bool,
     timeout: Option<Duration>,
 ) {
@@ -66,7 +66,7 @@ pub(crate) fn log_session_started(
         event = "runner.session_started",
         session_id = session_id,
         container_name = container_name,
-        profile_name = profile_name,
+        agent_name = agent_name,
         work_unit_present = work_unit_present,
         timeout_ms = timeout.map(|value| value.as_millis() as u64),
         "runner session started"

--- a/crates/agentd-runner/src/naming.rs
+++ b/crates/agentd-runner/src/naming.rs
@@ -5,7 +5,7 @@ pub(crate) const SESSION_ID_LEN: usize = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ContainerNameParts<'a> {
     pub(crate) daemon_instance_id: &'a str,
-    pub(crate) profile_name: &'a str,
+    pub(crate) agent_name: &'a str,
     pub(crate) session_id: &'a str,
 }
 
@@ -18,10 +18,10 @@ pub(crate) struct SecretNameParts<'a> {
 
 pub(crate) fn format_container_name(
     daemon_instance_id: &str,
-    profile_name: &str,
+    agent_name: &str,
     session_id: &str,
 ) -> String {
-    format!("{PODMAN_RESOURCE_PREFIX}{daemon_instance_id}-{profile_name}-{session_id}")
+    format!("{PODMAN_RESOURCE_PREFIX}{daemon_instance_id}-{agent_name}-{session_id}")
 }
 
 pub(crate) fn format_secret_name(
@@ -35,14 +35,14 @@ pub(crate) fn format_secret_name(
 pub(crate) fn parse_container_name(name: &str) -> Option<ContainerNameParts<'_>> {
     let suffix = name.strip_prefix(PODMAN_RESOURCE_PREFIX)?;
     let (daemon_instance_id, remainder) = suffix.split_once('-')?;
-    let (profile_name, session_id) = remainder.rsplit_once('-')?;
+    let (agent_name, session_id) = remainder.rsplit_once('-')?;
 
     (is_daemon_instance_id(daemon_instance_id)
-        && !profile_name.is_empty()
+        && !agent_name.is_empty()
         && is_session_id(session_id))
     .then_some(ContainerNameParts {
         daemon_instance_id,
-        profile_name,
+        agent_name,
         session_id,
     })
 }

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -320,7 +320,7 @@ fn create_audit_mount(
     create_prepared_bind_mount(
         &audit_record.runa_dir,
         staging_dir.join(AUDIT_RUNA_STAGE_LINK_NAME),
-        session_internal_audit_runa_dir(&spec.profile_name),
+        session_internal_audit_runa_dir(&spec.agent_name),
         false,
         true,
     )
@@ -463,7 +463,7 @@ mod tests {
             runa_dir,
             metadata_path,
             session_id: session_id.to_string(),
-            profile: "site-builder".to_string(),
+            agent: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: None,
             start_timestamp: "2026-04-16T00:00:00Z".to_string(),

--- a/crates/agentd-runner/src/session_paths.rs
+++ b/crates/agentd-runner/src/session_paths.rs
@@ -7,26 +7,26 @@ const INTERNAL_AUDIT_DIR_NAME: &str = "audit";
 const INTERNAL_AUDIT_RUNA_DIR_NAME: &str = "runa";
 const REPO_RUNA_DIR_NAME: &str = ".runa";
 
-pub(crate) fn session_home_dir(profile_name: &str) -> PathBuf {
-    PathBuf::from(HOME_ROOT_DIR).join(profile_name)
+pub(crate) fn session_home_dir(agent_name: &str) -> PathBuf {
+    PathBuf::from(HOME_ROOT_DIR).join(agent_name)
 }
 
-pub(crate) fn session_repo_dir(profile_name: &str) -> PathBuf {
-    session_home_dir(profile_name).join(REPO_DIR_NAME)
+pub(crate) fn session_repo_dir(agent_name: &str) -> PathBuf {
+    session_home_dir(agent_name).join(REPO_DIR_NAME)
 }
 
-pub(crate) fn session_internal_agentd_dir(profile_name: &str) -> PathBuf {
-    session_home_dir(profile_name).join(INTERNAL_AGENTD_DIR_NAME)
+pub(crate) fn session_internal_agentd_dir(agent_name: &str) -> PathBuf {
+    session_home_dir(agent_name).join(INTERNAL_AGENTD_DIR_NAME)
 }
 
-pub(crate) fn session_internal_audit_dir(profile_name: &str) -> PathBuf {
-    session_internal_agentd_dir(profile_name).join(INTERNAL_AUDIT_DIR_NAME)
+pub(crate) fn session_internal_audit_dir(agent_name: &str) -> PathBuf {
+    session_internal_agentd_dir(agent_name).join(INTERNAL_AUDIT_DIR_NAME)
 }
 
-pub(crate) fn session_internal_audit_runa_dir(profile_name: &str) -> PathBuf {
-    session_internal_audit_dir(profile_name).join(INTERNAL_AUDIT_RUNA_DIR_NAME)
+pub(crate) fn session_internal_audit_runa_dir(agent_name: &str) -> PathBuf {
+    session_internal_audit_dir(agent_name).join(INTERNAL_AUDIT_RUNA_DIR_NAME)
 }
 
-pub(crate) fn session_repo_runa_dir(profile_name: &str) -> PathBuf {
-    session_repo_dir(profile_name).join(REPO_RUNA_DIR_NAME)
+pub(crate) fn session_repo_runa_dir(agent_name: &str) -> PathBuf {
+    session_repo_dir(agent_name).join(REPO_RUNA_DIR_NAME)
 }

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -14,12 +14,12 @@ const VALID_REMOTE_REPO_URL: &str = "https://example.com/agentd.git";
 pub(crate) fn test_session_spec() -> SessionSpec {
     SessionSpec {
         daemon_instance_id: "1a2b3c4d".to_string(),
-        profile_name: "site-builder".to_string(),
+        agent_name: "site-builder".to_string(),
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
         audit_root: std::env::temp_dir().join("agentd-runner-test-audit-root"),
         mounts: Vec::new(),
-        command: vec!["site-builder".to_string(), "exec".to_string()],
+        agent_command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),
     }
 }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -12,9 +12,9 @@ use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::time::Duration;
 
-/// Static configuration for a session, derived from a profile.
+/// Static configuration for a session, derived from an agent.
 ///
-/// Describes the profile identity, container image, methodology, command, and
+/// Describes the agent identity, container image, methodology, command, and
 /// caller-resolved environment variables. Validated by
 /// [`run_session`](crate::run_session) before any resources are allocated.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,34 +23,34 @@ pub struct SessionSpec {
     /// resource names so startup reconciliation can scope ownership to one
     /// daemon instance.
     pub daemon_instance_id: String,
-    /// Profile identity string. Doubles as the in-container unix username, a
-    /// component of the container name, and the value of the `PROFILE_NAME`
+    /// Agent identity string. Doubles as the in-container unix username, a
+    /// component of the container name, and the value of the `AGENT_NAME`
     /// environment variable. Must pass
-    /// [`validate_profile_name`](crate::validate_profile_name).
-    pub profile_name: String,
+    /// [`validate_agent_name`](crate::validate_agent_name).
+    pub agent_name: String,
     /// Container image reference. The image must provide `/bin/sh`, `git`,
     /// `find`, and the setup/session binaries required by the configured
-    /// profile command in `PATH`, including `useradd` and `gosu`.
+    /// agent command in `PATH`, including `useradd` and `gosu`.
     pub base_image: String,
     /// Host-side path to the methodology directory. Mounted read-only into
     /// the container at `/agentd/methodology`. Must contain `manifest.toml`.
     pub methodology_dir: PathBuf,
     /// Host-side root where persistent audit records are created. The runner
-    /// stores each session under `<audit_root>/<profile>/<session_id>/`.
+    /// stores each session under `<audit_root>/<agent>/<session_id>/`.
     pub audit_root: PathBuf,
-    /// Additional host bind mounts declared by the selected profile.
+    /// Additional host bind mounts declared by the selected agent.
     pub mounts: Vec<BindMount>,
     /// Command array executed directly from the cloned repository after
-    /// workspace setup. Not a shell command unless the profile explicitly
+    /// workspace setup. Not a shell command unless the agent explicitly
     /// configures one (for example, `["/bin/sh", "-lc", "..."]`).
-    pub command: Vec<String>,
+    pub agent_command: Vec<String>,
     /// Caller-resolved environment variables injected into the container.
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
     pub environment: Vec<ResolvedEnvironmentVariable>,
 }
 
-/// A host bind mount declared by a session profile.
+/// A host bind mount declared by a session agent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BindMount {
     /// Host-side source path to bind into the container.
@@ -69,7 +69,7 @@ pub struct BindMount {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedEnvironmentVariable {
     /// Variable name. Must not be empty, contain `,` or `=`, or collide with
-    /// runner-managed names (currently `PROFILE_NAME`).
+    /// runner-managed names (currently `AGENT_NAME`).
     pub name: String,
     /// Variable value. Empty values are legal and are injected as direct
     /// `--env NAME=` assignments rather than podman secrets, which reject
@@ -107,12 +107,13 @@ pub struct SessionInvocation {
     /// request for `https://` repository URLs. This token is not passed
     /// through to the agent runtime.
     pub repo_token: Option<String>,
-    /// Optional work unit identifier exposed to the session command through
-    /// the runner-managed `AGENTD_WORK_UNIT` environment variable when set.
+    /// Optional work unit identifier passed to `runa run --work-unit` and
+    /// exposed through the runner-managed `AGENTD_WORK_UNIT` environment
+    /// variable when set.
     /// Mutually exclusive with [`Self::input`].
     pub work_unit: Option<String>,
     /// Optional operator-supplied input to materialize into the repo
-    /// workspace before the session command runs. Artifact names supplied
+    /// workspace after `runa init` and before `runa run`. Artifact names supplied
     /// through [`InvocationInput::Artifact`] must each be a single path
     /// segment. Mutually exclusive with [`Self::work_unit`].
     pub input: Option<InvocationInput>,
@@ -250,7 +251,7 @@ mod tests {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct StartupReconciliationReport {
     /// Stale runner-managed session containers matching
-    /// `agentd-{daemon8}-{profile}-{session16}` that were removed during startup.
+    /// `agentd-{daemon8}-{agent}-{session16}` that were removed during startup.
     pub removed_container_names: Vec<String>,
     /// Orphaned runner-managed secrets matching `agentd-{daemon8}-{session16}-{suffix}`
     /// that were removed during startup.
@@ -268,10 +269,10 @@ pub enum EnvironmentNameValidationError {
     Reserved,
 }
 
-/// Error returned by [`validate_profile_name`](crate::validate_profile_name)
+/// Error returned by [`validate_agent_name`](crate::validate_agent_name)
 /// when a name violates naming rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProfileNameValidationError {
+pub enum AgentNameValidationError {
     /// The name is not a valid unix username: must start with a lowercase
     /// letter, contain only lowercase letters, digits, `_`, or `-`, and be
     /// at most 32 characters.
@@ -304,7 +305,7 @@ pub struct MountOverlapError {
 
 /// Errors produced during session execution.
 ///
-/// Validation errors ([`InvalidProfileName`](Self::InvalidProfileName),
+/// Validation errors ([`InvalidAgentName`](Self::InvalidAgentName),
 /// [`InvalidBaseImage`](Self::InvalidBaseImage), etc.) are returned before
 /// any resources are allocated. Resource and execution errors
 /// ([`MissingMethodologyManifest`](Self::MissingMethodologyManifest),
@@ -318,9 +319,9 @@ pub enum RunnerError {
     /// The methodology directory does not contain `manifest.toml`. Produced
     /// during resource allocation, after spec and invocation validation pass.
     MissingMethodologyManifest { path: PathBuf },
-    /// The profile name fails unix username rules or matches a reserved system
+    /// The agent name fails unix username rules or matches a reserved system
     /// name. Produced during spec validation.
-    InvalidProfileName,
+    InvalidAgentName,
     /// The base image string is empty or has surrounding whitespace. Produced
     /// during spec validation.
     InvalidBaseImage,
@@ -385,9 +386,9 @@ impl fmt::Display for RunnerError {
                     path.display()
                 )
             }
-            RunnerError::InvalidProfileName => write!(
+            RunnerError::InvalidAgentName => write!(
                 f,
-                "profile_name must already be a unix username starting with a lowercase letter, containing only lowercase letters, digits, '_', or '-', be at most 32 characters, and not be one of the reserved system names root, nobody, daemon, bin, sys, man, or mail"
+                "agent_name must already be a unix username starting with a lowercase letter, containing only lowercase letters, digits, '_', or '-', be at most 32 characters, and not be one of the reserved system names root, nobody, daemon, bin, sys, man, or mail"
             ),
             RunnerError::InvalidBaseImage => write!(f, "base_image must not be empty"),
             RunnerError::InvalidAuditRoot { path } => {

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -2,7 +2,7 @@
 //!
 //! All validation runs before any filesystem or podman interaction, so invalid
 //! inputs are rejected without side effects. The public validators
-//! ([`validate_profile_name`], [`validate_environment_name`], and
+//! ([`validate_agent_name`], [`validate_environment_name`], and
 //! [`validate_mount_target`], [`validate_mount_overlap`]) are also used by the
 //! configuration layer in the `agentd` crate.
 
@@ -10,16 +10,16 @@ use crate::input::INVOCATION_INPUT_MOUNT_PATH;
 use crate::naming::is_daemon_instance_id;
 use crate::session_paths::{session_home_dir, session_internal_agentd_dir, session_repo_dir};
 use crate::types::{
-    BindMount, EnvironmentNameValidationError, MountOverlapError, MountTargetValidationError,
-    ProfileNameValidationError, RunnerError, SessionInvocation, SessionSpec,
+    AgentNameValidationError, BindMount, EnvironmentNameValidationError, MountOverlapError,
+    MountTargetValidationError, RunnerError, SessionInvocation, SessionSpec,
 };
 use std::collections::HashSet;
 use std::path::Path;
 
-const PROFILE_NAME_ENV: &str = "PROFILE_NAME";
+const AGENT_NAME_ENV: &str = "AGENT_NAME";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
 pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
-const RESERVED_PROFILE_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys", "man", "mail"];
+const RESERVED_AGENT_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys", "man", "mail"];
 const SUPPORTED_REPO_URL_FORMS: &str = "https://, http://, or git://";
 const SUPPORTED_REPO_URL_PREFIXES: [&str; 3] = ["https://", "http://", "git://"];
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
@@ -28,8 +28,8 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     if !is_daemon_instance_id(&spec.daemon_instance_id) {
         return Err(RunnerError::InvalidDaemonInstanceId);
     }
-    if validate_profile_name(&spec.profile_name).is_err() {
-        return Err(RunnerError::InvalidProfileName);
+    if validate_agent_name(&spec.agent_name).is_err() {
+        return Err(RunnerError::InvalidAgentName);
     }
     if spec.base_image.trim().is_empty() || spec.base_image != spec.base_image.trim() {
         return Err(RunnerError::InvalidBaseImage);
@@ -39,7 +39,7 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
             path: spec.audit_root.clone(),
         });
     }
-    if spec.command.is_empty() || spec.command.iter().any(|arg| arg.is_empty()) {
+    if spec.agent_command.is_empty() || spec.agent_command.iter().any(|arg| arg.is_empty()) {
         return Err(RunnerError::InvalidCommand);
     }
 
@@ -50,7 +50,7 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
                 path: mount.source.clone(),
             });
         }
-        match validate_mount_target(&mount.target, &spec.profile_name) {
+        match validate_mount_target(&mount.target, &spec.agent_name) {
             Ok(()) => {}
             Err(MountTargetValidationError::Invalid { path }) => {
                 return Err(RunnerError::InvalidMountTarget { path });
@@ -93,10 +93,10 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
 /// Rejects targets that are not absolute, contain `.` or `..` components,
 /// contain `,`, end with `/`, contain `find -path` metacharacters, or collide
 /// with runner-managed paths such as `/agentd/methodology`,
-/// `/home/{profile}`, or `/home/{profile}/repo`.
+/// `/home/{agent}`, or `/home/{agent}/repo`.
 pub fn validate_mount_target(
     target: &Path,
-    profile_name: &str,
+    agent_name: &str,
 ) -> Result<(), MountTargetValidationError> {
     if !target.is_absolute()
         || has_relative_mount_target_component(target)
@@ -108,7 +108,7 @@ pub fn validate_mount_target(
             path: target.to_path_buf(),
         });
     }
-    if is_reserved_mount_target(target, profile_name) {
+    if is_reserved_mount_target(target, agent_name) {
         return Err(MountTargetValidationError::Reserved {
             target: target.to_path_buf(),
         });
@@ -120,7 +120,7 @@ pub fn validate_mount_target(
 /// Validates that declared bind-mount targets are pairwise non-overlapping.
 ///
 /// Rejects distinct targets when one is a component-aware prefix of the other,
-/// such as `/home/{profile}/.config` and `/home/{profile}/.config/claude`.
+/// such as `/home/{agent}/.config` and `/home/{agent}/.config/claude`.
 pub fn validate_mount_overlap(mounts: &[BindMount]) -> Result<(), MountOverlapError> {
     for (index, mount) in mounts.iter().enumerate() {
         for other in mounts.iter().skip(index + 1) {
@@ -161,7 +161,7 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
 /// Validates an environment variable name against naming rules.
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
-/// runner-managed names (currently `PROFILE_NAME`, `AGENTD_WORK_UNIT`, and
+/// runner-managed names (currently `AGENT_NAME`, `AGENTD_WORK_UNIT`, and
 /// `AGENTD_REPO_TOKEN`). Used both by
 /// [`run_session`](crate::run_session) during spec validation and by the
 /// configuration layer for credential name validation.
@@ -176,19 +176,19 @@ pub fn validate_environment_name(name: &str) -> Result<(), EnvironmentNameValida
     Ok(())
 }
 
-/// Validates a profile name against unix username rules and reserved names.
+/// Validates an agent name against unix username rules and reserved names.
 ///
 /// The name must start with a lowercase ASCII letter, contain only lowercase
 /// letters, digits, `_`, or `-`, and be at most 32 characters. Names matching
 /// reserved system usernames (`root`, `nobody`, `daemon`, `bin`, `sys`, `man`,
 /// `mail`) are also rejected. Used both by [`run_session`](crate::run_session)
 /// during spec validation and by the configuration layer.
-pub fn validate_profile_name(name: &str) -> Result<(), ProfileNameValidationError> {
+pub fn validate_agent_name(name: &str) -> Result<(), AgentNameValidationError> {
     if !is_valid_unix_username(name) {
-        return Err(ProfileNameValidationError::Invalid);
+        return Err(AgentNameValidationError::Invalid);
     }
-    if is_reserved_profile_name(name) {
-        return Err(ProfileNameValidationError::Reserved);
+    if is_reserved_agent_name(name) {
+        return Err(AgentNameValidationError::Reserved);
     }
 
     Ok(())
@@ -220,7 +220,7 @@ pub fn validate_repo_url(repo_url: &str) -> Result<(), RunnerError> {
 /// These names are reserved — callers cannot use them in
 /// [`SessionSpec::environment`] because the runner injects them directly.
 pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> [(&str, &str); 1] {
-    [(PROFILE_NAME_ENV, &spec.profile_name)]
+    [(AGENT_NAME_ENV, &spec.agent_name)]
 }
 
 fn is_supported_repo_url(repo_url: &str) -> bool {
@@ -281,17 +281,17 @@ fn repo_token_requires_https_error() -> RunnerError {
 }
 
 fn is_reserved_environment_name(name: &str) -> bool {
-    matches!(name, PROFILE_NAME_ENV | WORK_UNIT_ENV | REPO_TOKEN_ENV)
+    matches!(name, AGENT_NAME_ENV | WORK_UNIT_ENV | REPO_TOKEN_ENV)
 }
 
-fn is_reserved_profile_name(name: &str) -> bool {
-    RESERVED_PROFILE_NAMES.contains(&name)
+fn is_reserved_agent_name(name: &str) -> bool {
+    RESERVED_AGENT_NAMES.contains(&name)
 }
 
-fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
-    let home_dir = session_home_dir(profile_name);
-    let internal_agentd_dir = session_internal_agentd_dir(profile_name);
-    let repo_dir = session_repo_dir(profile_name);
+fn is_reserved_mount_target(target: &Path, agent_name: &str) -> bool {
+    let home_dir = session_home_dir(agent_name);
+    let internal_agentd_dir = session_internal_agentd_dir(agent_name);
+    let repo_dir = session_repo_dir(agent_name);
     let methodology_dir = Path::new(METHODOLOGY_MOUNT_PATH);
     let invocation_input_dir = Path::new(INVOCATION_INPUT_MOUNT_PATH);
 
@@ -311,8 +311,8 @@ fn is_reserved_mount_target(target: &Path, profile_name: &str) -> bool {
     }
 
     // Target and runner-owned repo path must be disjoint by path components:
-    // neither may be a prefix of the other. This keeps `/home/{profile}/repo-cache`
-    // valid while reserving `/home/{profile}/repo`, its descendants, and its
+    // neither may be a prefix of the other. This keeps `/home/{agent}/repo-cache`
+    // valid while reserving `/home/{agent}/repo`, its descendants, and its
     // ancestors.
     if target.starts_with(&repo_dir) || repo_dir.starts_with(target) {
         return true;
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn validate_spec_rejects_reserved_environment_names() {
-        for reserved_name in ["PROFILE_NAME", WORK_UNIT_ENV, REPO_TOKEN_ENV] {
+        for reserved_name in ["AGENT_NAME", WORK_UNIT_ENV, REPO_TOKEN_ENV] {
             let error = validate_spec(&SessionSpec {
                 environment: vec![ResolvedEnvironmentVariable {
                     name: reserved_name.to_string(),
@@ -1035,8 +1035,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_spec_accepts_valid_unix_profile_names() {
-        for profile_name in [
+    fn validate_spec_accepts_valid_unix_agent_names() {
+        for agent_name in [
             "site-builder",
             "site-builder-01",
             "site-builder_01",
@@ -1044,33 +1044,31 @@ mod tests {
             &"a".repeat(32),
         ] {
             validate_spec(&SessionSpec {
-                profile_name: profile_name.to_string(),
+                agent_name: agent_name.to_string(),
                 ..test_session_spec()
             })
-            .unwrap_or_else(|error| {
-                panic!("expected {profile_name:?} to be accepted, got {error}")
-            });
+            .unwrap_or_else(|error| panic!("expected {agent_name:?} to be accepted, got {error}"));
         }
     }
 
     #[test]
-    fn validate_profile_name_accepts_valid_unix_profile_names() {
-        for profile_name in [
+    fn validate_agent_name_accepts_valid_unix_agent_names() {
+        for agent_name in [
             "site-builder",
             "site-builder-01",
             "site-builder_01",
             "site-builder-name_01",
             &"a".repeat(32),
         ] {
-            validate_profile_name(profile_name).unwrap_or_else(|error| {
-                panic!("expected {profile_name:?} to be accepted, got {error:?}")
+            validate_agent_name(agent_name).unwrap_or_else(|error| {
+                panic!("expected {agent_name:?} to be accepted, got {error:?}")
             });
         }
     }
 
     #[test]
-    fn validate_profile_name_rejects_invalid_unix_usernames() {
-        for profile_name in [
+    fn validate_agent_name_rejects_invalid_unix_usernames() {
+        for agent_name in [
             "",
             "   ",
             "Site-Builder 01",
@@ -1080,50 +1078,50 @@ mod tests {
             "site-builder__name!",
             &format!("a{}", "b".repeat(32)),
         ] {
-            let error = validate_profile_name(profile_name)
+            let error = validate_agent_name(agent_name)
                 .expect_err("invalid unix usernames should be rejected");
 
             assert_eq!(
                 error,
-                ProfileNameValidationError::Invalid,
-                "expected Invalid for {profile_name:?}, got {error:?}"
+                AgentNameValidationError::Invalid,
+                "expected Invalid for {agent_name:?}, got {error:?}"
             );
         }
     }
 
     #[test]
-    fn validate_profile_name_rejects_reserved_names() {
-        for profile_name in ["root", "nobody", "daemon", "bin", "sys", "man", "mail"] {
+    fn validate_agent_name_rejects_reserved_names() {
+        for agent_name in ["root", "nobody", "daemon", "bin", "sys", "man", "mail"] {
             let error =
-                validate_profile_name(profile_name).expect_err("reserved names should be rejected");
+                validate_agent_name(agent_name).expect_err("reserved names should be rejected");
 
             assert_eq!(
                 error,
-                ProfileNameValidationError::Reserved,
-                "expected Reserved for {profile_name:?}, got {error:?}"
+                AgentNameValidationError::Reserved,
+                "expected Reserved for {agent_name:?}, got {error:?}"
             );
         }
     }
 
     #[test]
-    fn validate_spec_maps_invalid_or_reserved_profile_names_to_runner_error() {
-        for profile_name in ["123site-builder", "root"] {
+    fn validate_spec_maps_invalid_or_reserved_agent_names_to_runner_error() {
+        for agent_name in ["123site-builder", "root"] {
             let error = validate_spec(&SessionSpec {
-                profile_name: profile_name.to_string(),
+                agent_name: agent_name.to_string(),
                 ..test_session_spec()
             })
-            .expect_err("invalid profile names should be rejected");
+            .expect_err("invalid agent names should be rejected");
 
             assert!(
-                matches!(error, RunnerError::InvalidProfileName),
-                "expected InvalidProfileName for {profile_name:?}, got {error:?}"
+                matches!(error, RunnerError::InvalidAgentName),
+                "expected InvalidAgentName for {agent_name:?}, got {error:?}"
             );
         }
     }
 
     #[test]
-    fn invalid_profile_name_error_mentions_format_and_reserved_names() {
-        let message = RunnerError::InvalidProfileName.to_string();
+    fn invalid_agent_name_error_mentions_format_and_reserved_names() {
+        let message = RunnerError::InvalidAgentName.to_string();
 
         assert!(
             message.contains("must already be a unix username"),
@@ -1407,10 +1405,10 @@ mod tests {
     }
 
     #[test]
-    fn run_session_rejects_reserved_profile_name_before_methodology_validation() {
+    fn run_session_rejects_reserved_agent_name_before_methodology_validation() {
         let error = crate::run_session(
             SessionSpec {
-                profile_name: "root".to_string(),
+                agent_name: "root".to_string(),
                 methodology_dir: PathBuf::from("/tmp/does-not-exist"),
                 ..test_session_spec()
             },
@@ -1422,11 +1420,11 @@ mod tests {
                 timeout: None,
             },
         )
-        .expect_err("reserved profile name should be rejected before setup");
+        .expect_err("reserved agent name should be rejected before setup");
 
         assert!(
-            matches!(error, RunnerError::InvalidProfileName),
-            "expected InvalidProfileName, got {error:?}"
+            matches!(error, RunnerError::InvalidAgentName),
+            "expected InvalidAgentName, got {error:?}"
         );
     }
 }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -28,15 +28,11 @@ fn run_session_with_test_audit_root(
     run_session(spec, invocation)
 }
 
-fn wait_for_session_record_dir(
-    audit_root: &Path,
-    profile_name: &str,
-    timeout: Duration,
-) -> PathBuf {
+fn wait_for_session_record_dir(audit_root: &Path, agent_name: &str, timeout: Duration) -> PathBuf {
     let deadline = Instant::now() + timeout;
     loop {
-        let profile_root = audit_root.join(profile_name);
-        if let Ok(entries) = fs::read_dir(&profile_root) {
+        let agent_root = audit_root.join(agent_name);
+        if let Ok(entries) = fs::read_dir(&agent_root) {
             let entries = entries
                 .map(|entry| {
                     entry
@@ -53,7 +49,7 @@ fn wait_for_session_record_dir(
         assert!(
             Instant::now() < deadline,
             "timed out waiting for session record under {}",
-            profile_root.display()
+            agent_root.display()
         );
         thread::sleep(Duration::from_millis(25));
     }
@@ -133,12 +129,12 @@ fn succeeds_without_timeout_and_cleans_up_container() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "success-run".to_string(),
+            agent_name: "success-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec![
+            agent_command: vec![
                 "site-builder".to_string(),
                 "exec".to_string(),
                 "--sandbox".to_string(),
@@ -188,12 +184,12 @@ fn materializes_request_text_input_before_session_command_runs() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "request-input-run".to_string(),
+            agent_name: "request-input-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "assert-request-input-present".to_string(),
@@ -235,12 +231,12 @@ fn materializes_generic_artifact_input_before_session_command_runs() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "artifact-input-run".to_string(),
+            agent_name: "artifact-input-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "assert-claim-input-present".to_string(),
@@ -285,12 +281,12 @@ fn rejects_request_text_when_methodology_declares_an_unsupported_request_version
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "unsupported-request-version-run".to_string(),
+            agent_name: "unsupported-request-version-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),
         },
         SessionInvocation {
@@ -329,12 +325,12 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "mixed-env-run".to_string(),
+            agent_name: "mixed-env-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -381,12 +377,12 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "unset-work-unit-run".to_string(),
+            agent_name: "unset-work-unit-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "success-without-work-unit".to_string(),
@@ -425,12 +421,12 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "failure-run".to_string(),
+            agent_name: "failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -475,12 +471,12 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "failure-run-125".to_string(),
+            agent_name: "failure-run-125".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -526,12 +522,12 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "comma-methodology-run".to_string(),
+            agent_name: "comma-methodology-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -585,7 +581,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "readonly-mount-run".to_string(),
+            agent_name: "readonly-mount-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
@@ -594,7 +590,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
                 target: PathBuf::from("/home/readonly-mount-run/.claude"),
                 read_only: true,
             }],
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "verify-read-only-mount".to_string(),
@@ -653,7 +649,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "readwrite-mount-run".to_string(),
+            agent_name: "readwrite-mount-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
@@ -662,7 +658,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
                 target: PathBuf::from("/home/readwrite-mount-run/.runa"),
                 read_only: false,
             }],
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "write-read-write-mount".to_string(),
@@ -725,7 +721,7 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "nested-home-mount-run".to_string(),
+            agent_name: "nested-home-mount-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
@@ -734,7 +730,7 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
                 target: PathBuf::from("/home/nested-home-mount-run/.config/claude"),
                 read_only: false,
             }],
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "write-nested-home-mount".to_string(),
@@ -776,12 +772,12 @@ fn preserves_session_user_access_to_preexisting_home_content() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "preexisting-home-run".to_string(),
+            agent_name: "preexisting-home-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "write-preexisting-home-file".to_string(),
@@ -818,12 +814,12 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "audit-success-run".to_string(),
+            agent_name: "audit-success-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "write-repo-audit-state".to_string(),
@@ -852,13 +848,24 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
             .expect("execution record should persist"),
         "{\"protocols\":[\"begin\"],\"postconditions\":[\"passed\"]}\n"
     );
+    assert_eq!(
+        fs::read_to_string(record_dir.join("runa/calls.log"))
+            .expect("runa call log should persist"),
+        "init --methodology /agentd/methodology/manifest.toml\nrun --work-unit issue-76 --agent-command -- site-builder exec\n"
+    );
+    let runa_config = fs::read_to_string(record_dir.join("runa/config.toml"))
+        .expect("runa config should persist");
+    assert!(
+        !runa_config.contains("[agent]"),
+        "agentd-managed runa config must not contain an [agent] section: {runa_config}"
+    );
 
     let metadata: Value = serde_json::from_str(
         &fs::read_to_string(record_dir.join("agentd/session.json"))
             .expect("session metadata should persist"),
     )
     .expect("session metadata should be valid json");
-    assert_eq!(metadata["profile"], "audit-success-run");
+    assert_eq!(metadata["agent"], "audit-success-run");
     assert_eq!(metadata["repo_url"], fixture.repo_url());
     assert_eq!(metadata["work_unit"], "issue-76");
     assert_eq!(metadata["outcome"], "success");
@@ -907,12 +914,12 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "audit-restrictive-modes-run".to_string(),
+            agent_name: "audit-restrictive-modes-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "write-restrictive-repo-audit-state".to_string(),
@@ -1005,7 +1012,7 @@ fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes(
         &audit_root,
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "audit-hard-link-run".to_string(),
+            agent_name: "audit-hard-link-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: audit_root.clone(),
@@ -1014,7 +1021,7 @@ fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes(
                 target: PathBuf::from("/home/audit-hard-link-run/shared"),
                 read_only: false,
             }],
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "sleep-short".to_string(),
@@ -1083,12 +1090,12 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "audit-failure-run".to_string(),
+            agent_name: "audit-failure-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
                 name: "SESSION_TEST_BEHAVIOR".to_string(),
                 value: "write-failing-audit-trail".to_string(),
@@ -1150,12 +1157,12 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
         &fixture.audit_root(),
         SessionSpec {
             daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-            profile_name: "timeout-run".to_string(),
+            agent_name: "timeout-run".to_string(),
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             mounts: Vec::new(),
-            command: vec!["site-builder".to_string(), "exec".to_string()],
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
                 ResolvedEnvironmentVariable {
                     name: "GITHUB_TOKEN".to_string(),
@@ -1202,12 +1209,12 @@ fn releases_session_secret_after_container_reaches_running_state() {
             &audit_root,
             SessionSpec {
                 daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
-                profile_name: "running-secret-run".to_string(),
+                agent_name: "running-secret-run".to_string(),
                 base_image: image,
                 methodology_dir,
                 audit_root: audit_root.clone(),
                 mounts: Vec::new(),
-                command: vec!["site-builder".to_string(), "exec".to_string()],
+                agent_command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![
                     ResolvedEnvironmentVariable {
                         name: "GITHUB_TOKEN".to_string(),
@@ -1244,21 +1251,21 @@ fn releases_session_secret_after_container_reaches_running_state() {
 
 struct SessionFixture {
     root: PathBuf,
-    profile_name: String,
+    agent_name: String,
     baseline_runner_secret_names: BTreeSet<String>,
     repo_server: RepoHttpServer,
 }
 
 impl SessionFixture {
-    fn new(profile_name: &str) -> Self {
-        Self::new_with_repo_server(profile_name, &format!("agentd-runner-{profile_name}"))
+    fn new(agent_name: &str) -> Self {
+        Self::new_with_repo_server(agent_name, &format!("agentd-runner-{agent_name}"))
     }
 
-    fn new_with_root_prefix(profile_name: &str, root_prefix: &str) -> Self {
-        Self::new_with_repo_server(profile_name, root_prefix)
+    fn new_with_root_prefix(agent_name: &str, root_prefix: &str) -> Self {
+        Self::new_with_repo_server(agent_name, root_prefix)
     }
 
-    fn new_with_repo_server(profile_name: &str, root_prefix: &str) -> Self {
+    fn new_with_repo_server(agent_name: &str, root_prefix: &str) -> Self {
         let root = unique_temp_dir(root_prefix);
         fs::create_dir_all(&root).expect("fixture root should be created");
 
@@ -1276,7 +1283,7 @@ impl SessionFixture {
 
         Self {
             root,
-            profile_name: profile_name.to_string(),
+            agent_name: agent_name.to_string(),
             baseline_runner_secret_names: list_runner_secret_names(),
             repo_server: RepoHttpServer::start(repo_root),
         }
@@ -1291,9 +1298,9 @@ impl SessionFixture {
     }
 
     fn only_session_record_dir(&self) -> PathBuf {
-        let profile_root = self.audit_root().join(&self.profile_name);
-        let entries = fs::read_dir(&profile_root)
-            .unwrap_or_else(|error| panic!("failed to read {}: {error}", profile_root.display()))
+        let agent_root = self.audit_root().join(&self.agent_name);
+        let entries = fs::read_dir(&agent_root)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", agent_root.display()))
             .map(|entry| {
                 entry
                     .expect("session record entry should be readable")
@@ -1305,7 +1312,7 @@ impl SessionFixture {
             entries.len(),
             1,
             "expected exactly one session record under {}",
-            profile_root.display()
+            agent_root.display()
         );
         entries[0].clone()
     }
@@ -1346,6 +1353,7 @@ impl SessionFixture {
 
         fs::write(context_dir.join("site-builder"), SITE_BUILDER_STUB)
             .expect("site-builder stub should be written");
+        fs::write(context_dir.join("runa"), RUNA_STUB).expect("runa stub should be written");
         fs::write(context_dir.join("entrypoint.sh"), ENTRYPOINT_SH)
             .expect("entrypoint script should be written");
         let mut containerfile = work_unit
@@ -1360,7 +1368,7 @@ impl SessionFixture {
         fs::write(context_dir.join("Containerfile"), containerfile)
             .expect("containerfile should be written");
 
-        let tag = format!("agentd-runner-test:{}", self.profile_name);
+        let tag = format!("agentd-runner-test:{}", self.agent_name);
         let status = Command::new("podman")
             .args(["build", "--tag", &tag, context_dir.to_str().unwrap()])
             .stdout(Stdio::inherit())
@@ -1384,7 +1392,7 @@ impl SessionFixture {
         );
 
         let names = String::from_utf8(output.stdout).expect("podman ps output should be utf-8");
-        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.profile_name);
+        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.agent_name);
         assert!(
             !names.lines().any(|name| name.starts_with(&expected_prefix)),
             "runner left container behind with prefix {expected_prefix}: {names}"
@@ -1406,7 +1414,7 @@ impl SessionFixture {
 
     fn wait_for_runner_container_to_be_running(&self, timeout: Duration) -> String {
         let deadline = Instant::now() + timeout;
-        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.profile_name);
+        let expected_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{}-", self.agent_name);
 
         loop {
             let running_container_names = list_running_container_names();
@@ -1430,7 +1438,7 @@ impl SessionFixture {
         let expected_secret_prefix = format!("agentd-{TEST_DAEMON_INSTANCE_ID}-{session_id}-");
         let expected_container_prefix = format!(
             "agentd-{TEST_DAEMON_INSTANCE_ID}-{}-{session_id}",
-            self.profile_name
+            self.agent_name
         );
 
         loop {
@@ -1607,8 +1615,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends findutils git gosu passwd \
     && rm -rf /var/lib/apt/lists/*
 COPY site-builder /usr/local/bin/site-builder
+COPY runa /usr/local/bin/runa
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /usr/local/bin/site-builder /entrypoint.sh
+RUN chmod +x /usr/local/bin/site-builder /usr/local/bin/runa /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
@@ -1617,6 +1626,85 @@ set -eu
 
 echo "image entrypoint should not run" >&2
 exit 97
+"#;
+
+const RUNA_STUB: &str = r#"#!/bin/sh
+set -eu
+
+subcommand="${1:-}"
+if [ "$#" -gt 0 ]; then
+    shift
+fi
+
+case "$subcommand" in
+    init)
+        methodology=""
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --methodology)
+                    shift
+                    methodology="${1:-}"
+                    ;;
+                *)
+                    echo "unexpected runa init argument: $1" >&2
+                    exit 97
+                    ;;
+            esac
+            shift
+        done
+        [ "$methodology" = "/agentd/methodology/manifest.toml" ]
+        [ -f "$methodology" ]
+        mkdir -p .runa/workspace .runa/store
+        cat > .runa/config.toml <<EOF
+methodology = "$methodology"
+EOF
+        printf 'initialized = true\n' > .runa/state.toml
+        printf 'init --methodology %s\n' "$methodology" >> .runa/calls.log
+        if grep -F '[agent]' .runa/config.toml >/dev/null; then
+            echo "runa config unexpectedly contains [agent]" >&2
+            exit 96
+        fi
+        ;;
+    run)
+        work_unit=""
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --work-unit)
+                    shift
+                    work_unit="${1:-}"
+                    ;;
+                --agent-command)
+                    shift
+                    if [ "${1:-}" = "--" ]; then
+                        shift
+                    fi
+                    if [ "$#" -eq 0 ]; then
+                        echo "missing agent command" >&2
+                        exit 95
+                    fi
+                    if [ -n "$work_unit" ]; then
+                        export AGENTD_WORK_UNIT="$work_unit"
+                        printf 'run --work-unit %s --agent-command -- %s\n' "$work_unit" "$*" >> .runa/calls.log
+                    else
+                        printf 'run --agent-command -- %s\n' "$*" >> .runa/calls.log
+                    fi
+                    exec "$@"
+                    ;;
+                *)
+                    echo "unexpected runa run argument: $1" >&2
+                    exit 94
+                    ;;
+            esac
+            shift
+        done
+        echo "missing --agent-command" >&2
+        exit 93
+        ;;
+    *)
+        echo "unexpected runa subcommand: $subcommand" >&2
+        exit 92
+        ;;
+esac
 "#;
 
 struct RepoHttpServer {
@@ -1748,14 +1836,14 @@ shift
 case "$command_name" in
     exec)
         [ -f /agentd/methodology/manifest.toml ]
-        [ "${PROFILE_NAME:-}" != "" ]
+        [ "${AGENT_NAME:-}" != "" ]
         if [ "${GITHUB_TOKEN+set}" = "set" ]; then
             [ "${GITHUB_TOKEN}" = "test-token" ]
         fi
         [ "$(id -u)" != "0" ]
-        [ "$(id -un)" = "${PROFILE_NAME}" ]
-        [ "${HOME:-}" = "/home/${PROFILE_NAME}" ]
-        [ "$(pwd)" = "/home/${PROFILE_NAME}/repo" ]
+        [ "$(id -un)" = "${AGENT_NAME}" ]
+        [ "${HOME:-}" = "/home/${AGENT_NAME}" ]
+        [ "$(pwd)" = "/home/${AGENT_NAME}/repo" ]
         [ -w "${HOME}" ]
         [ -w "${HOME}/repo" ]
         [ -f "${HOME}/repo/README.md" ]

--- a/crates/agentd-scheduler/src/lib.rs
+++ b/crates/agentd-scheduler/src/lib.rs
@@ -1,4 +1,4 @@
-//! Cron-based scheduling for agentd profiles.
+//! Cron-based scheduling for agentd agents.
 //!
 //! The scheduler owns timing policy only: it evaluates cron expressions in
 //! daemon-local time and dispatches run requests through an abstract
@@ -16,19 +16,19 @@ use croner::parser::{CronParser, Seconds, Year};
 
 const MAX_IDLE_SLEEP: Duration = Duration::from_secs(1);
 
-/// One scheduled autonomous run source: profile identity, default repo, and a
+/// One scheduled autonomous run source: agent identity, default repo, and a
 /// parsed cron expression.
 #[derive(Debug, Clone)]
-pub struct ScheduledProfile {
+pub struct ScheduledAgent {
     request: ScheduledRunRequest,
     cron: Cron,
 }
 
-impl ScheduledProfile {
-    /// Parses a five-field cron expression for a scheduled profile.
-    pub fn new(profile: String, repo_url: String, schedule: &str) -> Result<Self, CronError> {
+impl ScheduledAgent {
+    /// Parses a five-field cron expression for a scheduled agent.
+    pub fn new(agent: String, repo_url: String, schedule: &str) -> Result<Self, CronError> {
         Ok(Self {
-            request: ScheduledRunRequest { profile, repo_url },
+            request: ScheduledRunRequest { agent, repo_url },
             cron: parse_schedule(schedule)?,
         })
     }
@@ -37,7 +37,7 @@ impl ScheduledProfile {
 /// A concrete run request emitted by the scheduler.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScheduledRunRequest {
-    pub profile: String,
+    pub agent: String,
     pub repo_url: String,
 }
 
@@ -88,24 +88,24 @@ impl Clock for SystemClock {
     }
 }
 
-/// In-memory scheduler state that tracks the next fire time per profile.
+/// In-memory scheduler state that tracks the next fire time per agent.
 #[derive(Debug, Clone)]
 pub struct Scheduler {
     entries: Vec<ScheduledEntry>,
 }
 
 impl Scheduler {
-    /// Builds scheduler state from the configured scheduled profiles.
-    pub fn new(profiles: Vec<ScheduledProfile>, now: DateTime<Local>) -> Result<Self, CronError> {
-        let mut entries = Vec::with_capacity(profiles.len());
-        for profile in profiles {
-            entries.push(ScheduledEntry::new(profile, now)?);
+    /// Builds scheduler state from the configured scheduled agents.
+    pub fn new(agents: Vec<ScheduledAgent>, now: DateTime<Local>) -> Result<Self, CronError> {
+        let mut entries = Vec::with_capacity(agents.len());
+        for agent in agents {
+            entries.push(ScheduledEntry::new(agent, now)?);
         }
 
         Ok(Self { entries })
     }
 
-    /// Returns whether the scheduler has any active profiles.
+    /// Returns whether the scheduler has any active agents.
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
@@ -115,9 +115,9 @@ impl Scheduler {
         self.entries.iter().map(|entry| entry.next_fire).min()
     }
 
-    /// Dispatches every profile whose next fire time is due at `now`.
+    /// Dispatches every agent whose next fire time is due at `now`.
     ///
-    /// Each due profile dispatches at most once per tick. After dispatch, the
+    /// Each due agent dispatches at most once per tick. After dispatch, the
     /// next fire time advances to the first occurrence strictly after `now`,
     /// which intentionally skips missed occurrences instead of backfilling.
     /// Startup seeding is inclusive, but post-dispatch advancement is
@@ -134,9 +134,9 @@ impl Scheduler {
                 continue;
             }
 
-            let request = entry.profile.request.clone();
+            let request = entry.agent.request.clone();
             let dispatch_result = dispatcher.dispatch(request.clone()).map(|_| request);
-            entry.next_fire = entry.profile.cron.find_next_occurrence(&now, false).expect(
+            entry.next_fire = entry.agent.cron.find_next_occurrence(&now, false).expect(
                 "validated schedules should always have a next occurrence after the current time",
             );
             results.push(dispatch_result);
@@ -178,14 +178,14 @@ pub fn run_until_shutdown<D: Dispatcher, C: Clock>(
 
 #[derive(Debug, Clone)]
 struct ScheduledEntry {
-    profile: ScheduledProfile,
+    agent: ScheduledAgent,
     next_fire: DateTime<Local>,
 }
 
 impl ScheduledEntry {
-    fn new(profile: ScheduledProfile, now: DateTime<Local>) -> Result<Self, CronError> {
-        let next_fire = profile.cron.find_next_occurrence(&now, true)?;
-        Ok(Self { profile, next_fire })
+    fn new(agent: ScheduledAgent, now: DateTime<Local>) -> Result<Self, CronError> {
+        let next_fire = agent.cron.find_next_occurrence(&now, true)?;
+        Ok(Self { agent, next_fire })
     }
 }
 
@@ -244,17 +244,17 @@ mod tests {
     }
 
     #[test]
-    fn dispatches_due_profiles_once_each_when_schedules_overlap() {
+    fn dispatches_due_agents_once_each_when_schedules_overlap() {
         let start = local_datetime(2026, 4, 10, 10, 0, 30);
         let mut scheduler = Scheduler::new(
             vec![
-                ScheduledProfile::new(
+                ScheduledAgent::new(
                     "site-builder".to_string(),
                     "https://example.com/site.git".to_string(),
                     "*/15 * * * *",
                 )
                 .expect("schedule should parse"),
-                ScheduledProfile::new(
+                ScheduledAgent::new(
                     "code-reviewer".to_string(),
                     "https://example.com/review.git".to_string(),
                     "*/15 * * * *",
@@ -273,11 +273,11 @@ mod tests {
             dispatcher.requests(),
             vec![
                 ScheduledRunRequest {
-                    profile: "site-builder".to_string(),
+                    agent: "site-builder".to_string(),
                     repo_url: "https://example.com/site.git".to_string(),
                 },
                 ScheduledRunRequest {
-                    profile: "code-reviewer".to_string(),
+                    agent: "code-reviewer".to_string(),
                     repo_url: "https://example.com/review.git".to_string(),
                 },
             ]
@@ -289,7 +289,7 @@ mod tests {
         let start = local_datetime(2026, 4, 10, 10, 0, 30);
         let mut scheduler = Scheduler::new(
             vec![
-                ScheduledProfile::new(
+                ScheduledAgent::new(
                     "site-builder".to_string(),
                     "https://example.com/site.git".to_string(),
                     "* * * * *",
@@ -330,7 +330,7 @@ mod tests {
         let start = local_datetime(2026, 4, 10, 10, 15, 0);
         let mut scheduler = Scheduler::new(
             vec![
-                ScheduledProfile::new(
+                ScheduledAgent::new(
                     "site-builder".to_string(),
                     "https://example.com/site.git".to_string(),
                     "*/15 * * * *",
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(
             dispatcher.requests(),
             vec![ScheduledRunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: "https://example.com/site.git".to_string(),
             }]
         );
@@ -369,17 +369,17 @@ mod tests {
     }
 
     #[test]
-    fn next_wake_at_tracks_the_earliest_scheduled_profile() {
+    fn next_wake_at_tracks_the_earliest_scheduled_agent() {
         let start = local_datetime(2026, 4, 10, 10, 0, 30);
         let scheduler = Scheduler::new(
             vec![
-                ScheduledProfile::new(
+                ScheduledAgent::new(
                     "site-builder".to_string(),
                     "https://example.com/site.git".to_string(),
                     "*/20 * * * *",
                 )
                 .expect("schedule should parse"),
-                ScheduledProfile::new(
+                ScheduledAgent::new(
                     "code-reviewer".to_string(),
                     "https://example.com/review.git".to_string(),
                     "*/5 * * * *",

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -1,8 +1,8 @@
-//! TOML configuration parsing and validation for the daemon and profile registry.
+//! TOML configuration parsing and validation for the daemon and agent registry.
 //!
 //! Bridges operator-facing configuration to daemon dispatch and the runner's
 //! [`SessionSpec`] model. Validation here is stricter than the runner's own
-//! validation — it enforces uniqueness (no duplicate profile or credential
+//! validation — it enforces uniqueness (no duplicate agent or credential
 //! names), non-empty fields, and whitespace hygiene in addition to the
 //! runner's format and reservation rules. Relative daemon runtime paths and
 //! `methodology_dir` are resolved against the configuration file location when
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use agentd_runner::{
-    BindMount, MountTargetValidationError, RunnerError, validate_environment_name,
-    validate_mount_overlap, validate_mount_target, validate_profile_name, validate_repo_url,
+    BindMount, MountTargetValidationError, RunnerError, validate_agent_name,
+    validate_environment_name, validate_mount_overlap, validate_mount_target, validate_repo_url,
 };
 use croner::parser::{CronParser, Seconds, Year};
 use serde::Deserialize;
@@ -25,9 +25,9 @@ use sha2::{Digest, Sha256};
 
 use crate::runtime_paths::default_daemon_runtime_paths;
 
-/// Validated daemon and profile registry parsed from a TOML configuration file.
+/// Validated daemon and agent registry parsed from a TOML configuration file.
 ///
-/// Guarantees that daemon runtime paths are present, all profile names are
+/// Guarantees that daemon runtime paths are present, all agent names are
 /// unique and valid, all required fields are non-empty, and all credential
 /// names are valid environment variable names. Relative daemon runtime paths
 /// and `methodology_dir` paths are resolved against the configuration file's
@@ -35,7 +35,7 @@ use crate::runtime_paths::default_daemon_runtime_paths;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     daemon: DaemonConfig,
-    profiles: Vec<ProfileConfig>,
+    agents: Vec<Agent>,
 }
 
 impl Config {
@@ -51,9 +51,9 @@ impl Config {
         Self::parse(&contents, base_dir.as_deref())
     }
 
-    /// Returns all configured profiles.
-    pub fn profiles(&self) -> &[ProfileConfig] {
-        &self.profiles
+    /// Returns all configured agents.
+    pub fn agents(&self) -> &[Agent] {
+        &self.agents
     }
 
     /// Returns the daemon-wide runtime paths.
@@ -61,77 +61,77 @@ impl Config {
         &self.daemon
     }
 
-    /// Looks up a profile by name. Returns `None` if no profile matches.
-    pub fn profile(&self, name: &str) -> Option<&ProfileConfig> {
-        self.profiles.iter().find(|profile| profile.name == name)
+    /// Looks up an agent by name. Returns `None` if no agent matches.
+    pub fn agent(&self, name: &str) -> Option<&Agent> {
+        self.agents.iter().find(|agent| agent.name == name)
     }
 
     fn parse(contents: &str, base_dir: Option<&Path>) -> Result<Self, ConfigError> {
         let raw: RawConfig = toml::from_str(contents)?;
         let daemon = DaemonConfig::parse(raw.daemon, base_dir)?;
 
-        if raw.profiles.is_empty() {
-            return Err(ConfigError::NoProfiles);
+        if raw.agents.is_empty() {
+            return Err(ConfigError::NoAgents);
         }
 
-        let mut seen_profiles = HashSet::new();
-        let mut profiles = Vec::with_capacity(raw.profiles.len());
+        let mut seen_agents = HashSet::new();
+        let mut agents = Vec::with_capacity(raw.agents.len());
 
-        for raw_profile in raw.profiles {
-            validate_lookup_key("name", &raw_profile.name, None, None)?;
-            if validate_profile_name(&raw_profile.name).is_err() {
-                return Err(ConfigError::InvalidProfileName {
-                    name: raw_profile.name,
+        for raw_agent in raw.agents {
+            validate_lookup_key("name", &raw_agent.name, None, None)?;
+            if validate_agent_name(&raw_agent.name).is_err() {
+                return Err(ConfigError::InvalidAgentName {
+                    name: raw_agent.name,
                 });
             }
 
-            if !seen_profiles.insert(raw_profile.name.clone()) {
-                return Err(ConfigError::DuplicateProfileName {
-                    name: raw_profile.name,
+            if !seen_agents.insert(raw_agent.name.clone()) {
+                return Err(ConfigError::DuplicateAgentName {
+                    name: raw_agent.name,
                 });
             }
 
             validate_non_empty(
                 "base_image",
-                &raw_profile.base_image,
-                Some(raw_profile.name.as_str()),
+                &raw_agent.base_image,
+                Some(raw_agent.name.as_str()),
                 None,
             )?;
             validate_non_empty(
                 "methodology_dir",
-                &raw_profile.methodology_dir,
-                Some(raw_profile.name.as_str()),
+                &raw_agent.methodology_dir,
+                Some(raw_agent.name.as_str()),
                 None,
             )?;
-            let repo = match raw_profile.repo {
+            let repo = match raw_agent.repo {
                 Some(value) => {
-                    validate_lookup_key("repo", &value, Some(raw_profile.name.as_str()), None)?;
+                    validate_lookup_key("repo", &value, Some(raw_agent.name.as_str()), None)?;
                     validate_repo_url(&value).map_err(|error| ConfigError::InvalidRepo {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         message: error.to_string(),
                     })?;
                     Some(value)
                 }
                 None => None,
             };
-            let schedule = match raw_profile.schedule {
+            let schedule = match raw_agent.schedule {
                 Some(value) => {
-                    validate_lookup_key("schedule", &value, Some(raw_profile.name.as_str()), None)?;
+                    validate_lookup_key("schedule", &value, Some(raw_agent.name.as_str()), None)?;
                     validate_schedule(&value).map_err(|_| ConfigError::InvalidSchedule {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         schedule: value.clone(),
                     })?;
                     Some(value)
                 }
                 None => None,
             };
-            let repo_token_source = match raw_profile.repo_token_source {
+            let repo_token_source = match raw_agent.repo_token_source {
                 Some(value) if value.is_empty() => None,
                 Some(value) => {
                     validate_lookup_key(
                         "repo_token_source",
                         &value,
-                        Some(raw_profile.name.as_str()),
+                        Some(raw_agent.name.as_str()),
                         None,
                     )?;
                     Some(value)
@@ -139,58 +139,63 @@ impl Config {
                 None => None,
             };
 
-            if raw_profile.command.is_empty() {
-                return Err(ConfigError::EmptyCommand {
-                    profile: raw_profile.name.clone(),
+            if raw_agent.command.argv.is_empty() {
+                return Err(ConfigError::EmptyAgentCommand {
+                    agent: raw_agent.name.clone(),
                 });
             }
 
-            let mut command = Vec::with_capacity(raw_profile.command.len());
-            for element in raw_profile.command {
-                validate_non_empty("command", &element, Some(raw_profile.name.as_str()), None)?;
-                command.push(element);
+            let mut agent_command = Vec::with_capacity(raw_agent.command.argv.len());
+            for element in raw_agent.command.argv {
+                validate_non_empty(
+                    "command.argv",
+                    &element,
+                    Some(raw_agent.name.as_str()),
+                    None,
+                )?;
+                agent_command.push(element);
             }
 
             let mut seen_mount_targets = HashSet::new();
-            let mut mounts = Vec::with_capacity(raw_profile.mounts.len());
-            for raw_mount in raw_profile.mounts {
+            let mut mounts = Vec::with_capacity(raw_agent.mounts.len());
+            for raw_mount in raw_agent.mounts {
                 validate_lookup_key(
                     "mounts.source",
                     &raw_mount.source,
-                    Some(raw_profile.name.as_str()),
+                    Some(raw_agent.name.as_str()),
                     None,
                 )?;
                 validate_lookup_key(
                     "mounts.target",
                     &raw_mount.target,
-                    Some(raw_profile.name.as_str()),
+                    Some(raw_agent.name.as_str()),
                     None,
                 )?;
 
                 let source = PathBuf::from(&raw_mount.source);
                 if !source.is_absolute() {
                     return Err(ConfigError::MountSourceMustBeAbsolute {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         source,
                     });
                 }
 
                 let target = PathBuf::from(&raw_mount.target);
-                if let Err(error) = validate_mount_target(&target, &raw_profile.name) {
+                if let Err(error) = validate_mount_target(&target, &raw_agent.name) {
                     return Err(ConfigError::InvalidMountTarget {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         error,
                     });
                 }
 
                 if !seen_mount_targets.insert(target.clone()) {
                     return Err(ConfigError::DuplicateMountTarget {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         target,
                     });
                 }
 
-                mounts.push(ProfileMountConfig {
+                mounts.push(AgentMountConfig {
                     source,
                     target,
                     read_only: raw_mount.read_only,
@@ -198,41 +203,41 @@ impl Config {
             }
             let runner_mounts = mounts
                 .iter()
-                .map(ProfileMountConfig::to_runner_mount)
+                .map(AgentMountConfig::to_runner_mount)
                 .collect::<Vec<_>>();
             if let Err(error) = validate_mount_overlap(&runner_mounts) {
                 return Err(ConfigError::OverlappingMountTargets {
-                    profile: raw_profile.name.clone(),
+                    agent: raw_agent.name.clone(),
                     first: error.first,
                     second: error.second,
                 });
             }
 
             let mut seen_credentials = HashSet::new();
-            let mut credentials = Vec::with_capacity(raw_profile.credentials.len());
-            for raw_credential in raw_profile.credentials {
+            let mut credentials = Vec::with_capacity(raw_agent.credentials.len());
+            for raw_credential in raw_agent.credentials {
                 validate_lookup_key(
                     "credentials.name",
                     &raw_credential.name,
-                    Some(raw_profile.name.as_str()),
+                    Some(raw_agent.name.as_str()),
                     None,
                 )?;
                 if validate_environment_name(&raw_credential.name).is_err() {
                     return Err(ConfigError::InvalidCredentialName {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         name: raw_credential.name,
                     });
                 }
                 validate_non_empty(
                     "credentials.source",
                     &raw_credential.source,
-                    Some(raw_profile.name.as_str()),
+                    Some(raw_agent.name.as_str()),
                     Some(raw_credential.name.as_str()),
                 )?;
 
                 if !seen_credentials.insert(raw_credential.name.clone()) {
                     return Err(ConfigError::DuplicateCredentialName {
-                        profile: raw_profile.name.clone(),
+                        agent: raw_agent.name.clone(),
                         name: raw_credential.name,
                     });
                 }
@@ -245,25 +250,25 @@ impl Config {
 
             if schedule.is_some() && repo.is_none() {
                 return Err(ConfigError::ScheduleRequiresRepo {
-                    profile: raw_profile.name.clone(),
+                    agent: raw_agent.name.clone(),
                 });
             }
 
-            let methodology_dir = resolve_methodology_dir(base_dir, &raw_profile.methodology_dir);
-            profiles.push(ProfileConfig {
-                name: raw_profile.name,
-                base_image: raw_profile.base_image,
+            let methodology_dir = resolve_methodology_dir(base_dir, &raw_agent.methodology_dir);
+            agents.push(Agent {
+                name: raw_agent.name,
+                base_image: raw_agent.base_image,
                 methodology_dir,
                 mounts,
                 repo,
                 schedule,
                 repo_token_source,
                 credentials,
-                command,
+                agent_command,
             });
         }
 
-        Ok(Self { daemon, profiles })
+        Ok(Self { daemon, agents })
     }
 }
 
@@ -279,31 +284,31 @@ impl FromStr for Config {
     }
 }
 
-/// Configuration for a single profile in the registry.
+/// Configuration for a single agent in the registry.
 ///
-/// Fields are private; use the accessor methods to read values. The profile
+/// Fields are private; use the accessor methods to read values. The agent
 /// name has been validated as a legal unix username and is unique within the
 /// [`Config`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProfileConfig {
+pub struct Agent {
     name: String,
     base_image: String,
     methodology_dir: PathBuf,
-    mounts: Vec<ProfileMountConfig>,
+    mounts: Vec<AgentMountConfig>,
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
     credentials: Vec<CredentialConfig>,
-    command: Vec<String>,
+    agent_command: Vec<String>,
 }
 
-impl ProfileConfig {
-    /// Profile identity string, validated as a legal unix username.
+impl Agent {
+    /// Agent identity string, validated as a legal unix username.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Container image reference for this profile's sessions.
+    /// Container image reference for this agent's sessions.
     pub fn base_image(&self) -> &str {
         &self.base_image
     }
@@ -315,12 +320,12 @@ impl ProfileConfig {
         &self.methodology_dir
     }
 
-    /// Additional bind mounts declared for this profile.
-    pub fn mounts(&self) -> &[ProfileMountConfig] {
+    /// Additional bind mounts declared for this agent.
+    pub fn mounts(&self) -> &[AgentMountConfig] {
         &self.mounts
     }
 
-    /// Optional default repository URL for sessions launched from this profile.
+    /// Optional default repository URL for sessions launched from this agent.
     pub fn repo(&self) -> Option<&str> {
         self.repo.as_deref()
     }
@@ -337,27 +342,27 @@ impl ProfileConfig {
         self.repo_token_source.as_deref()
     }
 
-    /// Declared credentials for this profile. Each credential's name is a
-    /// valid environment variable name, unique within this profile.
+    /// Declared credentials for this agent. Each credential's name is a
+    /// valid environment variable name, unique within this agent.
     pub fn credentials(&self) -> &[CredentialConfig] {
         &self.credentials
     }
 
-    /// Static session command executed from the cloned repository.
-    pub fn command(&self) -> &[String] {
-        &self.command
+    /// Agent command argv passed to runa for live execution.
+    pub fn agent_command(&self) -> &[String] {
+        &self.agent_command
     }
 }
 
-/// A validated profile-declared bind mount.
+/// A validated agent-declared bind mount.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProfileMountConfig {
+pub struct AgentMountConfig {
     source: PathBuf,
     target: PathBuf,
     read_only: bool,
 }
 
-impl ProfileMountConfig {
+impl AgentMountConfig {
     /// Host-side source path for this mount.
     pub fn source(&self) -> &Path {
         &self.source
@@ -382,7 +387,7 @@ impl ProfileMountConfig {
     }
 }
 
-/// A declared credential for a profile.
+/// A declared credential for an agent.
 ///
 /// The `name` becomes the environment variable name inside the container.
 /// The `source` is the name of an environment variable that the daemon reads
@@ -420,7 +425,7 @@ impl DaemonConfig {
     /// configuration file at `path`.
     ///
     /// Relative daemon runtime paths are resolved against the directory
-    /// containing `path`. The profile registry is ignored entirely, but other
+    /// containing `path`. The agent registry is ignored entirely, but other
     /// top-level sections must match the daemon config schema.
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
         let contents = std::fs::read_to_string(path)?;
@@ -528,21 +533,21 @@ pub enum ConfigError {
     Io(std::io::Error),
     /// The file contains invalid TOML or violates the expected schema.
     Parse(toml::de::Error),
-    /// The configuration defines zero profiles. At least one must be declared.
-    NoProfiles,
-    /// Two profiles share the same name.
-    DuplicateProfileName { name: String },
-    /// A profile name fails the runner's [`validate_profile_name`] rules.
-    InvalidProfileName { name: String },
-    /// Two credentials within the same profile share a name.
-    DuplicateCredentialName { profile: String, name: String },
+    /// The configuration defines zero agents. At least one must be declared.
+    NoAgents,
+    /// Two agents share the same name.
+    DuplicateAgentName { name: String },
+    /// An agent name fails the runner's [`validate_agent_name`] rules.
+    InvalidAgentName { name: String },
+    /// Two credentials within the same agent share a name.
+    DuplicateCredentialName { agent: String, name: String },
     /// A credential name fails [`validate_environment_name`] (contains `,`
-    /// or `=`, or is the reserved `PROFILE_NAME`).
-    InvalidCredentialName { profile: String, name: String },
+    /// or `=`, or is the reserved `AGENT_NAME`).
+    InvalidCredentialName { agent: String, name: String },
     /// A required string field is empty or whitespace-only.
     EmptyField {
         field: &'static str,
-        profile: Option<String>,
+        agent: Option<String>,
         credential: Option<String>,
     },
     /// A lookup-key field has leading or trailing whitespace. Caught
@@ -550,7 +555,7 @@ pub enum ConfigError {
     /// whitespace itself is the error.
     FieldHasOuterWhitespace {
         field: &'static str,
-        profile: Option<String>,
+        agent: Option<String>,
         credential: Option<String>,
     },
     /// Deriving the daemon instance id requires absolute daemon runtime paths.
@@ -564,26 +569,26 @@ pub enum ConfigError {
         path: PathBuf,
         error: std::io::Error,
     },
-    /// The `command` array is empty for a profile.
-    EmptyCommand { profile: String },
-    /// A profile declares a default repository URL the runner would reject.
-    InvalidRepo { profile: String, message: String },
-    /// A profile declares an invalid cron expression.
-    InvalidSchedule { profile: String, schedule: String },
-    /// A scheduled profile must declare a default repo for autonomous runs.
-    ScheduleRequiresRepo { profile: String },
+    /// The `command` array is empty for an agent.
+    EmptyAgentCommand { agent: String },
+    /// An agent declares a default repository URL the runner would reject.
+    InvalidRepo { agent: String, message: String },
+    /// An agent declares an invalid cron expression.
+    InvalidSchedule { agent: String, schedule: String },
+    /// A scheduled agent must declare a default repo for autonomous runs.
+    ScheduleRequiresRepo { agent: String },
     /// A configured mount source is not an absolute path.
-    MountSourceMustBeAbsolute { profile: String, source: PathBuf },
+    MountSourceMustBeAbsolute { agent: String, source: PathBuf },
     /// A configured mount target violates the runner's target rules.
     InvalidMountTarget {
-        profile: String,
+        agent: String,
         error: MountTargetValidationError,
     },
-    /// Two configured mounts in one profile share the same target path.
-    DuplicateMountTarget { profile: String, target: PathBuf },
-    /// Two configured mounts in one profile overlap by path components.
+    /// Two configured mounts in one agent share the same target path.
+    DuplicateMountTarget { agent: String, target: PathBuf },
+    /// Two configured mounts in one agent overlap by path components.
     OverlappingMountTargets {
-        profile: String,
+        agent: String,
         first: PathBuf,
         second: PathBuf,
     },
@@ -594,38 +599,38 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::Io(error) => write!(f, "failed to read config: {error}"),
             ConfigError::Parse(error) => write!(f, "invalid config: {error}"),
-            ConfigError::NoProfiles => write!(f, "config must define at least one profile"),
-            ConfigError::DuplicateProfileName { name } => {
-                write!(f, "duplicate profile name: {name}")
+            ConfigError::NoAgents => write!(f, "config must define at least one agent"),
+            ConfigError::DuplicateAgentName { name } => {
+                write!(f, "duplicate agent name: {name}")
             }
-            ConfigError::InvalidProfileName { name } => {
+            ConfigError::InvalidAgentName { name } => {
                 write!(
                     f,
-                    "invalid profile name '{name}'; {}",
-                    RunnerError::InvalidProfileName
+                    "invalid agent name '{name}'; {}",
+                    RunnerError::InvalidAgentName
                 )
             }
-            ConfigError::DuplicateCredentialName { profile, name } => {
+            ConfigError::DuplicateCredentialName { agent, name } => {
                 write!(
                     f,
-                    "profile '{profile}' defines duplicate credential name '{name}'"
+                    "agent '{agent}' defines duplicate credential name '{name}'"
                 )
             }
-            ConfigError::InvalidCredentialName { profile, name } => {
+            ConfigError::InvalidCredentialName { agent, name } => {
                 write!(
                     f,
-                    "profile '{profile}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use reserved name 'PROFILE_NAME'"
+                    "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use reserved name 'AGENT_NAME'"
                 )
             }
             ConfigError::EmptyField {
                 field,
-                profile,
+                agent,
                 credential,
             } => {
                 write!(f, "field '{field}' must not be empty")?;
 
-                if let Some(profile) = profile {
-                    write!(f, " for profile '{profile}'")?;
+                if let Some(agent) = agent {
+                    write!(f, " for agent '{agent}'")?;
                 }
                 if let Some(credential) = credential {
                     write!(f, " credential '{credential}'")?;
@@ -635,7 +640,7 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                profile,
+                agent,
                 credential,
             } => {
                 write!(
@@ -643,8 +648,8 @@ impl fmt::Display for ConfigError {
                     "field '{field}' must not have leading or trailing whitespace"
                 )?;
 
-                if let Some(profile) = profile {
-                    write!(f, " for profile '{profile}'")?;
+                if let Some(agent) = agent {
+                    write!(f, " for agent '{agent}'")?;
                 }
                 if let Some(credential) = credential {
                     write!(f, " credential '{credential}'")?;
@@ -677,52 +682,46 @@ impl fmt::Display for ConfigError {
                     path.display()
                 )
             }
-            ConfigError::EmptyCommand { profile } => {
-                write!(f, "profile '{profile}' must define a non-empty command")
+            ConfigError::EmptyAgentCommand { agent } => {
+                write!(f, "agent '{agent}' must define a non-empty command")
             }
-            ConfigError::InvalidRepo { profile, message } => {
-                write!(f, "profile '{profile}' defines invalid repo: {message}")
+            ConfigError::InvalidRepo { agent, message } => {
+                write!(f, "agent '{agent}' defines invalid repo: {message}")
             }
-            ConfigError::InvalidSchedule { profile, schedule } => {
+            ConfigError::InvalidSchedule { agent, schedule } => {
+                write!(f, "agent '{agent}' defines invalid schedule '{schedule}'")
+            }
+            ConfigError::ScheduleRequiresRepo { agent } => {
                 write!(
                     f,
-                    "profile '{profile}' defines invalid schedule '{schedule}'"
+                    "agent '{agent}' defines schedule but no repo; scheduled agents must define a repo"
                 )
             }
-            ConfigError::ScheduleRequiresRepo { profile } => {
+            ConfigError::MountSourceMustBeAbsolute { agent, source } => {
                 write!(
                     f,
-                    "profile '{profile}' defines schedule but no repo; scheduled profiles must define a repo"
-                )
-            }
-            ConfigError::MountSourceMustBeAbsolute { profile, source } => {
-                write!(
-                    f,
-                    "profile '{profile}' defines mount source that must be absolute: {}",
+                    "agent '{agent}' defines mount source that must be absolute: {}",
                     source.display()
                 )
             }
-            ConfigError::InvalidMountTarget { profile, error } => {
-                write!(
-                    f,
-                    "profile '{profile}' defines invalid mount target: {error}"
-                )
+            ConfigError::InvalidMountTarget { agent, error } => {
+                write!(f, "agent '{agent}' defines invalid mount target: {error}")
             }
-            ConfigError::DuplicateMountTarget { profile, target } => {
+            ConfigError::DuplicateMountTarget { agent, target } => {
                 write!(
                     f,
-                    "profile '{profile}' defines duplicate mount target: {}",
+                    "agent '{agent}' defines duplicate mount target: {}",
                     target.display()
                 )
             }
             ConfigError::OverlappingMountTargets {
-                profile,
+                agent,
                 first,
                 second,
             } => {
                 write!(
                     f,
-                    "profile '{profile}' defines overlapping mount targets: {} and {}",
+                    "agent '{agent}' defines overlapping mount targets: {} and {}",
                     first.display(),
                     second.display()
                 )
@@ -760,7 +759,7 @@ struct RawConfig {
     #[serde(default)]
     daemon: RawDaemonConfig,
     #[serde(default)]
-    profiles: Vec<RawProfileConfig>,
+    agents: Vec<RawAgent>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -768,8 +767,8 @@ struct RawConfig {
 struct RawDaemonOnlyConfig {
     #[serde(default)]
     daemon: RawDaemonConfig,
-    #[serde(default, rename = "profiles")]
-    _profiles: Option<toml::Value>,
+    #[serde(default, rename = "agents")]
+    _agents: Option<toml::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -794,11 +793,11 @@ impl Default for RawDaemonConfig {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawProfileConfig {
+struct RawAgent {
     name: String,
     base_image: String,
     methodology_dir: String,
-    command: Vec<String>,
+    command: RawAgentCommand,
     #[serde(default)]
     mounts: Vec<RawMountConfig>,
     repo: Option<String>,
@@ -806,6 +805,12 @@ struct RawProfileConfig {
     repo_token_source: Option<String>,
     #[serde(default)]
     credentials: Vec<RawCredentialConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAgentCommand {
+    argv: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -877,13 +882,13 @@ fn hex_encode(bytes: &[u8]) -> String {
 fn validate_non_empty(
     field: &'static str,
     value: &str,
-    profile: Option<&str>,
+    agent: Option<&str>,
     credential: Option<&str>,
 ) -> Result<(), ConfigError> {
     if value.trim().is_empty() {
         return Err(ConfigError::EmptyField {
             field,
-            profile: profile.map(str::to_owned),
+            agent: agent.map(str::to_owned),
             credential: credential.map(str::to_owned),
         });
     }
@@ -894,15 +899,15 @@ fn validate_non_empty(
 fn validate_lookup_key(
     field: &'static str,
     value: &str,
-    profile: Option<&str>,
+    agent: Option<&str>,
     credential: Option<&str>,
 ) -> Result<(), ConfigError> {
-    validate_non_empty(field, value, profile, credential)?;
+    validate_non_empty(field, value, agent, credential)?;
 
     if value != value.trim() {
         return Err(ConfigError::FieldHasOuterWhitespace {
             field,
-            profile: profile.map(str::to_owned),
+            agent: agent.map(str::to_owned),
             credential: credential.map(str::to_owned),
         });
     }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -119,11 +119,11 @@ impl From<serde_json::Error> for ClientError {
     }
 }
 
-fn log_manual_run_completed(profile: &str, work_unit: Option<&str>, outcome: &SessionOutcome) {
+fn log_manual_run_completed(agent: &str, work_unit: Option<&str>, outcome: &SessionOutcome) {
     match outcome {
         SessionOutcome::TimedOut => tracing::warn!(
             event = "agentd.manual_run_completed",
-            profile = profile,
+            agent = agent,
             work_unit = work_unit.unwrap_or(""),
             work_unit_present = work_unit.is_some(),
             outcome = outcome.label(),
@@ -133,7 +133,7 @@ fn log_manual_run_completed(profile: &str, work_unit: Option<&str>, outcome: &Se
         | SessionOutcome::Blocked { .. }
         | SessionOutcome::NothingReady { .. } => tracing::info!(
             event = "agentd.manual_run_completed",
-            profile = profile,
+            agent = agent,
             work_unit = work_unit.unwrap_or(""),
             work_unit_present = work_unit.is_some(),
             outcome = outcome.label(),
@@ -143,7 +143,7 @@ fn log_manual_run_completed(profile: &str, work_unit: Option<&str>, outcome: &Se
         ),
         _ => tracing::warn!(
             event = "agentd.manual_run_completed",
-            profile = profile,
+            agent = agent,
             work_unit = work_unit.unwrap_or(""),
             work_unit_present = work_unit.is_some(),
             outcome = outcome.label(),
@@ -344,7 +344,7 @@ pub fn request_run(
     match send_request(
         socket_path.as_ref(),
         &RequestMessage::Run {
-            profile: request.profile.clone(),
+            agent: request.agent.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
             input: request.input.clone(),
@@ -365,7 +365,7 @@ pub(crate) fn request_run_without_waiting(
     send_request_without_response(
         socket_path.as_ref(),
         &RequestMessage::Run {
-            profile: request.profile.clone(),
+            agent: request.agent.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
             input: request.input.clone(),
@@ -469,14 +469,14 @@ fn handle_connection_inner(
     let response = match request {
         RequestMessage::Ping => ResponseMessage::Pong,
         RequestMessage::Run {
-            profile,
+            agent,
             repo_url,
             work_unit,
             input,
         } => match dispatch_run(
             config,
             &RunRequest {
-                profile: profile.clone(),
+                agent: agent.clone(),
                 repo_url,
                 work_unit: work_unit.clone(),
                 input,
@@ -484,7 +484,7 @@ fn handle_connection_inner(
             executor,
         ) {
             Ok(outcome) => {
-                log_manual_run_completed(&profile, work_unit.as_deref(), &outcome);
+                log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
                 ResponseMessage::SessionOutcome {
                     outcome: outcome.into(),
                 }
@@ -816,14 +816,15 @@ mod tests {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -11,7 +11,7 @@ use crate::config::{Config, ConfigError};
 /// Parameters for a daemon run request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunRequest {
-    pub profile: String,
+    pub agent: String,
     pub repo_url: Option<String>,
     /// Optional manual work-unit target. Mutually exclusive with `input`.
     pub work_unit: Option<String>,
@@ -22,14 +22,14 @@ pub struct RunRequest {
 /// Errors produced while mapping a run request into a runner session.
 #[derive(Debug)]
 pub enum DispatchError {
-    UnknownProfile {
-        profile: String,
+    UnknownAgent {
+        agent: String,
     },
     MissingRepo {
-        profile: String,
+        agent: String,
     },
     MissingCredentialSource {
-        profile: String,
+        agent: String,
         credential: String,
         source: String,
     },
@@ -40,18 +40,18 @@ pub enum DispatchError {
 impl fmt::Display for DispatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnknownProfile { profile } => write!(f, "unknown profile '{profile}'"),
-            Self::MissingRepo { profile } => write!(
+            Self::UnknownAgent { agent } => write!(f, "unknown agent '{agent}'"),
+            Self::MissingRepo { agent } => write!(
                 f,
-                "profile '{profile}' requires a repo argument or configured profile repo"
+                "agent '{agent}' requires a repo argument or configured agent repo"
             ),
             Self::MissingCredentialSource {
-                profile,
+                agent,
                 credential,
                 source,
             } => write!(
                 f,
-                "profile '{profile}' credential '{credential}' requires daemon environment variable '{source}'"
+                "agent '{agent}' credential '{credential}' requires daemon environment variable '{source}'"
             ),
             Self::Config(error) => write!(f, "{error}"),
             Self::Runner(error) => write!(f, "{error}"),
@@ -104,35 +104,34 @@ impl SessionExecutor for RunnerSessionExecutor {
     }
 }
 
-/// Resolve a named profile plus run request into a runner session and run it.
+/// Resolve a named agent plus run request into a runner session and run it.
 pub fn dispatch_run(
     config: &Config,
     request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
-    let profile =
-        config
-            .profile(&request.profile)
-            .ok_or_else(|| DispatchError::UnknownProfile {
-                profile: request.profile.clone(),
-            })?;
+    let agent = config
+        .agent(&request.agent)
+        .ok_or_else(|| DispatchError::UnknownAgent {
+            agent: request.agent.clone(),
+        })?;
     let repo_url = request
         .repo_url
         .clone()
-        .or_else(|| profile.repo().map(str::to_owned));
+        .or_else(|| agent.repo().map(str::to_owned));
     let repo_url = repo_url.ok_or_else(|| DispatchError::MissingRepo {
-        profile: profile.name().to_string(),
+        agent: agent.name().to_string(),
     })?;
     let daemon_instance_id = config.daemon().daemon_instance_id()?;
     let audit_root = prepare_audit_root(config.daemon())?;
 
-    let environment = profile
+    let environment = agent
         .credentials()
         .iter()
         .map(|credential| {
             let value = std::env::var(credential.source()).map_err(|_| {
                 DispatchError::MissingCredentialSource {
-                    profile: profile.name().to_string(),
+                    agent: agent.name().to_string(),
                     credential: credential.name().to_string(),
                     source: credential.source().to_string(),
                 }
@@ -145,7 +144,7 @@ pub fn dispatch_run(
         })
         .collect::<Result<Vec<_>, DispatchError>>()?;
 
-    let repo_token = profile
+    let repo_token = agent
         .repo_token_source()
         .and_then(|source| std::env::var(source).ok())
         .filter(|value| !value.is_empty());
@@ -154,16 +153,16 @@ pub fn dispatch_run(
         .run_session(
             SessionSpec {
                 daemon_instance_id,
-                profile_name: profile.name().to_string(),
-                base_image: profile.base_image().to_string(),
-                methodology_dir: profile.methodology_dir().to_path_buf(),
+                agent_name: agent.name().to_string(),
+                base_image: agent.base_image().to_string(),
+                methodology_dir: agent.methodology_dir().to_path_buf(),
                 audit_root,
-                mounts: profile
+                mounts: agent
                     .mounts()
                     .iter()
                     .map(|mount| mount.to_runner_mount())
                     .collect(),
-                command: profile.command().to_vec(),
+                agent_command: agent.agent_command().to_vec(),
                 environment,
             },
             SessionInvocation {

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -1,6 +1,6 @@
 //! Composition root for the agentd daemon.
 //!
-//! Exposes the [`config`] module for TOML-based profile configuration. The
+//! Exposes the [`config`] module for TOML-based agent configuration. The
 //! binary crate (`main.rs`) assembles runner and scheduler from the parsed
 //! configuration and starts the daemon.
 

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -107,7 +107,7 @@ enum Command {
     Daemon(DaemonArgs),
     /// Trigger a manual session through the running daemon.
     Run {
-        profile: String,
+        agent: String,
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
@@ -153,7 +153,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             resolve_daemon_config_path(cli.config.as_deref(), daemon_args.config.as_deref())?,
         )?),
         Some(Command::Run {
-            profile,
+            agent,
             repo,
             socket_path,
             work_unit,
@@ -169,7 +169,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             run_client(
                 socket_path.as_deref(),
-                profile,
+                agent,
                 repo,
                 work_unit,
                 request,
@@ -214,7 +214,7 @@ fn register_termination_handlers(shutdown: Arc<AtomicBool>) -> Result<(), std::i
 
 fn run_client(
     explicit_socket_path: Option<&std::path::Path>,
-    profile: String,
+    agent: String,
     repo: Option<String>,
     work_unit: Option<String>,
     request: Option<String>,
@@ -232,7 +232,7 @@ fn run_client(
     let outcome = request_run(
         &socket_path,
         &RunRequest {
-            profile,
+            agent,
             repo_url: repo,
             work_unit,
             input,

--- a/crates/agentd/src/protocol.rs
+++ b/crates/agentd/src/protocol.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) enum RequestMessage {
     Ping,
     Run {
-        profile: String,
+        agent: String,
         repo_url: Option<String>,
         work_unit: Option<String>,
         input: Option<InvocationInput>,

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::AtomicBool;
 use std::thread::{self, JoinHandle};
 
 use agentd_scheduler::{
-    Clock, DispatchError, Dispatcher, ScheduledProfile, ScheduledRunRequest, Scheduler,
-    SystemClock, run_until_shutdown,
+    Clock, DispatchError, Dispatcher, ScheduledAgent, ScheduledRunRequest, Scheduler, SystemClock,
+    run_until_shutdown,
 };
 
 use crate::RunRequest;
@@ -15,8 +15,8 @@ pub(crate) fn spawn_scheduler_thread(
     config: &Config,
     shutdown: Arc<AtomicBool>,
 ) -> std::io::Result<Option<JoinHandle<()>>> {
-    let scheduled_profiles = scheduled_profiles_from_config(config);
-    if scheduled_profiles.is_empty() {
+    let scheduled_agents = scheduled_agents_from_config(config);
+    if scheduled_agents.is_empty() {
         return Ok(None);
     }
 
@@ -25,7 +25,7 @@ pub(crate) fn spawn_scheduler_thread(
         .name("agentd-scheduler".to_string())
         .spawn(move || {
             let clock = SystemClock;
-            let mut scheduler = Scheduler::new(scheduled_profiles, clock.now())
+            let mut scheduler = Scheduler::new(scheduled_agents, clock.now())
                 .expect("config validation should guarantee valid schedules");
             let dispatcher = SocketDispatcher { daemon_config };
             run_until_shutdown(&mut scheduler, &dispatcher, &clock, shutdown.as_ref());
@@ -46,17 +46,17 @@ pub(crate) fn join_scheduler_thread(handle: Option<JoinHandle<()>>) {
     }
 }
 
-fn scheduled_profiles_from_config(config: &Config) -> Vec<ScheduledProfile> {
+fn scheduled_agents_from_config(config: &Config) -> Vec<ScheduledAgent> {
     config
-        .profiles()
+        .agents()
         .iter()
-        .filter_map(|profile| {
-            let schedule = profile.schedule()?;
-            let repo = profile
+        .filter_map(|agent| {
+            let schedule = agent.schedule()?;
+            let repo = agent
                 .repo()
-                .expect("config validation should guarantee scheduled profiles declare repo");
+                .expect("config validation should guarantee scheduled agents declare repo");
             Some(
-                ScheduledProfile::new(profile.name().to_string(), repo.to_string(), schedule)
+                ScheduledAgent::new(agent.name().to_string(), repo.to_string(), schedule)
                     .expect("config validation should guarantee valid schedules"),
             )
         })
@@ -72,12 +72,12 @@ impl Dispatcher for SocketDispatcher {
     fn dispatch(&self, request: ScheduledRunRequest) -> Result<(), DispatchError> {
         let daemon_config = self.daemon_config.clone();
         thread::Builder::new()
-            .name(format!("agentd-scheduled-dispatch-{}", request.profile))
+            .name(format!("agentd-scheduled-dispatch-{}", request.agent))
             .spawn(move || {
                 if let Err(error) = request_run_without_waiting(
                     daemon_config.socket_path(),
                     &RunRequest {
-                        profile: request.profile.clone(),
+                        agent: request.agent.clone(),
                         repo_url: Some(request.repo_url.clone()),
                         work_unit: None,
                         input: None,
@@ -85,7 +85,7 @@ impl Dispatcher for SocketDispatcher {
                 ) {
                     tracing::warn!(
                         event = "agentd.scheduled_run_dispatch_failed",
-                        profile = request.profile,
+                        agent = request.agent,
                         error = %error,
                         "scheduled run dispatch failed"
                     );
@@ -166,36 +166,38 @@ mod tests {
     }
 
     #[test]
-    fn scheduled_profiles_ignore_profiles_without_schedule() {
+    fn scheduled_agents_ignore_agents_without_schedule() {
         let config = Config::from_str(
             r#"
 [daemon]
 socket_path = "/tmp/agentd.sock"
 pid_file = "/tmp/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/site.git"
 schedule = "*/15 * * * *"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles]]
+[[agents]]
 name = "code-reviewer"
 base_image = "ghcr.io/example/code-reviewer:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/review.git"
 
-command = ["code-reviewer", "exec"]
+[agents.command]
+argv = ["code-reviewer", "exec"]
 "#,
         )
         .expect("config should parse");
 
-        let scheduled_profiles = scheduled_profiles_from_config(&config);
+        let scheduled_agents = scheduled_agents_from_config(&config);
 
-        assert_eq!(scheduled_profiles.len(), 1);
+        assert_eq!(scheduled_agents.len(), 1);
     }
 
     #[test]
@@ -207,13 +209,14 @@ command = ["code-reviewer", "exec"]
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/site.git"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
             socket_path = runtime_dir.join("agentd.sock").display(),
             pid_file = runtime_dir.join("agentd.pid").display(),
@@ -233,7 +236,7 @@ command = ["site-builder", "exec"]
         };
         dispatcher
             .dispatch(ScheduledRunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: "https://example.com/site.git".to_string(),
             })
             .expect("dispatch should spawn a socket client");
@@ -272,13 +275,14 @@ command = ["site-builder", "exec"]
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/site.git"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
             socket_path = socket_path.display(),
             pid_file = runtime_dir.join("agentd.pid").display(),
@@ -290,7 +294,7 @@ command = ["site-builder", "exec"]
 
         dispatcher
             .dispatch(ScheduledRunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: "https://example.com/site.git".to_string(),
             })
             .expect("dispatch should spawn a socket client");
@@ -309,7 +313,7 @@ command = ["site-builder", "exec"]
             serde_json::from_str::<serde_json::Value>(&line).expect("request should be valid json"),
             serde_json::json!({
                 "type": "run",
-                "profile": "site-builder",
+                "agent": "site-builder",
                 "repo_url": "https://example.com/site.git",
                 "work_unit": null,
                 "input": null,

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -92,12 +92,13 @@ fn daemon_test_config(socket_path: &Path, pid_file: &Path) -> String {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
         socket_path = socket_path.display(),
         pid_file = pid_file.display()
@@ -111,13 +112,14 @@ fn daemon_test_config_with_default_repo(socket_path: &Path, pid_file: &Path, rep
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "{repo}"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
         socket_path = socket_path.display(),
         pid_file = pid_file.display(),
@@ -132,14 +134,15 @@ fn daemon_test_config_with_credential(socket_path: &Path, pid_file: &Path) -> St
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -419,7 +422,7 @@ fn binary_run_command_rejects_root_level_config() {
 }
 
 #[test]
-fn binary_run_command_uses_profile_default_repo_when_repo_argument_is_omitted() {
+fn binary_run_command_uses_agent_default_repo_when_repo_argument_is_omitted() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-default-repo-{}-{}",
         std::process::id(),
@@ -458,7 +461,7 @@ fn binary_run_command_uses_profile_default_repo_when_repo_argument_is_omitted() 
 
     assert!(
         output.status.success(),
-        "run command should succeed with a profile default repo: {}",
+        "run command should succeed with an agent default repo: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(
@@ -468,7 +471,7 @@ fn binary_run_command_uses_profile_default_repo_when_repo_argument_is_omitted() 
 }
 
 #[test]
-fn binary_run_command_prefers_explicit_repo_over_profile_default_repo() {
+fn binary_run_command_prefers_explicit_repo_over_agent_default_repo() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-explicit-repo-{}-{}",
         std::process::id(),
@@ -741,7 +744,7 @@ fn binary_run_command_reads_artifact_file_and_forwards_structured_input() {
 }
 
 #[test]
-fn binary_run_command_reports_clear_error_when_repo_is_missing_from_cli_and_profile() {
+fn binary_run_command_reports_clear_error_when_repo_is_missing_from_cli_and_agent() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-missing-repo-{}-{}",
         std::process::id(),
@@ -783,15 +786,15 @@ fn binary_run_command_reports_clear_error_when_repo_is_missing_from_cli_and_prof
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
     assert!(
-        stderr.contains("requires a repo argument or configured profile repo"),
+        stderr.contains("requires a repo argument or configured agent repo"),
         "expected missing-repo error, got: {stderr}"
     );
 }
 
 #[test]
-fn binary_run_command_reports_unknown_profile_when_repo_argument_is_omitted() {
+fn binary_run_command_reports_unknown_agent_when_repo_argument_is_omitted() {
     let runtime_dir = std::env::temp_dir().join(format!(
-        "agentd-cli-runtime-unknown-profile-{}-{}",
+        "agentd-cli-runtime-unknown-agent-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -802,7 +805,7 @@ fn binary_run_command_reports_unknown_profile_when_repo_argument_is_omitted() {
     let socket_path = runtime_dir.join("agentd.sock");
     let pid_file = runtime_dir.join("agentd.pid");
     let config_path = write_temp_config(
-        "client-command-unknown-profile",
+        "client-command-unknown-agent",
         &daemon_test_config(&socket_path, &pid_file),
     );
     let (shutdown, handle, _config) =
@@ -813,7 +816,7 @@ fn binary_run_command_reports_unknown_profile_when_repo_argument_is_omitted() {
             "run",
             "--socket-path",
             socket_path.to_str().expect("socket path should be utf-8"),
-            "unknown-profile",
+            "unknown-agent",
         ])
         .output()
         .expect("agentd binary should run");
@@ -826,17 +829,17 @@ fn binary_run_command_reports_unknown_profile_when_repo_argument_is_omitted() {
 
     assert!(
         !output.status.success(),
-        "run command should fail for an unknown profile"
+        "run command should fail for an unknown agent"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
     assert!(
-        stderr.contains("unknown profile 'unknown-profile'"),
-        "expected unknown-profile error, got: {stderr}"
+        stderr.contains("unknown agent 'unknown-agent'"),
+        "expected unknown-agent error, got: {stderr}"
     );
     assert!(
-        !stderr.contains("requires a repo argument or configured profile repo"),
-        "unknown-profile failure should not be reported as missing repo: {stderr}"
+        !stderr.contains("requires a repo argument or configured agent repo"),
+        "unknown-agent failure should not be reported as missing repo: {stderr}"
     );
 }
 
@@ -1149,13 +1152,14 @@ fn binary_run_command_succeeds_without_client_config_when_using_xdg_socket_disco
     let config_path = write_temp_config(
         "client-command-invalid-registry-after-start",
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/default.git"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -24,22 +24,23 @@ fn example_config() -> String {
         .expect("example config should be readable")
 }
 
-fn assert_invalid_profile_name_parse_error(name: &str) {
+fn assert_invalid_agent_name_parse_error(name: &str) {
     let error = Config::from_str(&format!(
         r#"
-[[profiles]]
+[[agents]]
 name = "{name}"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#
     ))
-    .expect_err("invalid profile names should be rejected at parse time");
+    .expect_err("invalid agent names should be rejected at parse time");
 
     match error {
-        ConfigError::InvalidProfileName { name: invalid_name } => assert_eq!(invalid_name, name),
-        other => panic!("expected invalid profile name error, got {other}"),
+        ConfigError::InvalidAgentName { name: invalid_name } => assert_eq!(invalid_name, name),
+        other => panic!("expected invalid agent name error, got {other}"),
     }
 }
 
@@ -86,14 +87,15 @@ fn assert_invalid_mount_target_parse_error(
     let target = target.replace('\\', "\\\\").replace('"', "\\\"");
     let error = Config::from_str(&format!(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.claude"
 target = "{target}"
 read_only = true
@@ -102,8 +104,8 @@ read_only = true
     .expect_err("runner-invalid mount targets should be rejected during config parse");
 
     match error {
-        ConfigError::InvalidMountTarget { profile, error } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::InvalidMountTarget { agent, error } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(error, expected_error);
         }
         other => panic!("expected invalid mount target error, got {other}"),
@@ -111,16 +113,40 @@ read_only = true
 }
 
 #[test]
-fn parses_example_config_into_static_profile_settings() {
+fn parses_agents_with_declarative_command_argv() {
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("agent config should parse");
+
+    let agent = config
+        .agent("site-builder")
+        .expect("site-builder agent should exist");
+
+    assert_eq!(config.agents().len(), 1);
+    assert_eq!(agent.name(), "site-builder");
+    assert_eq!(agent.agent_command(), ["site-builder", "exec"]);
+}
+
+#[test]
+fn parses_example_config_into_static_agent_settings() {
     let config = Config::from_str(&example_config()).expect("example config should parse");
     let site_builder = config
-        .profile("site-builder")
-        .expect("site-builder profile should exist");
+        .agent("site-builder")
+        .expect("site-builder agent should exist");
     let code_reviewer = config
-        .profile("code-reviewer")
-        .expect("code-reviewer profile should exist");
+        .agent("code-reviewer")
+        .expect("code-reviewer agent should exist");
 
-    assert_eq!(config.profiles().len(), 2);
+    assert_eq!(config.agents().len(), 2);
     let runtime_paths = default_daemon_runtime_paths();
     assert_eq!(config.daemon().socket_path(), runtime_paths.socket_path());
     assert_eq!(config.daemon().pid_file(), runtime_paths.pid_file());
@@ -139,12 +165,7 @@ fn parses_example_config_into_static_profile_settings() {
         site_builder.repo_token_source(),
         Some("SITE_BUILDER_REPO_TOKEN")
     );
-    assert_eq!(site_builder.command()[0], "/bin/sh");
-    assert_eq!(site_builder.command()[1], "-lc");
-    assert!(site_builder.command()[2].contains("runa init --methodology"));
-    assert!(site_builder.command()[2].contains("/agentd/methodology/manifest.toml"));
-    assert!(site_builder.command()[2].contains("command = [\"site-builder\", \"exec\"]"));
-    assert!(site_builder.command()[2].contains("AGENTD_WORK_UNIT"));
+    assert_eq!(site_builder.agent_command(), ["site-builder", "exec"]);
     assert_eq!(site_builder.credentials().len(), 1);
     assert_eq!(site_builder.credentials()[0].name(), "GITHUB_TOKEN");
     assert_eq!(
@@ -168,12 +189,7 @@ fn parses_example_config_into_static_profile_settings() {
         code_reviewer.repo_token_source(),
         Some("CODE_REVIEWER_REPO_TOKEN")
     );
-    assert_eq!(code_reviewer.command()[0], "/bin/sh");
-    assert_eq!(code_reviewer.command()[1], "-lc");
-    assert!(code_reviewer.command()[2].contains("runa init --methodology"));
-    assert!(code_reviewer.command()[2].contains("/agentd/methodology/manifest.toml"));
-    assert!(code_reviewer.command()[2].contains("command = [\"code-reviewer\", \"exec\"]"));
-    assert!(code_reviewer.command()[2].contains("AGENTD_WORK_UNIT"));
+    assert_eq!(code_reviewer.agent_command(), ["code-reviewer", "exec"]);
     assert_eq!(code_reviewer.credentials().len(), 1);
     assert_eq!(code_reviewer.credentials()[0].name(), "GITHUB_TOKEN");
     assert_eq!(
@@ -188,22 +204,21 @@ fn loading_config_resolves_relative_methodology_path_from_file_location() {
     let path = write_temp_config(
         "relative-path",
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 
     let config = Config::load(&path).expect("config file should parse");
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
     assert_eq!(
-        profile.methodology_dir(),
+        agent.methodology_dir(),
         path.parent()
             .expect("config file should have a parent directory")
             .join("../groundwork")
@@ -217,12 +232,13 @@ fn loading_config_from_a_relative_path_resolves_methodology_dir_from_an_absolute
         &current_dir.join("target"),
         "relative-load-path",
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
     let relative_path = path
@@ -230,18 +246,16 @@ command = ["site-builder", "exec"]
         .expect("fixture path should be under the current directory");
 
     let config = Config::load(relative_path).expect("config file should parse");
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
     assert_eq!(
-        profile.methodology_dir(),
+        agent.methodology_dir(),
         path.parent()
             .expect("config file should have a parent directory")
             .join("../groundwork")
     );
     assert!(
-        profile.methodology_dir().is_absolute(),
+        agent.methodology_dir().is_absolute(),
         "loaded methodology_dir should be absolute when loaded from a file"
     );
 }
@@ -255,12 +269,13 @@ fn loading_config_resolves_relative_daemon_paths_from_file_location() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 
@@ -290,12 +305,13 @@ fn loading_config_from_a_relative_path_resolves_relative_daemon_paths_from_an_ab
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
     let relative_path = path
@@ -333,12 +349,13 @@ fn daemon_instance_id_is_stable_for_the_same_runtime_paths() {
 socket_path = "/run/agentd/a.sock"
 pid_file = "/run/agentd/a.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -370,12 +387,13 @@ fn daemon_instance_id_changes_when_daemon_runtime_paths_change() {
 socket_path = "/run/agentd/a.sock"
 pid_file = "/run/agentd/a.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("first config should parse");
@@ -385,12 +403,13 @@ command = ["site-builder", "exec"]
 socket_path = "/run/agentd/b.sock"
 pid_file = "/run/agentd/a.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("second config should parse");
@@ -415,12 +434,13 @@ fn daemon_instance_id_rejects_relative_daemon_runtime_paths_from_str_configs() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -443,12 +463,13 @@ command = ["site-builder", "exec"]
 fn parses_default_daemon_paths_when_daemon_section_is_omitted() {
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse with daemon defaults");
@@ -466,12 +487,13 @@ fn daemon_instance_id_rejects_relative_pid_file_after_absolute_socket_path() {
 socket_path = "/run/agentd/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -498,12 +520,13 @@ fn parses_explicit_daemon_paths() {
 socket_path = "/tmp/agentd-test.sock"
 pid_file = "/tmp/agentd-test.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse explicit daemon paths");
@@ -527,12 +550,13 @@ socket_path = "/tmp/agentd-test.sock"
 pid_file = "/tmp/agentd-test.pid"
 audit_root = "/srv/agentd/audit"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse explicit daemon paths");
@@ -556,12 +580,13 @@ socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 audit_root = "state/audit"
 
-[[profiles]]
+[[agents]]
 name = "Site-Builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 
@@ -590,12 +615,13 @@ fn daemon_audit_root_uses_xdg_state_home_before_home_fallback() {
 
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -626,12 +652,13 @@ fn daemon_audit_root_falls_back_to_home_local_state_when_xdg_state_home_is_unset
 
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -661,12 +688,13 @@ fn daemon_audit_root_requires_a_usable_default_when_not_explicitly_configured() 
 
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
@@ -686,86 +714,84 @@ command = ["site-builder", "exec"]
 fn parses_repo_token_source_as_optional_clone_auth_lookup_key() {
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "SITE_BUILDER_REPO_TOKEN"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse repo token source");
 
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(profile.repo_token_source(), Some("SITE_BUILDER_REPO_TOKEN"));
+    assert_eq!(agent.repo_token_source(), Some("SITE_BUILDER_REPO_TOKEN"));
 }
 
 #[test]
-fn parses_profile_repo_as_optional_default_clone_url() {
+fn parses_agent_repo_as_optional_default_clone_url() {
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/agentd.git"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse repo");
 
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(profile.repo(), Some("https://example.com/agentd.git"));
+    assert_eq!(agent.repo(), Some("https://example.com/agentd.git"));
 }
 
 #[test]
-fn parses_profile_schedule_as_optional_cron_expression() {
+fn parses_agent_schedule_as_optional_cron_expression() {
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/agentd.git"
 schedule = "*/15 * * * *"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse schedule");
 
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(profile.schedule(), Some("*/15 * * * *"));
+    assert_eq!(agent.schedule(), Some("*/15 * * * *"));
 }
 
 #[test]
-fn parses_profile_mounts_as_operator_declared_bind_mounts() {
+fn parses_agent_mounts_as_operator_declared_bind_mounts() {
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.claude"
 target = "/home/site-builder/.claude"
 read_only = true
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/var/lib/tesserine/audit"
 target = "/home/site-builder/.runa"
 read_only = false
@@ -773,43 +799,39 @@ read_only = false
     )
     .expect("config should parse declared mounts");
 
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(profile.mounts().len(), 2);
+    assert_eq!(agent.mounts().len(), 2);
+    assert_eq!(agent.mounts()[0].source(), Path::new("/home/core/.claude"));
     assert_eq!(
-        profile.mounts()[0].source(),
-        Path::new("/home/core/.claude")
-    );
-    assert_eq!(
-        profile.mounts()[0].target(),
+        agent.mounts()[0].target(),
         Path::new("/home/site-builder/.claude")
     );
-    assert!(profile.mounts()[0].read_only());
+    assert!(agent.mounts()[0].read_only());
     assert_eq!(
-        profile.mounts()[1].source(),
+        agent.mounts()[1].source(),
         Path::new("/var/lib/tesserine/audit")
     );
     assert_eq!(
-        profile.mounts()[1].target(),
+        agent.mounts()[1].target(),
         Path::new("/home/site-builder/.runa")
     );
-    assert!(!profile.mounts()[1].read_only());
+    assert!(!agent.mounts()[1].read_only());
 }
 
 #[test]
-fn rejects_profile_mount_sources_that_are_not_absolute() {
+fn rejects_agent_mount_sources_that_are_not_absolute() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "../claude"
 target = "/home/site-builder/.claude"
 read_only = true
@@ -818,8 +840,8 @@ read_only = true
     .expect_err("relative mount sources should be rejected");
 
     match error {
-        ConfigError::MountSourceMustBeAbsolute { profile, source } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::MountSourceMustBeAbsolute { agent, source } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(source, Path::new("../claude"));
         }
         other => panic!("expected absolute mount source error, got {other}"),
@@ -827,7 +849,7 @@ read_only = true
 }
 
 #[test]
-fn rejects_profile_mount_targets_that_are_not_absolute() {
+fn rejects_agent_mount_targets_that_are_not_absolute() {
     assert_invalid_mount_target_parse_error(
         ".claude",
         MountTargetValidationError::Invalid {
@@ -837,22 +859,23 @@ fn rejects_profile_mount_targets_that_are_not_absolute() {
 }
 
 #[test]
-fn rejects_duplicate_profile_mount_targets() {
+fn rejects_duplicate_agent_mount_targets() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.claude"
 target = "/home/site-builder/.claude"
 read_only = true
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/var/lib/tesserine/audit"
 target = "/home/site-builder/.claude"
 read_only = false
@@ -861,8 +884,8 @@ read_only = false
     .expect_err("duplicate mount targets should be rejected");
 
     match error {
-        ConfigError::DuplicateMountTarget { profile, target } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::DuplicateMountTarget { agent, target } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(target, Path::new("/home/site-builder/.claude"));
         }
         other => panic!("expected duplicate mount target error, got {other}"),
@@ -870,23 +893,24 @@ read_only = false
 }
 
 #[test]
-fn load_rejects_overlapping_profile_mount_targets() {
+fn load_rejects_overlapping_agent_mount_targets() {
     let path = write_temp_config(
         "overlapping-mount-targets",
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.config"
 target = "/home/site-builder/.config"
 read_only = true
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.config/claude"
 target = "/home/site-builder/.config/claude"
 read_only = true
@@ -897,11 +921,11 @@ read_only = true
 
     match error {
         ConfigError::OverlappingMountTargets {
-            profile,
+            agent,
             first,
             second,
         } => {
-            assert_eq!(profile, "site-builder");
+            assert_eq!(agent, "site-builder");
             assert_eq!(first, Path::new("/home/site-builder/.config"));
             assert_eq!(second, Path::new("/home/site-builder/.config/claude"));
         }
@@ -910,7 +934,7 @@ read_only = true
 }
 
 #[test]
-fn rejects_profile_mount_targets_with_parent_dir_components() {
+fn rejects_agent_mount_targets_with_parent_dir_components() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder/x/../repo/.git",
         MountTargetValidationError::Invalid {
@@ -920,7 +944,7 @@ fn rejects_profile_mount_targets_with_parent_dir_components() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_with_current_dir_components() {
+fn rejects_agent_mount_targets_with_current_dir_components() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder/./a",
         MountTargetValidationError::Invalid {
@@ -930,7 +954,7 @@ fn rejects_profile_mount_targets_with_current_dir_components() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_containing_commas() {
+fn rejects_agent_mount_targets_containing_commas() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder/data,archive",
         MountTargetValidationError::Invalid {
@@ -940,7 +964,7 @@ fn rejects_profile_mount_targets_containing_commas() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_with_trailing_slashes() {
+fn rejects_agent_mount_targets_with_trailing_slashes() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder/.claude/",
         MountTargetValidationError::Invalid {
@@ -950,7 +974,7 @@ fn rejects_profile_mount_targets_with_trailing_slashes() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_containing_find_metacharacters() {
+fn rejects_agent_mount_targets_containing_find_metacharacters() {
     for target in [
         "/home/site-builder/foo*bar",
         "/home/site-builder/foo?bar",
@@ -967,18 +991,19 @@ fn rejects_profile_mount_targets_containing_find_metacharacters() {
 }
 
 #[test]
-fn load_rejects_profile_mount_targets_with_trailing_slashes() {
+fn load_rejects_agent_mount_targets_with_trailing_slashes() {
     let path = write_temp_config(
         "invalid-mount-target-trailing-slash",
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.claude"
 target = "/home/site-builder/.claude/"
 read_only = true
@@ -988,8 +1013,8 @@ read_only = true
     let error = Config::load(&path).expect_err("trailing-slash mount targets should be rejected");
 
     match &error {
-        ConfigError::InvalidMountTarget { profile, error } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::InvalidMountTarget { agent, error } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(
                 error,
                 &MountTargetValidationError::Invalid {
@@ -1002,12 +1027,12 @@ read_only = true
 
     assert_eq!(
         error.to_string(),
-        "profile 'site-builder' defines invalid mount target: mount target must be an absolute path without trailing '/', '.' or '..' components, ',', or find metacharacters ('*', '?', '[', ']', '\\\\'): /home/site-builder/.claude/"
+        "agent 'site-builder' defines invalid mount target: mount target must be an absolute path without trailing '/', '.' or '..' components, ',', or find metacharacters ('*', '?', '[', ']', '\\\\'): /home/site-builder/.claude/"
     );
 }
 
 #[test]
-fn rejects_profile_mount_targets_that_are_ancestors_of_methodology_mount() {
+fn rejects_agent_mount_targets_that_are_ancestors_of_methodology_mount() {
     assert_invalid_mount_target_parse_error(
         "/agentd",
         MountTargetValidationError::Reserved {
@@ -1017,7 +1042,7 @@ fn rejects_profile_mount_targets_that_are_ancestors_of_methodology_mount() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_that_collide_with_methodology_mount() {
+fn rejects_agent_mount_targets_that_collide_with_methodology_mount() {
     assert_invalid_mount_target_parse_error(
         "/agentd/methodology",
         MountTargetValidationError::Reserved {
@@ -1027,7 +1052,7 @@ fn rejects_profile_mount_targets_that_collide_with_methodology_mount() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_that_collide_with_home_directory() {
+fn rejects_agent_mount_targets_that_collide_with_home_directory() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder",
         MountTargetValidationError::Reserved {
@@ -1037,7 +1062,7 @@ fn rejects_profile_mount_targets_that_collide_with_home_directory() {
 }
 
 #[test]
-fn rejects_profile_mount_targets_that_collide_with_repo_directory() {
+fn rejects_agent_mount_targets_that_collide_with_repo_directory() {
     assert_invalid_mount_target_parse_error(
         "/home/site-builder/repo",
         MountTargetValidationError::Reserved {
@@ -1050,85 +1075,87 @@ fn rejects_profile_mount_targets_that_collide_with_repo_directory() {
 fn normalizes_empty_repo_token_source_to_none() {
     let config = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = ""
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("empty repo token source should disable clone auth");
 
-    let profile = config
-        .profile("site-builder")
-        .expect("profile should exist");
+    let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(profile.repo_token_source(), None);
+    assert_eq!(agent.repo_token_source(), None);
 }
 
 #[test]
 fn rejects_schedule_without_repo() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 schedule = "*/15 * * * *"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
-    .expect_err("scheduled profiles without repos should be rejected");
+    .expect_err("scheduled agents without repos should be rejected");
 
     match error {
-        ConfigError::ScheduleRequiresRepo { profile } => assert_eq!(profile, "site-builder"),
+        ConfigError::ScheduleRequiresRepo { agent } => assert_eq!(agent, "site-builder"),
         other => panic!("expected schedule-requires-repo error, got {other}"),
     }
 }
 
 #[test]
-fn rejects_invalid_profile_repo_url() {
+fn rejects_invalid_agent_repo_url() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "/srv/test-repo.git"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
-    .expect_err("invalid profile repos should be rejected");
+    .expect_err("invalid agent repos should be rejected");
 
     match error {
-        ConfigError::InvalidRepo { profile, .. } => assert_eq!(profile, "site-builder"),
+        ConfigError::InvalidRepo { agent, .. } => assert_eq!(agent, "site-builder"),
         other => panic!("expected invalid repo error, got {other}"),
     }
 }
 
 #[test]
-fn rejects_invalid_profile_schedule() {
+fn rejects_invalid_agent_schedule() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo = "https://example.com/agentd.git"
 schedule = "* * *"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
-    .expect_err("invalid profile schedules should be rejected");
+    .expect_err("invalid agent schedules should be rejected");
 
     match error {
-        ConfigError::InvalidSchedule { profile, schedule } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::InvalidSchedule { agent, schedule } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(schedule, "* * *");
         }
         other => panic!("expected invalid schedule error, got {other}"),
@@ -1140,13 +1167,14 @@ fn rejects_repo_token_source_with_outer_whitespace() {
     for repo_token_source in [" SITE_BUILDER_REPO_TOKEN", "SITE_BUILDER_REPO_TOKEN "] {
         let error = Config::from_str(&format!(
             r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#
         ))
         .expect_err("whitespace-padded repo token sources should be rejected");
@@ -1154,11 +1182,11 @@ command = ["site-builder", "exec"]
         match error {
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                profile,
+                agent,
                 credential,
             } => {
                 assert_eq!(field, "repo_token_source");
-                assert_eq!(profile.as_deref(), Some("site-builder"));
+                assert_eq!(agent.as_deref(), Some("site-builder"));
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -1167,16 +1195,17 @@ command = ["site-builder", "exec"]
 }
 
 #[test]
-fn rejects_unknown_fields_in_profile_config() {
+fn rejects_unknown_fields_in_agent_config() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 extra = "nope"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect_err("unknown fields should be rejected");
@@ -1193,12 +1222,13 @@ fn rejects_unknown_fields_in_daemon_config() {
 socket_path = "/tmp/agentd.sock"
 extra = "nope"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect_err("unknown daemon fields should be rejected");
@@ -1208,55 +1238,58 @@ command = ["site-builder", "exec"]
 }
 
 #[test]
-fn rejects_duplicate_profile_names() {
+fn rejects_duplicate_agent_names() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:stable"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
-    .expect_err("duplicate profile names should be rejected");
+    .expect_err("duplicate agent names should be rejected");
 
     match error {
-        ConfigError::DuplicateProfileName { name } => assert_eq!(name, "site-builder"),
-        other => panic!("expected duplicate profile name error, got {other}"),
+        ConfigError::DuplicateAgentName { name } => assert_eq!(name, "site-builder"),
+        other => panic!("expected duplicate agent name error, got {other}"),
     }
 }
 
 #[test]
-fn rejects_configs_without_profiles() {
-    let error = Config::from_str("").expect_err("configs must define at least one profile");
+fn rejects_configs_without_agents() {
+    let error = Config::from_str("").expect_err("configs must define at least one agent");
 
-    assert!(error.to_string().contains("at least one profile"));
+    assert!(error.to_string().contains("at least one agent"));
 }
 
 #[test]
-fn rejects_duplicate_credential_names_within_a_profile() {
+fn rejects_duplicate_credential_names_within_a_agent() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_OTHER_TOKEN"
 "#,
@@ -1264,8 +1297,8 @@ source = "AGENTD_GITHUB_OTHER_TOKEN"
     .expect_err("duplicate credential names should be rejected");
 
     match error {
-        ConfigError::DuplicateCredentialName { profile, name } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::DuplicateCredentialName { agent, name } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(name, "GITHUB_TOKEN");
         }
         other => panic!("expected duplicate credential name error, got {other}"),
@@ -1276,12 +1309,13 @@ source = "AGENTD_GITHUB_OTHER_TOKEN"
 fn rejects_empty_required_string_fields() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = ""
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect_err("empty names should be rejected");
@@ -1290,28 +1324,29 @@ command = ["site-builder", "exec"]
 }
 
 #[test]
-fn rejects_profile_names_with_leading_or_trailing_whitespace() {
+fn rejects_agent_names_with_leading_or_trailing_whitespace() {
     for name in [" site-builder", "site-builder "] {
         let error = Config::from_str(&format!(
             r#"
-[[profiles]]
+[[agents]]
 name = "{name}"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#
         ))
-        .expect_err("whitespace-padded profile names should be rejected");
+        .expect_err("whitespace-padded agent names should be rejected");
 
         match error {
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                profile,
+                agent,
                 credential,
             } => {
                 assert_eq!(field, "name");
-                assert_eq!(profile, None);
+                assert_eq!(agent, None);
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -1320,23 +1355,23 @@ command = ["site-builder", "exec"]
 }
 
 #[test]
-fn rejects_uppercase_profile_names_at_parse_time() {
-    assert_invalid_profile_name_parse_error("Site-Builder");
+fn rejects_uppercase_agent_names_at_parse_time() {
+    assert_invalid_agent_name_parse_error("Site-Builder");
 }
 
 #[test]
-fn rejects_digit_prefixed_profile_names_at_parse_time() {
-    assert_invalid_profile_name_parse_error("123site-builder");
+fn rejects_digit_prefixed_agent_names_at_parse_time() {
+    assert_invalid_agent_name_parse_error("123site-builder");
 }
 
 #[test]
-fn rejects_reserved_profile_names_at_parse_time() {
-    assert_invalid_profile_name_parse_error("root");
+fn rejects_reserved_agent_names_at_parse_time() {
+    assert_invalid_agent_name_parse_error("root");
 }
 
 #[test]
-fn rejects_profile_names_longer_than_thirty_two_characters_at_parse_time() {
-    assert_invalid_profile_name_parse_error(&format!("a{}", "b".repeat(32)));
+fn rejects_agent_names_longer_than_thirty_two_characters_at_parse_time() {
+    assert_invalid_agent_name_parse_error(&format!("a{}", "b".repeat(32)));
 }
 
 #[test]
@@ -1344,14 +1379,15 @@ fn rejects_credential_names_with_leading_or_trailing_whitespace() {
     for name in [" GITHUB_TOKEN", "GITHUB_TOKEN "] {
         let error = Config::from_str(&format!(
             r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "{name}"
 source = "AGENTD_GITHUB_TOKEN"
 "#
@@ -1361,11 +1397,11 @@ source = "AGENTD_GITHUB_TOKEN"
         match error {
             ConfigError::FieldHasOuterWhitespace {
                 field,
-                profile,
+                agent,
                 credential,
             } => {
                 assert_eq!(field, "credentials.name");
-                assert_eq!(profile.as_deref(), Some("site-builder"));
+                assert_eq!(agent.as_deref(), Some("site-builder"));
                 assert_eq!(credential, None);
             }
             other => panic!("expected whitespace validation error, got {other}"),
@@ -1377,14 +1413,15 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_credential_names_containing_commas() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "TOKEN,EXTRA"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -1392,8 +1429,8 @@ source = "AGENTD_GITHUB_TOKEN"
     .expect_err("comma-delimited credential names should be rejected");
 
     match error {
-        ConfigError::InvalidCredentialName { profile, name } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::InvalidCredentialName { agent, name } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(name, "TOKEN,EXTRA");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -1404,14 +1441,15 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_credential_names_containing_equals_signs() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "FOO=BAR"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -1419,8 +1457,8 @@ source = "AGENTD_GITHUB_TOKEN"
     .expect_err("credential names containing '=' should be rejected");
 
     match error {
-        ConfigError::InvalidCredentialName { profile, name } => {
-            assert_eq!(profile, "site-builder");
+        ConfigError::InvalidCredentialName { agent, name } => {
+            assert_eq!(agent, "site-builder");
             assert_eq!(name, "FOO=BAR");
         }
         other => panic!("expected invalid credential name error, got {other}"),
@@ -1431,24 +1469,25 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_reserved_credential_names() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
-name = "PROFILE_NAME"
+[[agents.credentials]]
+name = "AGENT_NAME"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
     )
     .expect_err("runner-reserved credential names should be rejected");
 
     match error {
-        ConfigError::InvalidCredentialName { profile, name } => {
-            assert_eq!(profile, "site-builder");
-            assert_eq!(name, "PROFILE_NAME");
+        ConfigError::InvalidCredentialName { agent, name } => {
+            assert_eq!(agent, "site-builder");
+            assert_eq!(name, "AGENT_NAME");
         }
         other => panic!("expected invalid credential name error, got {other}"),
     }
@@ -1458,24 +1497,26 @@ source = "AGENTD_GITHUB_TOKEN"
 fn rejects_empty_command_arrays_and_empty_command_elements() {
     let empty_command_error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = []
+[agents.command]
+argv = []
 "#,
     )
     .expect_err("empty command arrays should be rejected");
 
     let empty_element_error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", ""]
+[agents.command]
+argv = ["site-builder", ""]
 "#,
     )
     .expect_err("empty command elements should be rejected");
@@ -1488,7 +1529,7 @@ command = ["site-builder", ""]
 fn rejects_missing_command_field() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
@@ -1503,13 +1544,14 @@ methodology_dir = "../groundwork"
 fn rejects_legacy_runa_table() {
     let error = Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-[profiles.runa]
-command = ["site-builder", "exec"]
+[agents.runa]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect_err("legacy runa table should be rejected");
@@ -1545,12 +1587,13 @@ fn loading_daemon_config_resolves_relative_paths_from_file_location() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "Site-Builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 
@@ -1568,12 +1611,13 @@ fn loading_daemon_config_uses_defaults_when_daemon_section_is_omitted() {
     let path = write_temp_config(
         "daemon-only-defaults",
         r#"
-[[profiles]]
+[[agents]]
 name = "Site-Builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 
@@ -1593,12 +1637,13 @@ fn loading_daemon_config_rejects_unknown_fields_in_daemon_section() {
 socket_path = "/tmp/agentd.sock"
 extra = "nope"
 
-[[profiles]]
+[[agents]]
 name = "Site-Builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     );
 
@@ -1616,7 +1661,7 @@ fn loading_daemon_config_rejects_unknown_top_level_sections() {
 [deamon]
 socket_path = "/tmp/agentd.sock"
 
-[[profiles]]
+[[agents]]
 unexpected = "still allowed to exist here"
 "#,
     );
@@ -1629,16 +1674,16 @@ unexpected = "still allowed to exist here"
 }
 
 #[test]
-fn loading_daemon_config_ignores_invalid_profile_registry_entries() {
+fn loading_daemon_config_ignores_invalid_agent_registry_entries() {
     let path = write_temp_config(
-        "daemon-only-ignores-profiles",
+        "daemon-only-ignores-agents",
         r#"
 [daemon]
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
-unexpected = "daemon loader should ignore profile schema entirely"
+[[agents]]
+unexpected = "daemon loader should ignore agent schema entirely"
 "#,
     );
 

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -163,14 +163,15 @@ fn config_in_runtime_dir(runtime_dir: &std::path::Path) -> Config {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -227,7 +228,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     let outcome = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "site-builder".to_string(),
+            agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
             work_unit: Some("task-42".to_string()),
             input: None,
@@ -255,7 +256,7 @@ fn client_reports_clear_error_when_daemon_is_not_running() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "site-builder".to_string(),
+            agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
             work_unit: None,
             input: None,
@@ -293,7 +294,7 @@ fn daemon_round_trips_typed_invocation_input_through_the_socket_protocol() {
     let outcome = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "site-builder".to_string(),
+            agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
             work_unit: None,
             input: Some(InvocationInput::Artifact {
@@ -347,7 +348,7 @@ fn daemon_rejects_conflicting_work_unit_and_input_from_socket_callers() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "site-builder".to_string(),
+            agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
             work_unit: Some("issue-42".to_string()),
             input: Some(InvocationInput::RequestText {
@@ -494,7 +495,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         request_run(
             first_config.daemon(),
             &RunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: Some("https://example.com/repo.git".to_string()),
                 work_unit: Some("first".to_string()),
                 input: None,
@@ -509,7 +510,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
         let outcome = request_run(
             second_config.daemon(),
             &RunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: Some("https://example.com/repo.git".to_string()),
                 work_unit: Some("second".to_string()),
                 input: None,
@@ -589,7 +590,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
         request_run(
             client_config.daemon(),
             &RunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: Some("https://example.com/repo.git".to_string()),
                 work_unit: Some("shutdown".to_string()),
                 input: None,
@@ -653,7 +654,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
         request_run(
             first_config.daemon(),
             &RunRequest {
-                profile: "site-builder".to_string(),
+                agent: "site-builder".to_string(),
                 repo_url: Some("https://example.com/repo.git".to_string()),
                 work_unit: Some("draining".to_string()),
                 input: None,
@@ -668,7 +669,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
     let error = request_run(
         config.daemon(),
         &RunRequest {
-            profile: "site-builder".to_string(),
+            agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
             work_unit: Some("rejected".to_string()),
             input: None,
@@ -716,14 +717,15 @@ fn daemon_created_runtime_socket_and_directory_are_private() {
 socket_path = "{socket_path}"
 pid_file = "{pid_file}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
@@ -811,12 +813,13 @@ fn daemon_startup_rejects_relative_daemon_runtime_paths_before_claiming_runtime(
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -70,15 +70,16 @@ impl SessionExecutor for RecordingExecutor {
 fn config_with_repo_token_source(repo_token_source: &str) -> Config {
     Config::from_str(&format!(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 repo_token_source = "{repo_token_source}"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#
@@ -92,14 +93,15 @@ fn config_with_audit_root(audit_root: &str) -> Config {
 [daemon]
 audit_root = "{audit_root}"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"
 "#
@@ -110,19 +112,20 @@ source = "AGENTD_GITHUB_TOKEN"
 fn config_with_mounts() -> Config {
     Config::from_str(
         r#"
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/home/core/.claude"
 target = "/home/site-builder/.claude"
 read_only = true
 
-[[profiles.mounts]]
+[[agents.mounts]]
 source = "/var/lib/tesserine/audit"
 target = "/home/site-builder/.runa"
 read_only = false
@@ -142,7 +145,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
     }
     let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: Some("task-42".to_string()),
         input: None,
@@ -163,7 +166,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
         .as_ref()
         .expect("executor should receive invocation");
 
-    assert_eq!(spec.profile_name, "site-builder");
+    assert_eq!(spec.agent_name, "site-builder");
     assert_eq!(spec.base_image, "ghcr.io/example/site-builder:latest");
     assert_eq!(spec.methodology_dir, Path::new("../groundwork"));
     assert_eq!(
@@ -181,7 +184,7 @@ fn dispatch_run_resolves_repo_token_without_injecting_it_into_runtime_environmen
             .expect("audit root should resolve")
     );
     assert_eq!(
-        spec.command,
+        spec.agent_command,
         vec!["site-builder".to_string(), "exec".to_string()]
     );
     assert_eq!(
@@ -217,7 +220,7 @@ fn dispatch_run_forwards_resolved_audit_root_into_session_spec() {
             .expect("temporary audit root should be valid utf-8"),
     );
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -266,7 +269,7 @@ fn dispatch_run_rejects_an_unwritable_audit_root_before_session_execution() {
             .expect("temporary audit root should be valid utf-8"),
     );
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -304,7 +307,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_missing() {
     }
     let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -337,7 +340,7 @@ fn dispatch_run_omits_repo_token_when_source_env_var_is_empty() {
     }
     let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -371,7 +374,7 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
     }
     let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -384,11 +387,11 @@ fn dispatch_run_errors_when_runtime_credential_source_is_missing() {
 
     match error {
         DispatchError::MissingCredentialSource {
-            profile,
+            agent,
             credential,
             source,
         } => {
-            assert_eq!(profile, "site-builder");
+            assert_eq!(agent, "site-builder");
             assert_eq!(credential, "GITHUB_TOKEN");
             assert_eq!(source, "AGENTD_GITHUB_TOKEN");
         }
@@ -408,17 +411,18 @@ fn dispatch_run_rejects_relative_daemon_runtime_paths_as_config_errors() {
 socket_path = "runtime/agentd.sock"
 pid_file = "runtime/agentd.pid"
 
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
 
-command = ["site-builder", "exec"]
+[agents.command]
+argv = ["site-builder", "exec"]
 "#,
     )
     .expect("config should parse");
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -439,10 +443,10 @@ command = ["site-builder", "exec"]
 }
 
 #[test]
-fn dispatch_run_forwards_profile_mounts_into_session_spec() {
+fn dispatch_run_forwards_agent_mounts_into_session_spec() {
     let config = config_with_mounts();
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: None,
@@ -484,7 +488,7 @@ fn dispatch_run_forwards_typed_invocation_input_into_session_invocation() {
     }
     let config = config_with_repo_token_source("SITE_BUILDER_REPO_TOKEN");
     let request = RunRequest {
-        profile: "site-builder".to_string(),
+        agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
         work_unit: None,
         input: Some(InvocationInput::Artifact {

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -1,5 +1,5 @@
-# Static profile registry for agentd.
-# A profile can carry its own default repo and optional schedule.
+# Static agent registry for agentd.
+# An agent can carry its own default repo and optional schedule.
 
 #[daemon]
 # Optional explicit host path for persistent audit records. Rootless installs
@@ -9,77 +9,50 @@
 # /var/lib/tesserine/audit.
 #audit_root = "/var/lib/tesserine/audit"
 
-[[profiles]]
-# Stable operator-facing profile name used for lookup and container identity.
+[[agents]]
+# Stable operator-facing agent name used for lookup and container identity.
 name = "site-builder"
 # Prebuilt image containing the agent runtime and runa.
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
-# and for each scheduled run of this profile.
+# and for each scheduled run of this agent.
 repo = "https://github.com/pentaxis93/agentd.git"
 # Optional five-field cron expression in daemon-local time.
 schedule = "*/15 * * * *"
-# Static session command executed from the cloned repository. This profile is
-# tightly bound to one codebase, so the session repo is the app it builds.
-command = [
-  "/bin/sh",
-  "-lc",
-  '''
-runa init --methodology /agentd/methodology/manifest.toml
-cat > .runa/config.toml <<'EOF'
-[agent]
-command = ["site-builder", "exec"]
-EOF
-if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
-  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
-fi
-exec runa run
-''',
-]
 # Optional environment variable name resolved by the daemon for clone-only
 # repository authentication. This value does not flow into the agent runtime.
 repo_token_source = "SITE_BUILDER_REPO_TOKEN"
+# Exact argv for the agent process. agentd handles runa init and runa run.
+[agents.command]
+argv = ["site-builder", "exec"]
 
-#[[profiles.mounts]]
+#[[agents.mounts]]
 # Additional bind mounts are operator-chosen host paths.
 # `source` must be an absolute existing host path.
 # `target` must be an absolute container path and must not duplicate or
-# overlap another mount target in the same profile.
+# overlap another mount target in the same agent.
 #source = "/home/core/.claude"
 #target = "/home/site-builder/.claude"
 #read_only = true
 
-[[profiles.credentials]]
+[[agents.credentials]]
 # Secret name exposed inside the session environment.
 name = "GITHUB_TOKEN"
 # Environment variable name read from the daemon's own process environment.
 source = "AGENTD_GITHUB_TOKEN"
 
-[[profiles]]
-# A profile whose home repo contains its own review policy and target selection.
+[[agents]]
+# An agent whose home repo contains its own review policy and target selection.
 name = "code-reviewer"
 base_image = "ghcr.io/example/code-reviewer:latest"
 methodology_dir = "../groundwork"
 repo = "https://github.com/pentaxis93/agentd.git"
-command = [
-  "/bin/sh",
-  "-lc",
-  '''
-runa init --methodology /agentd/methodology/manifest.toml
-cat > .runa/config.toml <<'EOF'
-[agent]
-command = ["code-reviewer", "exec"]
-EOF
-if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
-  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
-fi
-exec runa run
-''',
-]
 repo_token_source = "CODE_REVIEWER_REPO_TOKEN"
+[agents.command]
+argv = ["code-reviewer", "exec"]
 
-[[profiles.credentials]]
+[[agents.credentials]]
 name = "GITHUB_TOKEN"
 source = "AGENTD_GITHUB_TOKEN"


### PR DESCRIPTION
## Summary

- Replaces profile configuration with declarative `[[agents]]` entries and structured command argv.
- Moves session runtime composition into agentd: audit-backed `.runa` ownership, `runa init`, invocation-input materialization, and `runa run --agent-command -- <argv>`.
- Updates public vocabulary, examples, tests, README, ARCHITECTURE, and CHANGELOG for the breaking agent schema change.

## Changes

- Adds `Agent` config parsing with `[agents.command].argv` and migrates daemon, scheduler, protocol, CLI, and runner plumbing from profile terminology to agent terminology.
- Updates the container entrypoint composition to keep the existing repo `.runa` symlink, chown the internal audit target for the session user, invoke runa as the session user, and avoid writing `[agent]` into `.runa/config.toml`.
- Extends unit and integration coverage for declarative agent config, composed runa init/run calls, audit persistence, and migrated command/request surfaces.
- Refreshes operator docs and example config to describe the new declarative agent surface and runtime lifecycle.

## GitHub Issue(s)

Closes #88

## Test plan

- `cargo fmt --all --check`
- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- Vocabulary sweep for stale profile schema/type names: `ProfileConfig`, `AgentConfig`, `profile_name`, `PROFILE_NAME`, `[[profiles]]`, `profiles(`, `profile(`
