### PR TITLE
feat(cli): support --version flag on agentd binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
+- `agentd --version` and `agentd run --version` now report the crate release
+  version for operator deployment checks.
 - Agent configuration is now declarative and uses `[[agents]]` with `[agents.command].argv`; the old profile-table vocabulary and shell-wrapper command shape are removed as a pre-1.0 breaking change. agentd now composes `runa init` and `runa run --agent-command -- <argv>` itself, leaving runa-owned `.runa/` config formats to runa.
 - `agentd run` no longer reads `agentd.toml`: it now accepts `--socket-path <PATH>`, otherwise discovers the daemon socket through `$XDG_RUNTIME_DIR/agentd/agentd.sock` first when `XDG_RUNTIME_DIR` is set; for rootless XDG-unset clients it falls back to `/tmp/agentd-$UID/agentd.sock` with ownership and `0700` checks before `/run/agentd/agentd.sock`, while root XDG-unset clients use `/run/agentd/agentd.sock` directly; agent lookup and default-repo resolution now happen daemon-side.
 - `agentd run` now accepts one per-invocation work surface without agent edits: `--work-unit <id>`, `--request <text>`, or `--artifact-type <type> --artifact-file <path>`. Request text is synthesized into `.runa/workspace/request/operator-input.json`, while artifact-file input places validated JSON at `.runa/workspace/<type>/<file-stem>.json`.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ requires rootless Podman for container execution. Operational deployments also
 assume systemd user services and the SELinux considerations described in
 `ARCHITECTURE.md`.
 
+Confirm the deployed binary with `agentd --version`.
+
 Start the daemon:
 
 ```bash

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -87,7 +87,7 @@ impl fmt::Display for RunCommandError {
 impl Error for RunCommandError {}
 
 #[derive(Parser, Debug)]
-#[command(name = "agentd")]
+#[command(name = "agentd", version, propagate_version = true)]
 struct Cli {
     #[arg(long)]
     config: Option<PathBuf>,
@@ -106,6 +106,7 @@ enum Command {
     /// Start the foreground daemon.
     Daemon(DaemonArgs),
     /// Trigger a manual session through the running daemon.
+    #[command(display_name = "agentd")]
     Run {
         agent: String,
         repo: Option<String>,

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -203,6 +203,46 @@ fn start_recording_test_daemon(
 }
 
 #[test]
+fn binary_top_level_version_reports_crate_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .arg("--version")
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        output.status.success(),
+        "version command should exit successfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+    assert_eq!(stdout, format!("agentd {}\n", env!("CARGO_PKG_VERSION")));
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert_eq!(stderr, "");
+}
+
+#[test]
+fn binary_run_version_reports_crate_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args(["run", "--version"])
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        output.status.success(),
+        "run version command should exit successfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+    assert_eq!(stdout, format!("agentd {}\n", env!("CARGO_PKG_VERSION")));
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert_eq!(stderr, "");
+}
+
+#[test]
 fn binary_daemon_subcommand_starts_daemon_mode() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-{}-{}",


### PR DESCRIPTION
## Summary

- Adds crate-derived version reporting to the `agentd` operator CLI.
- Makes `agentd --version` and `agentd run --version` return the same release string for deployment checks.
- Documents the deployment verification command in README and records the user-visible CLI change in the changelog.

## Changes

- Enables clap version metadata and propagation on the `agentd` CLI.
- Keeps the propagated `run --version` display string aligned with the top-level `agentd` binary name.
- Adds binary integration coverage for both accepted version surfaces.

## GitHub Issue(s)

Closes #83

## Test plan

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
