### PR TITLE
refactor(runtime-paths): collapse to deterministic XDG socket resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,18 +102,16 @@ daemon and CLI must be the same build, and replacing the binary requires a
 daemon restart before new CLI invocations are supported.
 
 Manual CLI dispatch is intentionally decoupled from daemon-owned config files.
-`agentd run` discovers the daemon through a socket path rather than by reading
-`agentd.toml`: explicit `--socket-path` wins, otherwise the client checks
-`$XDG_RUNTIME_DIR/agentd/agentd.sock` first when `XDG_RUNTIME_DIR` is set.
-For rootless XDG-unset clients it then checks `/tmp/agentd-$UID/agentd.sock`
-before `/run/agentd/agentd.sock`; for root XDG-unset clients it bypasses the
-`/tmp` fallback and checks `/run/agentd/agentd.sock` directly. The
-`/tmp/agentd-$UID/` fallback is trusted only when the directory is user-owned
-and mode `0700`. A default candidate is selected only after it answers the
-agentd socket protocol `Ping` request with `Pong`; unrelated listeners and
-ambiguous probe failures are skipped so later defaults can be considered.
-Agent lookup and default-repo resolution happen daemon-side after the socket
-request is received, so client and daemon responsibility boundaries stay clean.
+`agentd run` resolves the daemon through a socket path rather than by reading
+`agentd.toml`: explicit `--socket-path` wins, otherwise the client resolves the
+single default path `$XDG_RUNTIME_DIR/agentd/agentd.sock`. Daemon defaults use
+the same XDG construction for the socket and PID file, so client and daemon
+agree by construction rather than by probing a candidate list. If
+`XDG_RUNTIME_DIR` is unset, empty, or relative, the default path is unavailable
+and operators must either fix the XDG runtime environment or provide explicit
+paths. There is no implicit `/tmp` or `/run` fallback. Agent lookup and
+default-repo resolution happen daemon-side after the socket request is
+received, so client and daemon responsibility boundaries stay clean.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agentd --version` and `agentd run --version` now report the crate release
   version for operator deployment checks.
 - Agent configuration is now declarative and uses `[[agents]]` with `[agents.command].argv`; the old profile-table vocabulary and shell-wrapper command shape are removed as a pre-1.0 breaking change. agentd now composes `runa init` and `runa run --agent-command -- <argv>` itself, leaving runa-owned `.runa/` config formats to runa.
-- `agentd run` no longer reads `agentd.toml`: it now accepts `--socket-path <PATH>`, otherwise discovers the daemon socket through `$XDG_RUNTIME_DIR/agentd/agentd.sock` first when `XDG_RUNTIME_DIR` is set; for rootless XDG-unset clients it falls back to `/tmp/agentd-$UID/agentd.sock` with ownership and `0700` checks before `/run/agentd/agentd.sock`, while root XDG-unset clients use `/run/agentd/agentd.sock` directly; agent lookup and default-repo resolution now happen daemon-side.
+- `agentd run` no longer reads `agentd.toml`: it now accepts `--socket-path <PATH>`, otherwise resolves the daemon socket deterministically as `$XDG_RUNTIME_DIR/agentd/agentd.sock`; the implicit `/tmp/agentd-$UID/agentd.sock` and `/run/agentd/agentd.sock` fallbacks are removed as a pre-1.0 breaking change, and agent lookup plus default-repo resolution now happen daemon-side.
 - `agentd run` now accepts one per-invocation work surface without agent edits: `--work-unit <id>`, `--request <text>`, or `--artifact-type <type> --artifact-file <path>`. Request text is synthesized into `.runa/workspace/request/operator-input.json`, while artifact-file input places validated JSON at `.runa/workspace/<type>/<file-stem>.json`.
 - `agentd-runner` now declares its real platform contract at compile time: the crate targets Linux only, and downstream non-Linux builds now fail explicitly instead of compiling dead fallback code into a non-functional binary.
 - Session outcomes now follow the shared `commons` exit-code convention across `agentd` and `agentd-runner`: outcomes carry semantic labels plus raw exit codes, daemon and CLI surfaces report labels such as `blocked` and `generic_failure`, `agentd run` exits successfully for normal terminal states (`success`, `blocked`, `nothing_ready`), and timeout remains an agentd-layer outcome outside the shared exit-code vocabulary.
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Default `agentd run` socket discovery now requires a candidate socket to
-  answer the agentd Ping/Pong protocol before selecting it, and ambiguous
-  connect/probe errors now fall through instead of being treated as ready.
+- Default socket resolution now fails explicitly when `XDG_RUNTIME_DIR` is
+  unset, empty, or relative instead of silently selecting a fallback path that
+  may belong to a different daemon.
 - Session teardown now skips audit finalization and sealing when cleanup fails, leaving `agentd/session.json` intentionally incomplete instead of marking a session complete while its audit bind mount may still be live.
 - Completed session outcomes now remain caller-visible when only audit finalization fails after teardown cleanup succeeds.
 - Audit sealing now refuses multi-linked entries before rewriting metadata, preventing host file mode changes through hard-linked audit aliases.

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ agentd daemon --config /etc/agentd/agentd.toml
 The daemon runs in the foreground, reconciles stale resources from prior runs,
 and binds a Unix socket for operator control. When `daemon.socket_path` and
 `daemon.pid_file` are omitted, agentd chooses coordinated defaults from the
-current runtime context:
+current XDG runtime context:
 
-- `$XDG_RUNTIME_DIR/agentd/agentd.sock` and `$XDG_RUNTIME_DIR/agentd/agentd.pid`
-  when `XDG_RUNTIME_DIR` is set
-- `/tmp/agentd-$UID/agentd.sock` and `/tmp/agentd-$UID/agentd.pid` for
-  rootless environments without `XDG_RUNTIME_DIR`
-- `/run/agentd/agentd.sock` and `/run/agentd/agentd.pid` for root-owned system
-  installs
+- `$XDG_RUNTIME_DIR/agentd/agentd.sock`
+- `$XDG_RUNTIME_DIR/agentd/agentd.pid`
+
+`XDG_RUNTIME_DIR` must be set to an absolute path for daemon defaults. Operators
+using a non-XDG deployment, such as a system-owned daemon under `/run`, should
+configure `daemon.socket_path` and `daemon.pid_file` explicitly.
 
 On SIGINT or SIGTERM, the daemon stops accepting connections and drains
 in-flight sessions; a second signal exits immediately.
@@ -188,20 +188,12 @@ Manual invocation supports exactly one intent surface at a time:
 either:
 
 - explicit override with `--socket-path <PATH>`
-- default discovery by runtime context:
-  `$XDG_RUNTIME_DIR/agentd/agentd.sock` first when `XDG_RUNTIME_DIR` is set;
-  for rootless XDG-unset clients, `/tmp/agentd-$UID/agentd.sock` before
-  `/run/agentd/agentd.sock`; for root XDG-unset clients,
-  `/run/agentd/agentd.sock` directly
+- default XDG resolution to `$XDG_RUNTIME_DIR/agentd/agentd.sock`
 
-Default discovery treats a candidate socket as available only when it answers
-the agentd socket protocol `Ping` request with `Pong`; unrelated listeners,
-silent sockets, malformed responses, and ambiguous probe errors fall through
-to the next default candidate.
-
-When the `/tmp/agentd-$UID/` fallback exists, the client requires that
-directory to be user-owned and mode `0700`; otherwise it refuses with an
-actionable error instead of trusting an insecure `/tmp` path.
+Default resolution is deterministic: the client does not probe candidate
+sockets and does not fall back to `/tmp` or `/run`. When `XDG_RUNTIME_DIR` is
+unset, empty, or relative, `agentd run` exits with an actionable error pointing
+to either setting `XDG_RUNTIME_DIR` or using `--socket-path`.
 
 Agent lookup and default-repo resolution now happen daemon-side. The client
 may omit the positional repo argument when the named agent declares `repo`,

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -23,7 +23,7 @@ use croner::parser::{CronParser, Seconds, Year};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-use crate::runtime_paths::default_daemon_runtime_paths;
+use crate::runtime_paths::{RuntimePathError, default_daemon_runtime_paths};
 
 /// Validated daemon and agent registry parsed from a TOML configuration file.
 ///
@@ -68,7 +68,7 @@ impl Config {
 
     fn parse(contents: &str, base_dir: Option<&Path>) -> Result<Self, ConfigError> {
         let raw: RawConfig = toml::from_str(contents)?;
-        let daemon = DaemonConfig::parse(raw.daemon, base_dir)?;
+        let raw_daemon = raw.daemon;
 
         if raw.agents.is_empty() {
             return Err(ConfigError::NoAgents);
@@ -267,6 +267,8 @@ impl Config {
                 agent_command,
             });
         }
+
+        let daemon = DaemonConfig::parse(raw_daemon, base_dir)?;
 
         Ok(Self { daemon, agents })
     }
@@ -501,12 +503,39 @@ impl DaemonConfig {
     }
 
     fn parse(raw: RawDaemonConfig, base_dir: Option<&Path>) -> Result<Self, ConfigError> {
-        validate_non_empty("daemon.socket_path", &raw.socket_path, None, None)?;
-        validate_non_empty("daemon.pid_file", &raw.pid_file, None, None)?;
+        let default_runtime_paths = if raw.socket_path.is_none() || raw.pid_file.is_none() {
+            Some(default_daemon_runtime_paths().map_err(ConfigError::DefaultDaemonRuntimePaths)?)
+        } else {
+            None
+        };
+
+        let socket_path = match raw.socket_path {
+            Some(path) => {
+                validate_non_empty("daemon.socket_path", &path, None, None)?;
+                resolve_config_path(base_dir, &path)
+            }
+            None => default_runtime_paths
+                .as_ref()
+                .expect("default runtime paths should be resolved when socket_path is omitted")
+                .socket_path()
+                .to_path_buf(),
+        };
+
+        let pid_file = match raw.pid_file {
+            Some(path) => {
+                validate_non_empty("daemon.pid_file", &path, None, None)?;
+                resolve_config_path(base_dir, &path)
+            }
+            None => default_runtime_paths
+                .as_ref()
+                .expect("default runtime paths should be resolved when pid_file is omitted")
+                .pid_file()
+                .to_path_buf(),
+        };
 
         Ok(Self {
-            socket_path: resolve_config_path(base_dir, &raw.socket_path),
-            pid_file: resolve_config_path(base_dir, &raw.pid_file),
+            socket_path,
+            pid_file,
             audit_root: raw
                 .audit_root
                 .as_deref()
@@ -564,6 +593,8 @@ pub enum ConfigError {
     RelativeDaemonAuditRootPath { path: PathBuf },
     /// No usable default audit-root environment was available.
     MissingDaemonAuditRootDefault,
+    /// No usable default daemon runtime-path environment was available.
+    DefaultDaemonRuntimePaths(RuntimePathError),
     /// The resolved daemon audit root could not be created or probed.
     AuditRootNotWritable {
         path: PathBuf,
@@ -675,6 +706,9 @@ impl fmt::Display for ConfigError {
                 f,
                 "daemon audit root could not be resolved; set absolute XDG_STATE_HOME, set absolute HOME, or configure daemon.audit_root explicitly"
             ),
+            ConfigError::DefaultDaemonRuntimePaths(error) => {
+                write!(f, "daemon runtime paths could not be resolved; {error}")
+            }
             ConfigError::AuditRootNotWritable { path, error } => {
                 write!(
                     f,
@@ -735,6 +769,7 @@ impl std::error::Error for ConfigError {
         match self {
             ConfigError::Io(error) => Some(error),
             ConfigError::Parse(error) => Some(error),
+            ConfigError::DefaultDaemonRuntimePaths(error) => Some(error),
             ConfigError::AuditRootNotWritable { error, .. } => Some(error),
             _ => None,
         }
@@ -771,24 +806,12 @@ struct RawDaemonOnlyConfig {
     _agents: Option<toml::Value>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawDaemonConfig {
-    #[serde(default = "default_daemon_socket_path")]
-    socket_path: String,
-    #[serde(default = "default_daemon_pid_file")]
-    pid_file: String,
+    socket_path: Option<String>,
+    pid_file: Option<String>,
     audit_root: Option<String>,
-}
-
-impl Default for RawDaemonConfig {
-    fn default() -> Self {
-        Self {
-            socket_path: default_daemon_socket_path(),
-            pid_file: default_daemon_pid_file(),
-            audit_root: None,
-        }
-    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -826,20 +849,6 @@ struct RawMountConfig {
 struct RawCredentialConfig {
     name: String,
     source: String,
-}
-
-fn default_daemon_socket_path() -> String {
-    default_daemon_runtime_paths()
-        .socket_path()
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn default_daemon_pid_file() -> String {
-    default_daemon_runtime_paths()
-        .pid_file()
-        .to_string_lossy()
-        .into_owned()
 }
 
 fn normalize_path_lexically(path: &Path) -> String {

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -18,7 +18,6 @@ use agentd_runner::{
 use crate::audit_root::prepare_audit_root;
 use crate::config::{Config, ConfigError};
 use crate::protocol::{RequestMessage, ResponseMessage};
-use crate::runtime_paths::{current_user_tmp_runtime_dir, ensure_tmp_runtime_dir};
 use crate::scheduler::{join_scheduler_thread, spawn_scheduler_thread};
 use crate::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 
@@ -628,17 +627,6 @@ impl Drop for DaemonRuntime {
 }
 
 fn prepare_runtime_directory(path: &Path) -> Result<(), DaemonError> {
-    let uid = unsafe { libc::geteuid() };
-    if path == current_user_tmp_runtime_dir() {
-        ensure_tmp_runtime_dir(path, uid).map_err(|error| {
-            DaemonError::Io(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                error.to_string(),
-            ))
-        })?;
-        return Ok(());
-    }
-
     let created = ensure_directory_exists(path)?;
     if created {
         restrict_directory_permissions(path, RUNTIME_DIR_MODE)?;

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -21,5 +21,6 @@ pub use logging::{
     LogFormat, LoggingError, ResolvedLoggingConfig, configure_tracing, resolve_logging_config,
 };
 pub use runtime_paths::{
-    ClientSocketPathError, default_daemon_runtime_paths, resolve_client_socket_path,
+    ClientSocketPathError, RuntimePathError, default_daemon_runtime_paths,
+    resolve_client_socket_path,
 };

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -6,8 +6,8 @@ use std::{error::Error, fmt};
 
 use agentd::config::Config;
 use agentd::{
-    ClientError, ClientSocketPathError, RunRequest, RunnerSessionExecutor, configure_tracing,
-    request_run, resolve_client_socket_path, run_daemon_until_shutdown,
+    RunRequest, RunnerSessionExecutor, configure_tracing, request_run, resolve_client_socket_path,
+    run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
 use clap::{Args, Parser, Subcommand};
@@ -222,13 +222,7 @@ fn run_client(
     artifact_file: Option<PathBuf>,
     artifact_type: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let socket_path = match resolve_client_socket_path(explicit_socket_path) {
-        Ok(path) => path,
-        Err(ClientSocketPathError::DaemonNotDiscovered { last_path }) => {
-            return Err(Box::new(ClientError::DaemonNotRunning { path: last_path }));
-        }
-        Err(error) => return Err(Box::new(error)),
-    };
+    let socket_path = resolve_client_socket_path(explicit_socket_path)?;
     let input = resolve_invocation_input(request, artifact_file, artifact_type)?;
     let outcome = request_run(
         &socket_path,

--- a/crates/agentd/src/runtime_paths.rs
+++ b/crates/agentd/src/runtime_paths.rs
@@ -1,19 +1,8 @@
-use std::ffi::CString;
 use std::fmt;
-use std::fs;
-use std::io::{self, BufRead, BufReader, Write};
-use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::MetadataExt;
-use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
-
-use crate::protocol::{RequestMessage, ResponseMessage};
 
 const SOCKET_BASENAME: &str = "agentd.sock";
 const PID_BASENAME: &str = "agentd.pid";
-const REQUIRED_TMP_MODE: u32 = 0o700;
-const SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DaemonRuntimePaths {
@@ -32,191 +21,104 @@ impl DaemonRuntimePaths {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ClientSocketPathError {
-    InsecureTemporaryRuntimeDir { path: PathBuf, message: String },
-    DaemonNotDiscovered { last_path: PathBuf },
+pub enum RuntimePathError {
+    XdgRuntimeDirUnavailable,
+    XdgRuntimeDirMustBeAbsolute { path: PathBuf },
+}
+
+impl fmt::Display for RuntimePathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::XdgRuntimeDirUnavailable => write!(
+                f,
+                "XDG_RUNTIME_DIR is not set; set XDG_RUNTIME_DIR or configure explicit daemon runtime paths"
+            ),
+            Self::XdgRuntimeDirMustBeAbsolute { path } => write!(
+                f,
+                "XDG_RUNTIME_DIR must be an absolute path: {}; set XDG_RUNTIME_DIR to an absolute runtime directory or configure explicit daemon runtime paths",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RuntimePathError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientSocketPathError {
+    source: RuntimePathError,
+}
+
+impl ClientSocketPathError {
+    fn new(source: RuntimePathError) -> Self {
+        Self { source }
+    }
 }
 
 impl fmt::Display for ClientSocketPathError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InsecureTemporaryRuntimeDir { path, message } => {
-                write!(
-                    f,
-                    "{message}: {}. Use --socket-path to override.",
-                    path.display()
-                )
-            }
-            Self::DaemonNotDiscovered { last_path } => {
-                write!(f, "agentd is not running (socket {})", last_path.display())
-            }
+        match &self.source {
+            RuntimePathError::XdgRuntimeDirUnavailable => write!(
+                f,
+                "XDG_RUNTIME_DIR is not set; set XDG_RUNTIME_DIR or use --socket-path to override"
+            ),
+            RuntimePathError::XdgRuntimeDirMustBeAbsolute { path } => write!(
+                f,
+                "XDG_RUNTIME_DIR must be an absolute path: {}; set XDG_RUNTIME_DIR to an absolute runtime directory or use --socket-path to override",
+                path.display()
+            ),
         }
     }
 }
 
-impl std::error::Error for ClientSocketPathError {}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TemporaryRuntimeDirError {
-    path: PathBuf,
-    message: String,
-}
-
-impl TemporaryRuntimeDirError {
-    fn new(path: &Path, message: impl Into<String>) -> Self {
-        Self {
-            path: path.to_path_buf(),
-            message: message.into(),
-        }
-    }
-}
-
-impl fmt::Display for TemporaryRuntimeDirError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.message, self.path.display())
-    }
-}
-
-impl std::error::Error for TemporaryRuntimeDirError {}
-
-impl From<TemporaryRuntimeDirError> for ClientSocketPathError {
-    fn from(error: TemporaryRuntimeDirError) -> Self {
-        Self::InsecureTemporaryRuntimeDir {
-            path: error.path,
-            message: error.message,
-        }
+impl std::error::Error for ClientSocketPathError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimePathLayout {
-    uid: u32,
-    xdg_runtime_dir: Option<PathBuf>,
-    tmp_runtime_dir: PathBuf,
-    system_runtime_dir: PathBuf,
+    xdg_runtime_dir: PathBuf,
 }
 
 impl RuntimePathLayout {
-    fn detect() -> Self {
-        let uid = unsafe { libc::geteuid() };
-        Self {
-            uid,
-            xdg_runtime_dir: std::env::var_os("XDG_RUNTIME_DIR")
-                .filter(|value| !value.is_empty())
-                .map(PathBuf::from)
-                .filter(|path| path.is_absolute()),
-            tmp_runtime_dir: tmp_runtime_dir_for_uid(uid),
-            system_runtime_dir: PathBuf::from("/run/agentd"),
-        }
-    }
+    fn detect() -> Result<Self, RuntimePathError> {
+        let Some(path) = std::env::var_os("XDG_RUNTIME_DIR")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+        else {
+            return Err(RuntimePathError::XdgRuntimeDirUnavailable);
+        };
 
-    fn client_socket_path(&self) -> Result<PathBuf, ClientSocketPathError> {
-        if let Some(runtime_dir) = &self.xdg_runtime_dir {
-            let candidate = runtime_dir.join("agentd").join(SOCKET_BASENAME);
-            if socket_candidate_is_ready(&candidate) {
-                return Ok(candidate);
-            }
+        if !path.is_absolute() {
+            return Err(RuntimePathError::XdgRuntimeDirMustBeAbsolute { path });
         }
 
-        if self.uid != 0 {
-            let tmp_socket_path = self.tmp_runtime_dir.join(SOCKET_BASENAME);
-            match fs::symlink_metadata(&self.tmp_runtime_dir) {
-                Ok(_) => {
-                    validate_tmp_runtime_dir(&self.tmp_runtime_dir, self.uid)?;
-                    if socket_candidate_is_ready(&tmp_socket_path) {
-                        return Ok(tmp_socket_path);
-                    }
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(TemporaryRuntimeDirError::new(
-                        &self.tmp_runtime_dir,
-                        format!("failed to inspect temporary runtime directory ({error})"),
-                    )
-                    .into());
-                }
-            }
-        }
-
-        let system_socket_path = self.system_runtime_dir.join(SOCKET_BASENAME);
-        if socket_candidate_is_ready(&system_socket_path) {
-            return Ok(system_socket_path);
-        }
-
-        Err(ClientSocketPathError::DaemonNotDiscovered {
-            last_path: system_socket_path,
+        Ok(Self {
+            xdg_runtime_dir: path,
         })
     }
 
-    fn daemon_runtime_paths(&self) -> DaemonRuntimePaths {
-        let runtime_dir = if let Some(runtime_dir) = &self.xdg_runtime_dir {
-            runtime_dir.join("agentd")
-        } else if self.uid == 0 {
-            self.system_runtime_dir.clone()
-        } else {
-            self.tmp_runtime_dir.clone()
-        };
+    fn client_socket_path(&self) -> PathBuf {
+        self.runtime_dir().join(SOCKET_BASENAME)
+    }
 
+    fn daemon_runtime_paths(&self) -> DaemonRuntimePaths {
+        let runtime_dir = self.runtime_dir();
         DaemonRuntimePaths {
             socket_path: runtime_dir.join(SOCKET_BASENAME),
             pid_file: runtime_dir.join(PID_BASENAME),
         }
     }
-}
 
-fn socket_candidate_is_ready(path: &Path) -> bool {
-    if !path.exists() {
-        return false;
-    }
-
-    match UnixStream::connect(path) {
-        Ok(stream) => socket_candidate_answers_agentd_ping(stream),
-        Err(error)
-            if matches!(
-                error.raw_os_error(),
-                Some(libc::ENOENT) | Some(libc::ECONNREFUSED)
-            ) =>
-        {
-            false
-        }
-        Err(_) => false,
+    fn runtime_dir(&self) -> PathBuf {
+        self.xdg_runtime_dir.join("agentd")
     }
 }
 
-fn socket_candidate_answers_agentd_ping(mut stream: UnixStream) -> bool {
-    if stream.set_read_timeout(Some(SOCKET_PROBE_TIMEOUT)).is_err() {
-        return false;
-    }
-
-    if stream
-        .set_write_timeout(Some(SOCKET_PROBE_TIMEOUT))
-        .is_err()
-    {
-        return false;
-    }
-
-    let payload = match serde_json::to_vec(&RequestMessage::Ping) {
-        Ok(payload) => payload,
-        Err(_) => return false,
-    };
-
-    if stream.write_all(&payload).is_err()
-        || stream.write_all(b"\n").is_err()
-        || stream.flush().is_err()
-    {
-        return false;
-    }
-
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    match reader.read_line(&mut line) {
-        Ok(0) | Err(_) => false,
-        Ok(_) => matches!(serde_json::from_str(&line), Ok(ResponseMessage::Pong)),
-    }
-}
-
-pub fn default_daemon_runtime_paths() -> DaemonRuntimePaths {
-    RuntimePathLayout::detect().daemon_runtime_paths()
+pub fn default_daemon_runtime_paths() -> Result<DaemonRuntimePaths, RuntimePathError> {
+    RuntimePathLayout::detect().map(|layout| layout.daemon_runtime_paths())
 }
 
 pub fn resolve_client_socket_path(
@@ -226,741 +128,113 @@ pub fn resolve_client_socket_path(
         return Ok(path.to_path_buf());
     }
 
-    RuntimePathLayout::detect().client_socket_path()
-}
-
-pub(crate) fn current_user_tmp_runtime_dir() -> PathBuf {
-    tmp_runtime_dir_for_uid(unsafe { libc::geteuid() })
-}
-
-pub(crate) fn ensure_tmp_runtime_dir(
-    path: &Path,
-    expected_uid: u32,
-) -> Result<(), TemporaryRuntimeDirError> {
-    match fs::symlink_metadata(path) {
-        Ok(_) => validate_tmp_runtime_dir(path, expected_uid),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            before_tmp_runtime_dir_create(path);
-            create_tmp_runtime_dir(path)?;
-            validate_tmp_runtime_dir(path, expected_uid)
-        }
-        Err(error) => Err(TemporaryRuntimeDirError::new(
-            path,
-            format!("failed to inspect temporary runtime directory ({error})"),
-        )),
-    }
-}
-
-fn create_tmp_runtime_dir(path: &Path) -> Result<(), TemporaryRuntimeDirError> {
-    let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-        TemporaryRuntimeDirError::new(
-            path,
-            "temporary runtime directory path contains an interior NUL byte",
-        )
-    })?;
-
-    let result = unsafe { libc::mkdir(c_path.as_ptr(), REQUIRED_TMP_MODE as libc::mode_t) };
-    if result == 0 {
-        return Ok(());
-    }
-
-    let error = io::Error::last_os_error();
-    if matches!(error.raw_os_error(), Some(libc::EEXIST)) {
-        return Ok(());
-    }
-
-    Err(TemporaryRuntimeDirError::new(
-        path,
-        format!("failed to create temporary runtime directory ({error})"),
-    ))
-}
-
-#[cfg(test)]
-type TmpRuntimeDirCreateHook = Option<(PathBuf, fn(&Path))>;
-
-#[cfg(test)]
-static BEFORE_TMP_RUNTIME_DIR_CREATE_HOOK: std::sync::Mutex<TmpRuntimeDirCreateHook> =
-    std::sync::Mutex::new(None);
-
-#[cfg(test)]
-fn set_before_tmp_runtime_dir_create_hook(path: &Path, hook: fn(&Path)) {
-    *BEFORE_TMP_RUNTIME_DIR_CREATE_HOOK
-        .lock()
-        .expect("tmp runtime dir create hook lock should not be poisoned") =
-        Some((path.to_path_buf(), hook));
-}
-
-#[cfg(test)]
-fn clear_before_tmp_runtime_dir_create_hook() {
-    *BEFORE_TMP_RUNTIME_DIR_CREATE_HOOK
-        .lock()
-        .expect("tmp runtime dir create hook lock should not be poisoned") = None;
-}
-
-#[cfg(test)]
-fn before_tmp_runtime_dir_create(path: &Path) {
-    let hook = BEFORE_TMP_RUNTIME_DIR_CREATE_HOOK
-        .lock()
-        .expect("tmp runtime dir create hook lock should not be poisoned")
-        .as_ref()
-        .and_then(|(hook_path, hook)| (hook_path == path).then_some(*hook));
-
-    if let Some(hook) = hook {
-        hook(path);
-    }
-}
-
-#[cfg(not(test))]
-fn before_tmp_runtime_dir_create(_path: &Path) {}
-
-fn tmp_runtime_dir_for_uid(uid: u32) -> PathBuf {
-    PathBuf::from(format!("/tmp/agentd-{uid}"))
-}
-
-fn validate_tmp_runtime_dir(
-    path: &Path,
-    expected_uid: u32,
-) -> Result<(), TemporaryRuntimeDirError> {
-    let metadata = fs::symlink_metadata(path).map_err(|error| {
-        TemporaryRuntimeDirError::new(
-            path,
-            format!("failed to inspect temporary runtime directory ({error})"),
-        )
-    })?;
-
-    if !metadata.is_dir() {
-        return Err(TemporaryRuntimeDirError::new(
-            path,
-            "temporary runtime path exists but is not a directory",
-        ));
-    }
-
-    let mode = metadata.mode() & 0o777;
-    if mode != REQUIRED_TMP_MODE {
-        return Err(TemporaryRuntimeDirError::new(
-            path,
-            format!(
-                "temporary runtime directory must have mode 0700, found {:04o}",
-                mode
-            ),
-        ));
-    }
-
-    let owner = metadata.uid();
-    if owner != expected_uid {
-        return Err(TemporaryRuntimeDirError::new(
-            path,
-            format!(
-                "temporary runtime directory must be owned by uid {expected_uid}, found uid {owner}"
-            ),
-        ));
-    }
-
-    Ok(())
+    RuntimePathLayout::detect()
+        .map(|layout| layout.client_socket_path())
+        .map_err(ClientSocketPathError::new)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, BufReader, Write};
-    use std::os::unix::fs::PermissionsExt;
-    use std::os::unix::net::UnixListener;
-    use std::thread;
-    use std::time::Duration;
+    use std::sync::{Mutex, OnceLock};
 
-    fn test_layout(
-        uid: u32,
-        xdg_runtime_dir: Option<PathBuf>,
-        tmp_runtime_dir: PathBuf,
-        system_runtime_dir: PathBuf,
-    ) -> RuntimePathLayout {
-        RuntimePathLayout {
-            uid,
-            xdg_runtime_dir,
-            tmp_runtime_dir,
-            system_runtime_dir,
-        }
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn test_layout(xdg_runtime_dir: PathBuf) -> RuntimePathLayout {
+        RuntimePathLayout { xdg_runtime_dir }
     }
 
     fn unique_dir(name: &str) -> PathBuf {
-        let path = std::env::temp_dir().join(format!(
+        std::env::temp_dir().join(format!(
             "agentd-runtime-paths-{name}-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("system time should be after epoch")
                 .as_nanos()
-        ));
-        std::fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn spawn_agentd_ping_responder(path: &Path) -> thread::JoinHandle<()> {
-        let listener = UnixListener::bind(path).expect("agentd responder socket should bind");
-        thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("probe connection should arrive");
-            let mut line = String::new();
-            BufReader::new(&mut stream)
-                .read_line(&mut line)
-                .expect("ping should be readable");
-            assert_eq!(line, "{\"type\":\"ping\"}\n");
-            stream
-                .write_all(b"{\"type\":\"pong\"}\n")
-                .expect("pong should be writable");
-        })
-    }
-
-    fn spawn_wrong_protocol_responder(path: &Path) -> thread::JoinHandle<()> {
-        let listener = UnixListener::bind(path).expect("wrong-protocol socket should bind");
-        thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("probe connection should arrive");
-            let mut line = String::new();
-            let _ = BufReader::new(&mut stream).read_line(&mut line);
-            let _ = stream.write_all(b"{\"type\":\"error\",\"message\":\"not agentd\"}\n");
-        })
-    }
-
-    fn spawn_silent_responder(path: &Path) -> thread::JoinHandle<()> {
-        let listener = UnixListener::bind(path).expect("silent socket should bind");
-        thread::spawn(move || {
-            let (_stream, _) = listener.accept().expect("probe connection should arrive");
-            thread::sleep(Duration::from_millis(500));
-        })
+        ))
     }
 
     #[test]
-    fn client_socket_path_prefers_xdg_runtime_dir_when_it_answers_agentd_ping() {
-        let root = unique_dir("client-xdg");
-        let xdg_runtime_dir = root.join("xdg-runtime");
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let responder = spawn_agentd_ping_responder(&xdg_agentd_dir.join("agentd.sock"));
-
-        let layout = test_layout(
-            1000,
-            Some(xdg_runtime_dir),
-            PathBuf::from("/tmp/agentd-1000"),
-            PathBuf::from("/run/agentd"),
-        );
+    fn client_socket_path_resolves_xdg_path_without_probing_for_a_daemon() {
+        let xdg_runtime_dir = unique_dir("client-xdg-no-probe");
+        let layout = test_layout(xdg_runtime_dir.clone());
 
         assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("xdg path should resolve"),
-            xdg_agentd_dir.join("agentd.sock")
-        );
-        responder.join().expect("agentd responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_falls_through_to_tmp_when_xdg_socket_is_missing() {
-        let xdg_root = unique_dir("client-xdg-fallback-to-tmp-xdg");
-        let xdg_runtime_dir = xdg_root.join("xdg-runtime");
-        std::fs::create_dir_all(xdg_runtime_dir.join("agentd"))
-            .expect("xdg runtime dir should be created");
-        let root = unique_dir("client-xdg-fallback-to-tmp");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o700))
-            .expect("permissions should be set");
-        let responder = spawn_agentd_ping_responder(&tmp_runtime_dir.join("agentd.sock"));
-
-        let uid = unsafe { libc::geteuid() };
-        let layout = test_layout(
-            uid,
-            Some(xdg_runtime_dir),
-            tmp_runtime_dir.clone(),
-            root.join("run-agentd"),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("tmp path should resolve"),
-            tmp_runtime_dir.join("agentd.sock")
-        );
-        responder.join().expect("tmp responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_ignores_insecure_tmp_dir_when_xdg_socket_is_available() {
-        let root = unique_dir("xdg-ignore-bad-tmp");
-        let xdg_runtime_dir = root.join("xdg-runtime");
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let responder = spawn_agentd_ping_responder(&xdg_agentd_dir.join("agentd.sock"));
-
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o755))
-            .expect("permissions should be set");
-
-        let uid = unsafe { libc::geteuid() };
-        let layout = test_layout(
-            uid,
-            Some(xdg_runtime_dir),
-            tmp_runtime_dir,
-            root.join("run-agentd"),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("xdg path should resolve before tmp validation"),
-            xdg_agentd_dir.join("agentd.sock")
-        );
-        responder.join().expect("agentd responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_prefers_xdg_runtime_dir_for_root_when_present() {
-        let root = unique_dir("client-root-xdg");
-        let xdg_runtime_dir = root.join("xdg-runtime");
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let responder = spawn_agentd_ping_responder(&xdg_agentd_dir.join("agentd.sock"));
-
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o755))
-            .expect("permissions should be set");
-
-        let layout = test_layout(
-            0,
-            Some(xdg_runtime_dir),
-            tmp_runtime_dir,
-            root.join("run-agentd"),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("xdg path should resolve before root system fallback"),
-            xdg_agentd_dir.join("agentd.sock")
-        );
-        responder.join().expect("agentd responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_falls_through_to_system_when_earlier_candidates_are_unavailable() {
-        let root = unique_dir("client-system-fallback");
-        let xdg_runtime_dir = root.join("xdg-runtime");
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let xdg_listener =
-            UnixListener::bind(xdg_agentd_dir.join("agentd.sock")).expect("xdg socket should bind");
-        drop(xdg_listener);
-
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o700))
-            .expect("permissions should be set");
-        let tmp_listener = UnixListener::bind(tmp_runtime_dir.join("agentd.sock"))
-            .expect("tmp socket should bind");
-        drop(tmp_listener);
-
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let responder = spawn_agentd_ping_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let uid = unsafe { libc::geteuid() };
-        let layout = test_layout(
-            uid,
-            Some(xdg_runtime_dir),
-            tmp_runtime_dir,
-            system_runtime_dir.clone(),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("system path should resolve"),
-            system_runtime_dir.join("agentd.sock")
-        );
-        responder.join().expect("system responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_falls_through_when_xdg_socket_does_not_speak_agentd() {
-        let root = unique_dir("xdg-wrong");
-        let xdg_runtime_dir = root.join("xdg-runtime");
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let xdg_responder = spawn_wrong_protocol_responder(&xdg_agentd_dir.join("agentd.sock"));
-
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let system_responder = spawn_agentd_ping_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let layout = test_layout(
-            0,
-            Some(xdg_runtime_dir),
-            root.join("tmp-runtime"),
-            system_runtime_dir.clone(),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("system path should resolve after wrong protocol"),
-            system_runtime_dir.join("agentd.sock")
-        );
-        xdg_responder
-            .join()
-            .expect("wrong-protocol responder should finish");
-        system_responder
-            .join()
-            .expect("system responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_falls_through_when_xdg_socket_does_not_answer_ping() {
-        let root = unique_dir("xdg-silent");
-        let xdg_runtime_dir = root.join("xdg-runtime");
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let xdg_responder = spawn_silent_responder(&xdg_agentd_dir.join("agentd.sock"));
-
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let system_responder = spawn_agentd_ping_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let layout = test_layout(
-            0,
-            Some(xdg_runtime_dir),
-            root.join("tmp-runtime"),
-            system_runtime_dir.clone(),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("system path should resolve after silent socket"),
-            system_runtime_dir.join("agentd.sock")
-        );
-        xdg_responder
-            .join()
-            .expect("silent responder should finish");
-        system_responder
-            .join()
-            .expect("system responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_falls_through_when_candidate_connect_error_is_unclassified() {
-        let root = unique_dir("xdg-unknown");
-        let xdg_runtime_dir = root.join("x".repeat(96));
-        let xdg_agentd_dir = xdg_runtime_dir.join("agentd");
-        std::fs::create_dir_all(&xdg_agentd_dir).expect("xdg runtime dir should be created");
-        let xdg_socket_path = xdg_agentd_dir.join("agentd.sock");
-        std::fs::write(&xdg_socket_path, "").expect("candidate path should exist");
-
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let system_responder = spawn_agentd_ping_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let layout = test_layout(
-            0,
-            Some(xdg_runtime_dir),
-            root.join("tmp-runtime"),
-            system_runtime_dir.clone(),
-        );
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("system path should resolve after unclassified connect error"),
-            system_runtime_dir.join("agentd.sock")
-        );
-        system_responder
-            .join()
-            .expect("system responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_rejects_insecure_tmp_dir_before_falling_through_to_system() {
-        let root = unique_dir("sys-reject-bad-tmp");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o700))
-            .expect("permissions should be set");
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-
-        let layout = test_layout(
-            unsafe { libc::geteuid() + 1 },
-            None,
-            tmp_runtime_dir.clone(),
-            system_runtime_dir,
-        );
-
-        let error = layout
-            .client_socket_path()
-            .expect_err("insecure tmp runtime dir should halt discovery");
-        assert!(error.to_string().contains("owned by uid"));
-        assert!(
-            error
-                .to_string()
-                .contains(tmp_runtime_dir.to_string_lossy().as_ref())
+            layout.client_socket_path(),
+            xdg_runtime_dir.join("agentd/agentd.sock")
         );
     }
 
     #[test]
-    fn client_socket_path_rejects_tmp_runtime_dir_with_wrong_mode() {
-        let root = unique_dir("client-tmp-bad-mode");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o755))
-            .expect("permissions should be set");
-
-        let uid = unsafe { libc::geteuid() };
-        let layout = test_layout(uid, None, tmp_runtime_dir.clone(), root.join("run-agentd"));
-
-        let error = layout
-            .client_socket_path()
-            .expect_err("insecure tmp runtime dir should be rejected");
-        assert!(error.to_string().contains("mode 0700"));
-        assert!(
-            error
-                .to_string()
-                .contains(tmp_runtime_dir.to_string_lossy().as_ref())
-        );
-    }
-
-    #[test]
-    fn client_socket_path_skips_tmp_validation_for_root_without_xdg() {
-        let root = unique_dir("client-root-skip-insecure-tmp");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o755))
-            .expect("permissions should be set");
-
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let responder = spawn_agentd_ping_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let layout = test_layout(0, None, tmp_runtime_dir, system_runtime_dir.clone());
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("root should resolve the system socket"),
-            system_runtime_dir.join("agentd.sock")
-        );
-        responder.join().expect("system responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_reports_undiscovered_daemon_when_no_default_socket_is_available() {
-        let root = unique_dir("client-run-fallback");
-        let layout = test_layout(
-            1000,
-            None,
-            root.join("missing-tmp-runtime"),
-            root.join("run-agentd"),
-        );
-
-        let error = layout
-            .client_socket_path()
-            .expect_err("exhausted discovery should report no daemon");
-        match error {
-            ClientSocketPathError::DaemonNotDiscovered { last_path } => {
-                assert_eq!(last_path, root.join("run-agentd/agentd.sock"));
-            }
-            other => panic!("expected daemon-not-discovered error, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn client_socket_path_reports_undiscovered_daemon_when_final_system_socket_fails_probe() {
-        let root = unique_dir("client-system-wrong-final");
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let responder = spawn_wrong_protocol_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let layout = test_layout(
-            1000,
-            None,
-            root.join("missing-tmp-runtime"),
-            system_runtime_dir.clone(),
-        );
-
-        let error = layout
-            .client_socket_path()
-            .expect_err("failed final probe should report no daemon");
-        match error {
-            ClientSocketPathError::DaemonNotDiscovered { last_path } => {
-                assert_eq!(last_path, system_runtime_dir.join("agentd.sock"));
-                assert_eq!(
-                    ClientSocketPathError::DaemonNotDiscovered { last_path }.to_string(),
-                    format!(
-                        "agentd is not running (socket {})",
-                        system_runtime_dir.join("agentd.sock").display()
-                    )
-                );
-            }
-            other => panic!("expected daemon-not-discovered error, got {other:?}"),
-        }
-        responder
-            .join()
-            .expect("wrong-protocol responder should finish");
-    }
-
-    #[test]
-    fn client_socket_path_ignores_tmp_socket_for_root_without_xdg() {
-        let root = unique_dir("client-root-ignore-tmp-socket");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o700))
-            .expect("permissions should be set");
-        let _tmp_listener = UnixListener::bind(tmp_runtime_dir.join("agentd.sock"))
-            .expect("tmp runtime socket should bind");
-
-        let system_runtime_dir = root.join("run-agentd");
-        std::fs::create_dir_all(&system_runtime_dir).expect("system runtime dir should be created");
-        let responder = spawn_agentd_ping_responder(&system_runtime_dir.join("agentd.sock"));
-
-        let layout = test_layout(0, None, tmp_runtime_dir, system_runtime_dir.clone());
-
-        assert_eq!(
-            layout
-                .client_socket_path()
-                .expect("root should prefer the system socket"),
-            system_runtime_dir.join("agentd.sock")
-        );
-        responder.join().expect("system responder should finish");
-    }
-
-    #[test]
-    fn ensure_tmp_runtime_dir_creates_a_private_directory_when_missing() {
-        let root = unique_dir("ensure-tmp-runtime-created");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        let uid = unsafe { libc::geteuid() };
-
-        ensure_tmp_runtime_dir(&tmp_runtime_dir, uid)
-            .expect("missing tmp runtime directory should be created");
-
-        let metadata =
-            std::fs::metadata(&tmp_runtime_dir).expect("tmp runtime metadata should be readable");
-        assert!(metadata.is_dir(), "tmp runtime path should be a directory");
-        assert_eq!(
-            metadata.permissions().mode() & 0o777,
-            0o700,
-            "tmp runtime directory should be created with mode 0700"
-        );
-    }
-
-    #[test]
-    fn ensure_tmp_runtime_dir_rejects_preexisting_directory_with_wrong_mode() {
-        let root = unique_dir("ensure-tmp-runtime-bad-mode");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        std::fs::create_dir(&tmp_runtime_dir).expect("tmp runtime dir should be created");
-        std::fs::set_permissions(&tmp_runtime_dir, std::fs::Permissions::from_mode(0o755))
-            .expect("permissions should be set");
-
-        let uid = unsafe { libc::geteuid() };
-        let error = ensure_tmp_runtime_dir(&tmp_runtime_dir, uid)
-            .expect_err("preexisting directory with wrong mode should be rejected");
-
-        assert!(error.to_string().contains("mode 0700"));
-        assert!(
-            error
-                .to_string()
-                .contains(tmp_runtime_dir.to_string_lossy().as_ref())
-        );
-    }
-
-    #[test]
-    fn ensure_tmp_runtime_dir_rejects_symlink_substitution_without_changing_target_mode() {
-        fn replace_missing_tmp_runtime_dir_with_symlink(path: &Path) {
-            let target = path.with_file_name("attacker-target");
-            std::os::unix::fs::symlink(target, path)
-                .expect("substituted symlink should be created");
-        }
-
-        let root = unique_dir("ensure-tmp-runtime-symlink-race");
-        let tmp_runtime_dir = root.join("tmp-runtime");
-        let attacker_target = root.join("attacker-target");
-        std::fs::create_dir(&attacker_target).expect("attacker target should be created");
-        std::fs::set_permissions(&attacker_target, std::fs::Permissions::from_mode(0o755))
-            .expect("attacker target mode should be set");
-        let uid = unsafe { libc::geteuid() };
-
-        set_before_tmp_runtime_dir_create_hook(
-            &tmp_runtime_dir,
-            replace_missing_tmp_runtime_dir_with_symlink,
-        );
-        let error = ensure_tmp_runtime_dir(&tmp_runtime_dir, uid)
-            .expect_err("substituted symlink should be rejected");
-        clear_before_tmp_runtime_dir_create_hook();
-
-        assert!(error.to_string().contains("not a directory"));
-        let target_metadata = std::fs::metadata(&attacker_target)
-            .expect("attacker target metadata should be readable");
-        assert_eq!(
-            target_metadata.permissions().mode() & 0o777,
-            0o755,
-            "symlink target mode should not be changed through the public tmp path"
-        );
-    }
-
-    #[test]
-    fn daemon_runtime_paths_follow_xdg_runtime_dir_when_present() {
-        let layout = test_layout(
-            1000,
-            Some(PathBuf::from("/xdg/runtime")),
-            PathBuf::from("/tmp/agentd-1000"),
-            PathBuf::from("/run/agentd"),
-        );
+    fn daemon_runtime_paths_resolve_from_the_same_xdg_runtime_dir() {
+        let xdg_runtime_dir = unique_dir("daemon-xdg");
+        let layout = test_layout(xdg_runtime_dir.clone());
 
         let runtime_paths = layout.daemon_runtime_paths();
         assert_eq!(
             runtime_paths.socket_path(),
-            Path::new("/xdg/runtime/agentd/agentd.sock")
+            xdg_runtime_dir.join("agentd/agentd.sock")
         );
         assert_eq!(
             runtime_paths.pid_file(),
-            Path::new("/xdg/runtime/agentd/agentd.pid")
+            xdg_runtime_dir.join("agentd/agentd.pid")
         );
     }
 
     #[test]
-    fn daemon_runtime_paths_use_user_tmp_dir_when_xdg_is_unset_for_non_root() {
-        let layout = test_layout(
-            1000,
-            None,
-            PathBuf::from("/tmp/agentd-1000"),
-            PathBuf::from("/run/agentd"),
-        );
+    fn client_socket_path_requires_xdg_runtime_dir_when_no_override_is_given() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
 
-        let runtime_paths = layout.daemon_runtime_paths();
-        assert_eq!(
-            runtime_paths.socket_path(),
-            Path::new("/tmp/agentd-1000/agentd.sock")
-        );
-        assert_eq!(
-            runtime_paths.pid_file(),
-            Path::new("/tmp/agentd-1000/agentd.pid")
-        );
+        let error = resolve_client_socket_path(None)
+            .expect_err("missing xdg runtime dir should be actionable");
+
+        assert!(error.to_string().contains("XDG_RUNTIME_DIR"));
+        assert!(error.to_string().contains("--socket-path"));
     }
 
     #[test]
-    fn daemon_runtime_paths_use_system_dir_when_running_as_root_without_xdg() {
-        let layout = test_layout(
-            0,
-            None,
-            PathBuf::from("/tmp/agentd-0"),
-            PathBuf::from("/run/agentd"),
-        );
+    fn relative_xdg_runtime_dir_is_rejected() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", "runtime");
+        }
 
-        let runtime_paths = layout.daemon_runtime_paths();
+        let error = default_daemon_runtime_paths()
+            .expect_err("relative xdg runtime dir should be rejected");
+
+        assert!(error.to_string().contains("XDG_RUNTIME_DIR"));
+        assert!(error.to_string().contains("absolute"));
+        assert!(error.to_string().contains("runtime"));
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
+    }
+
+    #[test]
+    fn explicit_client_socket_path_bypasses_xdg_resolution() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
+        let explicit_path = Path::new("relative/debug.sock");
+
         assert_eq!(
-            runtime_paths.socket_path(),
-            Path::new("/run/agentd/agentd.sock")
-        );
-        assert_eq!(
-            runtime_paths.pid_file(),
-            Path::new("/run/agentd/agentd.pid")
+            resolve_client_socket_path(Some(explicit_path))
+                .expect("explicit socket path should be accepted unchanged"),
+            explicit_path
         );
     }
 }

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -421,6 +421,26 @@ fn binary_run_command_reports_clear_error_when_daemon_is_not_running() {
 }
 
 #[test]
+fn binary_run_command_requires_xdg_runtime_dir_without_socket_override() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args(["run", "site-builder"])
+        .env_remove("XDG_RUNTIME_DIR")
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        !output.status.success(),
+        "run command should fail without xdg runtime dir"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
+    assert!(
+        stderr.contains("XDG_RUNTIME_DIR") && stderr.contains("--socket-path"),
+        "expected actionable xdg runtime error, got: {stderr}"
+    );
+}
+
+#[test]
 fn binary_run_command_rejects_root_level_config() {
     let runtime_dir = std::env::temp_dir().join(format!(
         "agentd-cli-runtime-root-config-rejected-{}-{}",

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::{Mutex, OnceLock};
 
 use agentd::config::{Config, ConfigError, DaemonConfig};
-use agentd::default_daemon_runtime_paths;
+use agentd::{RuntimePathError, default_daemon_runtime_paths};
 use agentd_runner::MountTargetValidationError;
 
 fn env_lock() -> &'static Mutex<()> {
@@ -62,6 +62,21 @@ fn write_temp_config(name: &str, contents: &str) -> PathBuf {
     path
 }
 
+fn set_xdg_runtime_dir(name: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "agentd-xdg-runtime-{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    unsafe {
+        std::env::set_var("XDG_RUNTIME_DIR", &path);
+    }
+    path
+}
+
 fn write_temp_config_under(base_dir: &Path, name: &str, contents: &str) -> PathBuf {
     let unique = format!(
         "agentd-config-test-{name}-{}-{}",
@@ -114,6 +129,10 @@ read_only = true
 
 #[test]
 fn parses_agents_with_declarative_command_argv() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("declarative-command");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -134,10 +153,17 @@ argv = ["site-builder", "exec"]
     assert_eq!(config.agents().len(), 1);
     assert_eq!(agent.name(), "site-builder");
     assert_eq!(agent.agent_command(), ["site-builder", "exec"]);
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn parses_example_config_into_static_agent_settings() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("example-config");
     let config = Config::from_str(&example_config()).expect("example config should parse");
     let site_builder = config
         .agent("site-builder")
@@ -147,7 +173,8 @@ fn parses_example_config_into_static_agent_settings() {
         .expect("code-reviewer agent should exist");
 
     assert_eq!(config.agents().len(), 2);
-    let runtime_paths = default_daemon_runtime_paths();
+    let runtime_paths =
+        default_daemon_runtime_paths().expect("xdg runtime dir should provide daemon defaults");
     assert_eq!(config.daemon().socket_path(), runtime_paths.socket_path());
     assert_eq!(config.daemon().pid_file(), runtime_paths.pid_file());
     assert_eq!(site_builder.name(), "site-builder");
@@ -197,10 +224,17 @@ fn parses_example_config_into_static_agent_settings() {
         "AGENTD_GITHUB_TOKEN"
     );
     assert!(code_reviewer.mounts().is_empty());
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn loading_config_resolves_relative_methodology_path_from_file_location() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("relative-methodology");
     let path = write_temp_config(
         "relative-path",
         r#"
@@ -223,10 +257,17 @@ argv = ["site-builder", "exec"]
             .expect("config file should have a parent directory")
             .join("../groundwork")
     );
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn loading_config_from_a_relative_path_resolves_methodology_dir_from_an_absolute_base_dir() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("relative-load-methodology");
     let current_dir = std::env::current_dir().expect("current directory should be available");
     let path = write_temp_config_under(
         &current_dir.join("target"),
@@ -258,6 +299,9 @@ argv = ["site-builder", "exec"]
         agent.methodology_dir().is_absolute(),
         "loaded methodology_dir should be absolute when loaded from a file"
     );
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
@@ -461,6 +505,10 @@ argv = ["site-builder", "exec"]
 
 #[test]
 fn parses_default_daemon_paths_when_daemon_section_is_omitted() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("config-defaults");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -474,9 +522,41 @@ argv = ["site-builder", "exec"]
     )
     .expect("config should parse with daemon defaults");
 
-    let runtime_paths = default_daemon_runtime_paths();
+    let runtime_paths =
+        default_daemon_runtime_paths().expect("xdg runtime dir should provide daemon defaults");
     assert_eq!(config.daemon().socket_path(), runtime_paths.socket_path());
     assert_eq!(config.daemon().pid_file(), runtime_paths.pid_file());
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+
+#[test]
+fn default_daemon_paths_require_xdg_runtime_dir_when_omitted() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+
+    let error = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect_err("omitted daemon paths should require xdg runtime dir");
+
+    match error {
+        ConfigError::DefaultDaemonRuntimePaths(RuntimePathError::XdgRuntimeDirUnavailable) => {}
+        other => panic!("expected missing xdg runtime dir error, got {other}"),
+    }
 }
 
 #[test]
@@ -608,6 +688,7 @@ fn daemon_audit_root_uses_xdg_state_home_before_home_fallback() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("audit-xdg-state");
     unsafe {
         std::env::set_var("XDG_STATE_HOME", "/tmp/xdg-state-home");
         std::env::set_var("HOME", "/tmp/home-fallback");
@@ -635,6 +716,7 @@ argv = ["site-builder", "exec"]
     );
 
     unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
         std::env::remove_var("XDG_STATE_HOME");
         std::env::remove_var("HOME");
     }
@@ -645,6 +727,7 @@ fn daemon_audit_root_falls_back_to_home_local_state_when_xdg_state_home_is_unset
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("audit-home-fallback");
     unsafe {
         std::env::remove_var("XDG_STATE_HOME");
         std::env::set_var("HOME", "/tmp/home-fallback");
@@ -672,6 +755,7 @@ argv = ["site-builder", "exec"]
     );
 
     unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
         std::env::remove_var("HOME");
     }
 }
@@ -681,6 +765,7 @@ fn daemon_audit_root_requires_a_usable_default_when_not_explicitly_configured() 
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("audit-missing-default");
     unsafe {
         std::env::remove_var("XDG_STATE_HOME");
         std::env::remove_var("HOME");
@@ -708,10 +793,17 @@ argv = ["site-builder", "exec"]
         error.to_string().contains("audit root"),
         "expected audit-root error, got {error}"
     );
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn parses_repo_token_source_as_optional_clone_auth_lookup_key() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("repo-token-source");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -729,10 +821,17 @@ argv = ["site-builder", "exec"]
     let agent = config.agent("site-builder").expect("agent should exist");
 
     assert_eq!(agent.repo_token_source(), Some("SITE_BUILDER_REPO_TOKEN"));
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn parses_agent_repo_as_optional_default_clone_url() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-repo");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -750,10 +849,17 @@ argv = ["site-builder", "exec"]
     let agent = config.agent("site-builder").expect("agent should exist");
 
     assert_eq!(agent.repo(), Some("https://example.com/agentd.git"));
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn parses_agent_schedule_as_optional_cron_expression() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-schedule");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -772,10 +878,17 @@ argv = ["site-builder", "exec"]
     let agent = config.agent("site-builder").expect("agent should exist");
 
     assert_eq!(agent.schedule(), Some("*/15 * * * *"));
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
 fn parses_agent_mounts_as_operator_declared_bind_mounts() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-mounts");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -817,6 +930,9 @@ read_only = false
         Path::new("/home/site-builder/.runa")
     );
     assert!(!agent.mounts()[1].read_only());
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
@@ -1073,6 +1189,10 @@ fn rejects_agent_mount_targets_that_collide_with_repo_directory() {
 
 #[test]
 fn normalizes_empty_repo_token_source_to_none() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("empty-repo-token-source");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -1090,6 +1210,9 @@ argv = ["site-builder", "exec"]
     let agent = config.agent("site-builder").expect("agent should exist");
 
     assert_eq!(agent.repo_token_source(), None);
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]
@@ -1608,6 +1731,10 @@ argv = ["site-builder", "exec"]
 
 #[test]
 fn loading_daemon_config_uses_defaults_when_daemon_section_is_omitted() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("daemon-config-defaults");
     let path = write_temp_config(
         "daemon-only-defaults",
         r#"
@@ -1623,9 +1750,13 @@ argv = ["site-builder", "exec"]
 
     let config = DaemonConfig::load(&path).expect("daemon config should parse");
 
-    let runtime_paths = default_daemon_runtime_paths();
+    let runtime_paths =
+        default_daemon_runtime_paths().expect("xdg runtime dir should provide daemon defaults");
     assert_eq!(config.socket_path(), runtime_paths.socket_path());
     assert_eq!(config.pid_file(), runtime_paths.pid_file());
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
 }
 
 #[test]

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -120,18 +120,14 @@ fn workspace_docs_declare_same_build_socket_policy() {
         "architecture should declare the same-build daemon/CLI requirement"
     );
     assert!(
-        readme.contains("rootless XDG-unset")
-            && readme.contains("/tmp/agentd-$UID/agentd.sock")
-            && readme.contains("root XDG-unset")
-            && readme.contains("/run/agentd/agentd.sock"),
-        "README should distinguish rootless tmp fallback from root system fallback"
+        readme.contains("$XDG_RUNTIME_DIR/agentd/agentd.sock")
+            && readme.contains("does not fall back to `/tmp` or `/run`"),
+        "README should describe deterministic XDG socket resolution"
     );
     assert!(
-        architecture.contains("rootless XDG-unset")
-            && architecture.contains("/tmp/agentd-$UID/agentd.sock")
-            && architecture.contains("root XDG-unset")
-            && architecture.contains("/run/agentd/agentd.sock"),
-        "architecture should distinguish rootless tmp fallback from root system fallback"
+        architecture.contains("$XDG_RUNTIME_DIR/agentd/agentd.sock")
+            && architecture.contains("There is no implicit `/tmp` or `/run` fallback"),
+        "architecture should describe deterministic XDG socket resolution"
     );
 }
 


### PR DESCRIPTION
## Summary

- Resolves default daemon and client socket paths from the same `$XDG_RUNTIME_DIR/agentd/agentd.sock` construction.
- Removes candidate probing, `/tmp` and `/run` fallbacks, uid-based runtime branching, and `/tmp`-specific validation machinery.
- Updates operator docs and changelog for the pre-1.0 breaking fallback removal.

## Changes

- Replaces runtime path discovery with fallible XDG-based default resolution and separate client/daemon error messaging.
- Makes omitted daemon runtime paths fail clearly when `XDG_RUNTIME_DIR` is unavailable, while preserving explicit daemon paths and client `--socket-path` overrides.
- Updates tests for deterministic XDG resolution, no-XDG errors, override behavior, and workspace documentation contracts.

## GitHub Issue(s)

Closes #91

## Test plan

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`
