### PR TITLE
feat: containerize agentd daemon

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,3 @@
+.git
+.grok
+target

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ service:
 | `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves staged bind sources | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
 | `audit_root` | daemon process creates/chmods; host Podman resolves staged bind sources; session containers write audit entries | Mount durable host storage at the configured audit root, with the daemon UID aligned to the session writer's mapped host UID or granted equivalent chmod authority. |
 | Agent-declared `mounts.source` | daemon process canonicalizes; host Podman resolves staged bind sources | Mount or expose each source so the daemon and host Podman agree on the source path. |
-| Runner staging directory | daemon process writes; host Podman resolves staged bind sources | The image sets `TMPDIR=/var/lib/agentd/tmp`; mount a host directory there. |
+| Runner staging directory | daemon process writes; host Podman resolves staged bind sources | The path named by `TMPDIR` must exist at the same absolute path for the daemon container and host Podman. The image default requires host `/var/lib/agentd/tmp` mounted to container `/var/lib/agentd/tmp`, or a changed `TMPDIR` exposed identically on both sides. |
 
 The path split follows directly from the current runner implementation. The
 daemon process validates and canonicalizes methodology, audit, additional

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ service:
 | Host Podman socket | daemon process through the Podman client | Mount the host rootless Podman socket to the path named by `CONTAINER_HOST`. |
 | Credential sources | daemon process environment | Inject the environment variables named by agent credentials into the daemon container. |
 | `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves staged bind sources | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
-| `audit_root` | daemon process creates/writes; host Podman resolves staged bind sources | Mount durable host storage at the configured audit root. |
+| `audit_root` | daemon process creates/chmods; host Podman resolves staged bind sources; session containers write audit entries | Mount durable host storage at the configured audit root, with the daemon UID aligned to the session writer's mapped host UID or granted equivalent chmod authority. |
 | Agent-declared `mounts.source` | daemon process canonicalizes; host Podman resolves staged bind sources | Mount or expose each source so the daemon and host Podman agree on the source path. |
 | Runner staging directory | daemon process writes; host Podman resolves staged bind sources | The image sets `TMPDIR=/var/lib/agentd/tmp`; mount a host directory there. |
 
@@ -265,6 +265,24 @@ SELinux-enforcing hosts such as Fedora CoreOS. `agentd/session.json` is not
 mounted into the container; it stays host-only so runa-written state and
 agentd-written metadata are distinguishable on disk without disambiguation.
 
+Final audit sealing is daemon-local. agentd uses direct filesystem operations
+to refuse unsafe multi-linked entries and chmod completed audit records; it
+does not invoke a Podman user-namespace helper. The startup audit-root probe
+verifies the daemon can create, chmod, restore, and remove probe entries it owns
+under the resolved audit root. That probe catches local path and permission
+failures, but it does not prove authority over future session-written files.
+The deployment contract supplies that second half: files written by the session
+container's unprivileged agent user must be owned by an identity the daemon can
+chmod.
+
+The primary supported contract is UID alignment. With the default rootless
+Podman user namespace mapping, a session container UID `N > 0` is represented
+on the host as `subuid_start + (N - 1)`. The daemon container's effective host
+identity must match the mapped host UID for the session's unprivileged agent
+user, or deployment must grant equivalent host-level chmod authority such as
+`CAP_FOWNER` over the audit tree. That daemon identity must also retain access
+to the mounted Podman socket and the configured runtime paths.
+
 Host audit records live under the resolved audit root, by default
 `$XDG_STATE_HOME/tesserine/audit/<agent>/<session_id>/` or
 `$HOME/.local/state/tesserine/audit/<agent>/<session_id>/` when
@@ -298,13 +316,14 @@ completion, agentd seals directories to `0555` and non-symlink entries to
 deployments such as babbie, that tradeoff is acceptable; a multi-tenant host
 would need a different permission model before deployment.
 
-The startup writability probe is intentionally local-filesystem scoped. It
-verifies that the daemon can create and remove a file under the resolved audit
-root before dispatch begins. That catches ordinary permission and path errors
-early, but it does not validate network-filesystem behavior beyond the probe;
-NFS and similar targets can still fail later with semantics the probe does not
-model. If probe-file creation succeeds but probe-file removal fails, the audit
-root can retain that uniquely named probe file as leftover cruft.
+The startup audit-root probe is intentionally local-filesystem scoped. It
+verifies that the daemon can create, chmod, restore, and remove daemon-owned
+probe entries under the resolved audit root before dispatch begins. That catches
+ordinary permission and path errors early, but it does not validate authority
+over future session-written files or network-filesystem behavior beyond the
+probe; NFS and similar targets can still fail later with semantics the probe
+does not model. If probe cleanup fails, the audit root can retain that uniquely
+named probe tree as leftover cruft.
 
 Session ids are 16 lowercase hex characters generated from `getrandom`, giving
 roughly `2^64` possible values per agent and a birthday bound near `2^32`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,44 @@ failure is intentional and matches the runtime contract: rootless Podman,
 systemd user services, SELinux-aware host filesystem handling, and Linux UID
 mapping semantics are all part of the supported execution model.
 
+### Deployment Shape
+
+The supported daemon deployment is a Quadlet-managed container image. The
+containerized daemon is still the same foreground `agentd daemon` process: it
+parses one config file, owns the Unix socket intake, schedules work, and
+dispatches sessions into `agentd-runner`. Quadlet supervises the persistent
+daemon container only. Session containers remain normal short-lived
+agentd-runner Podman workloads and are not represented as Quadlet units.
+
+The daemon image includes the Podman client and talks to the host's rootless
+Podman service through a mounted Podman socket. In the repository image, the
+client is configured with `CONTAINER_HOST=unix:///run/podman/podman.sock`, so
+deployment mounts the host user's Podman socket to that in-container path. The
+daemon does not run a nested Podman service and does not own a second container
+storage graph.
+
+Path responsibilities split across the daemon container and the host Podman
+service:
+
+| Path class | Who opens it | Deployment requirement |
+|---|---|---|
+| Daemon config | daemon process | Mount the config at the documented in-image config path. |
+| Daemon socket and PID file | daemon process; host clients use the socket through the host mount | Configure explicit daemon runtime paths inside the container and mount their parent directory from the host runtime location. |
+| Host Podman socket | daemon process through the Podman client | Mount the host rootless Podman socket to the path named by `CONTAINER_HOST`. |
+| Credential sources | daemon process environment | Inject the environment variables named by agent credentials into the daemon container. |
+| `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves staged bind sources | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
+| `audit_root` | daemon process creates/writes; host Podman resolves staged bind sources | Mount durable host storage at the configured audit root. |
+| Agent-declared `mounts.source` | daemon process canonicalizes; host Podman resolves staged bind sources | Mount or expose each source so the daemon and host Podman agree on the source path. |
+| Runner staging directory | daemon process writes; host Podman resolves staged bind sources | The image sets `TMPDIR=/var/lib/agentd/tmp`; mount a host directory there. |
+
+The path split follows directly from the current runner implementation. The
+daemon process validates and canonicalizes methodology, audit, additional
+mount, invocation-input, and staging paths, then sends bind-mount source
+strings to the host Podman service. Podman resolves those source strings on the
+host that owns the socket, not inside the daemon container. Any future
+host/container path translation would be a code change, not a deployment
+property.
+
 ### Terminology
 
 - **Agent**: a named, reusable environment specification in the daemon config — base image, methodology, optional default repo, optional schedule, credentials, and command. What the operator declares.
@@ -94,12 +132,14 @@ separate ownership scopes. Only after that cleanup succeeds does the daemon
 bind its Unix socket and begin accepting requests.
 
 The daemon's Unix socket is the single intake for all session triggers. Manual
-CLI invocation connects to that socket as a client. Scheduling policy also
-connects to that socket as a client when it decides work should start. The
-daemon accepts those run requests uniformly and dispatches them into session
-execution. In `v0.1.x` this socket protocol is internal and unversioned:
-daemon and CLI must be the same build, and replacing the binary requires a
-daemon restart before new CLI invocations are supported.
+CLI invocation connects to that socket as a client. In the supported
+containerized daemon deployment, the socket is created inside the daemon
+container at the configured path and exposed to the host through a bind mount.
+Scheduling policy also connects to that socket as a client when it decides work
+should start. The daemon accepts those run requests uniformly and dispatches
+them into session execution. In `v0.1.x` this socket protocol is internal and unversioned:
+daemon and CLI must be the same build, and replacing the daemon image requires
+restarting the daemon before new CLI invocations are supported.
 
 Manual CLI dispatch is intentionally decoupled from daemon-owned config files.
 `agentd run` resolves the daemon through a socket path rather than by reading
@@ -276,7 +316,7 @@ risk envelope.
 
 ## 6. Credential Flow
 
-Credentials are declared by agent configuration as daemon-side environment variable names. For each configured credential, the daemon resolves `source` with `std::env::var(source)` from its own process environment before calling `agentd-runner`. Operators provide those values through normal host mechanisms such as systemd `EnvironmentFile=`, shell exports, or container environment injection. During session setup, the runner receives only the already-resolved credential values, creates Podman-managed ephemeral secrets for non-empty values, and injects those values into the execution environment as environment variables without placing the secret values on the Podman command line. Empty assignments are injected directly as `NAME=` because Podman secrets reject zero-byte payloads. Once the container reaches the running state, the runner removes the backing Podman secret objects and relies on the in-container environment copy for the rest of the session.
+Credentials are declared by agent configuration as daemon-side environment variable names. For each configured credential, the daemon resolves `source` with `std::env::var(source)` from its own process environment before calling `agentd-runner`. Operators provide those values to the daemon container through normal container environment injection, such as Quadlet environment directives or mounted environment files. During session setup, the runner receives only the already-resolved credential values, creates Podman-managed ephemeral secrets for non-empty values, and injects those values into the execution environment as environment variables without placing the secret values on the Podman command line. Empty assignments are injected directly as `NAME=` because Podman secrets reject zero-byte payloads. Once the container reaches the running state, the runner removes the backing Podman secret objects and relies on the in-container environment copy for the rest of the session.
 
 Because startup reconciliation is scoped per daemon instance rather than to the
 whole Podman namespace, the daemon removes only runner-managed resources whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
+- The supported daemon deployment shape is now a locally built container image
+  for Quadlet-managed operation; host-installed daemon supervision is out of
+  band, while `agentd run` remains a host-side same-build client.
 - `agentd --version` and `agentd run --version` now report the crate release
   version for operator deployment checks.
 - Agent configuration is now declarative and uses `[[agents]]` with `[agents.command].argv`; the old profile-table vocabulary and shell-wrapper command shape are removed as a pre-1.0 breaking change. agentd now composes `runa init` and `runa run --agent-command -- <argv>` itself, leaving runa-owned `.runa/` config formats to runa.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session teardown now skips audit finalization and sealing when cleanup fails, leaving `agentd/session.json` intentionally incomplete instead of marking a session complete while its audit bind mount may still be live.
 - Completed session outcomes now remain caller-visible when only audit finalization fails after teardown cleanup succeeds.
 - Audit sealing now refuses multi-linked entries before rewriting metadata, preventing host file mode changes through hard-linked audit aliases.
+- Audit sealing now uses daemon-local filesystem chmod operations only, avoiding remote Podman client failures during finalization and surfacing the required audit-root UID alignment at daemon startup.
 - Allocation rollback failure now preserves the incomplete audit-record signal instead of finalizing `agentd/session.json` after leaked cleanup state.
 - Manual request-text input now rejects methodologies that do not declare canonical request support or that advertise an unsupported canonical request version, instead of synthesizing unchecked workspace content.
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+FROM docker.io/library/rust:1.88-bookworm AS builder
+
+WORKDIR /workspace
+COPY . .
+RUN cargo build --release --locked --bin agentd
+
+FROM docker.io/library/debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates podman \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/lib/agentd/tmp \
+    && chmod 1777 /var/lib/agentd/tmp
+
+COPY --from=builder /workspace/target/release/agentd /usr/local/bin/agentd
+
+ENV CONTAINER_HOST=unix:///run/podman/podman.sock
+ENV TMPDIR=/var/lib/agentd/tmp
+
+ENTRYPOINT ["/usr/local/bin/agentd"]
+CMD ["daemon", "--config", "/etc/agentd/agentd.toml"]

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ mount a host directory there. In practice, mount those shared session source
 trees into the daemon container at the same absolute paths recorded in
 `agentd.toml`.
 
+Audit sealing is performed by the daemon process with direct filesystem chmod
+operations; it does not enter Podman's user namespace during finalization. The
+startup probe verifies the daemon can create, chmod, restore, and remove its
+own probe entries under `audit_root`. That probe is necessary but not
+sufficient: deployment must also ensure files written by session containers are
+within the daemon's chmod authority. The primary supported contract is UID
+alignment. For a default rootless Podman map, session container UID `N > 0`
+appears on the host as `subuid_start + (N - 1)`, so the daemon's effective host
+identity must match the mapped writer UID for the unprivileged agent user, or
+the daemon must receive equivalent authority such as `CAP_FOWNER` over the
+audit tree. That same daemon identity still needs access to the mounted Podman
+socket and configured runtime paths.
+
 A host-installed `agentd` binary remains useful as a same-build CLI client for
 `agentd run`, but host-binary daemon supervision is out of band for supported
 deployments.

--- a/README.md
+++ b/README.md
@@ -179,9 +179,12 @@ inside the daemon container. Session bind sources that the daemon opens and
 then forwards to host Podman must also be valid from the host Podman service's
 view: `methodology_dir`, each agent-declared `mounts.source`, `audit_root`, and
 the runner staging directory. This image sets `TMPDIR=/var/lib/agentd/tmp`, so
-mount a host directory there. In practice, mount those shared session source
-trees into the daemon container at the same absolute paths recorded in
-`agentd.toml`.
+the host must also expose that staging directory at `/var/lib/agentd/tmp` when
+using the image default. Mount host `/var/lib/agentd/tmp` to container
+`/var/lib/agentd/tmp`, or set `TMPDIR` to another path the operator can expose
+at the same absolute path on both the host and daemon container. In practice,
+mount all shared session source trees into the daemon container at the same
+absolute paths recorded in `agentd.toml` or used by `TMPDIR`.
 
 Audit sealing is performed by the daemon process with direct filesystem chmod
 operations; it does not enter Podman's user namespace during finalization. The

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ nothing more.
 
 v0.1.1 — early development.
 
-The session lifecycle works end-to-end: agent configuration, foreground daemon
+The session lifecycle works end-to-end: agent configuration, containerized daemon
 startup, operator-triggered sessions, ephemeral Podman containers, credential
 injection, execution, and teardown. Startup reconciliation cleans stale
 resources from prior runs. Structured JSON tracing provides operational
@@ -135,34 +135,79 @@ fires are not backfilled after downtime. Persistent audit records default to
 `$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set
 `daemon.audit_root` to override that for system installations.
 
-## Running a Session
+## Deployment
 
-Build from source with `cargo build --release`. agentd targets Linux and
-requires rootless Podman for container execution. Operational deployments also
-assume systemd user services and the SELinux considerations described in
-`ARCHITECTURE.md`.
-
-Confirm the deployed binary with `agentd --version`.
-
-Start the daemon:
+The supported daemon deployment shape is a locally built container image run by
+Quadlet. Build the image on the target host or another trusted build host with
+access to the checked-out source or release tag:
 
 ```bash
-agentd daemon --config /etc/agentd/agentd.toml
+podman build --tag localhost/agentd:0.1.1 .
 ```
 
-`agentd` with no subcommand is equivalent to `agentd daemon`.
+The image's default command starts the daemon and reads
+`/etc/agentd/agentd.toml`. The image includes the `agentd` binary and the
+Podman client. The daemon container is a supervisor for ordinary agentd session
+containers; the session containers themselves are not Quadlets.
 
-The daemon runs in the foreground, reconciles stale resources from prior runs,
-and binds a Unix socket for operator control. When `daemon.socket_path` and
-`daemon.pid_file` are omitted, agentd chooses coordinated defaults from the
-current XDG runtime context:
+The daemon container talks to the host's rootless Podman service through a
+mounted Podman socket. The image expects that socket at
+`/run/podman/podman.sock` and sets `CONTAINER_HOST` accordingly. On a typical
+rootless host, mount the user's Podman socket from
+`$XDG_RUNTIME_DIR/podman/podman.sock` to that in-container path.
+
+Use explicit daemon runtime paths in the config so the socket can be mounted
+back to the host for `agentd run` clients:
+
+```toml
+[daemon]
+socket_path = "/run/agentd/agentd.sock"
+pid_file = "/run/agentd/agentd.pid"
+audit_root = "/var/lib/tesserine/audit"
+```
+
+Mount the host runtime directory that should hold the client socket to
+`/run/agentd` in the daemon container. With a host mount such as
+`$XDG_RUNTIME_DIR/agentd:/run/agentd`, host-side clients can use the normal
+default `$XDG_RUNTIME_DIR/agentd/agentd.sock` path, or pass the same host path
+with `--socket-path`.
+
+Path visibility matters because the daemon process and the host Podman service
+see different filesystems. The config file, socket path, PID file, credential
+environment, and mounted Podman socket must be reachable by the daemon process
+inside the daemon container. Session bind sources that the daemon opens and
+then forwards to host Podman must also be valid from the host Podman service's
+view: `methodology_dir`, each agent-declared `mounts.source`, `audit_root`, and
+the runner staging directory. This image sets `TMPDIR=/var/lib/agentd/tmp`, so
+mount a host directory there. In practice, mount those shared session source
+trees into the daemon container at the same absolute paths recorded in
+`agentd.toml`.
+
+A host-installed `agentd` binary remains useful as a same-build CLI client for
+`agentd run`, but host-binary daemon supervision is out of band for supported
+deployments.
+
+Confirm the image contents with:
+
+```bash
+podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:0.1.1 --version
+```
+
+## Running a Session
+
+The daemon runs in the container, reconciles stale resources from prior runs,
+and binds a Unix socket for operator control. `agentd` with no subcommand is
+equivalent to `agentd daemon`.
+
+When `daemon.socket_path` and `daemon.pid_file` are omitted, agentd chooses
+coordinated defaults from the current XDG runtime context:
 
 - `$XDG_RUNTIME_DIR/agentd/agentd.sock`
 - `$XDG_RUNTIME_DIR/agentd/agentd.pid`
 
-`XDG_RUNTIME_DIR` must be set to an absolute path for daemon defaults. Operators
-using a non-XDG deployment, such as a system-owned daemon under `/run`, should
-configure `daemon.socket_path` and `daemon.pid_file` explicitly.
+`XDG_RUNTIME_DIR` must be set to an absolute path for daemon defaults. Container
+deployments should configure `daemon.socket_path` and `daemon.pid_file`
+explicitly so the daemon socket location is also a deliberate host mount.
 
 On SIGINT or SIGTERM, the daemon stops accepting connections and drains
 in-flight sessions; a second signal exits immediately.

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -252,7 +252,7 @@ fn read_dir_for_audit_traversal(
         Ok(entries) => Ok(entries),
         Err(error) if error.kind() == ErrorKind::PermissionDenied => {
             let mode = metadata.permissions().mode();
-            let traversal_mode = mode | 0o500;
+            let traversal_mode = audit_traversal_retry_mode(mode);
             if traversal_mode != mode {
                 fs::set_permissions(path, fs::Permissions::from_mode(traversal_mode))?;
             }
@@ -263,6 +263,10 @@ fn read_dir_for_audit_traversal(
         }
         Err(error) => Err(RunnerError::from(error)),
     }
+}
+
+fn audit_traversal_retry_mode(mode: u32) -> u32 {
+    mode | SEALED_DIRECTORY_MODE
 }
 
 fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
@@ -819,6 +823,22 @@ mod tests {
 
         make_tree_writable(&root);
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn audit_traversal_retry_mode_grants_non_owner_traversal_authority() {
+        let retry_mode = super::audit_traversal_retry_mode(0o700);
+
+        assert_eq!(
+            retry_mode & 0o050,
+            0o050,
+            "group accessors must receive read and execute authority"
+        );
+        assert_eq!(
+            retry_mode & 0o005,
+            0o005,
+            "other accessors must receive read and execute authority"
+        );
     }
 
     #[test]

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -1,4 +1,3 @@
-use crate::podman::run_podman_command;
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
 #[cfg(test)]
@@ -105,13 +104,7 @@ pub(crate) fn finalize_session_audit_record(
     record: &SessionAuditRecord,
     completion: SessionAuditCompletion<'_>,
 ) -> Result<(), RunnerError> {
-    match preflight_validate_sealable_tree(&record.record_dir) {
-        Ok(()) => {}
-        Err(RunnerError::Io(error)) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-            validate_sealable_tree_with_podman_unshare(&record.record_dir)?;
-        }
-        Err(error) => return Err(error),
-    }
+    preflight_validate_sealable_tree(&record.record_dir)?;
     let (outcome, exit_code) = match completion {
         SessionAuditCompletion::Outcome(outcome) => (Some(outcome.label()), outcome.exit_code()),
         SessionAuditCompletion::Error => (Some("error"), None),
@@ -204,13 +197,7 @@ fn set_active_audit_directory_permissions(path: &Path) -> Result<(), RunnerError
 }
 
 fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerError> {
-    match seal_path_recursive(record, &record.record_dir) {
-        Ok(()) => Ok(()),
-        Err(RunnerError::Io(error)) if error.kind() == std::io::ErrorKind::PermissionDenied => {
-            seal_with_podman_unshare(record)
-        }
-        Err(error) => Err(error),
-    }
+    seal_path_recursive(record, &record.record_dir)
 }
 
 fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
@@ -274,87 +261,6 @@ fn should_skip_sealing_path(record: &SessionAuditRecord, path: &Path) -> bool {
             .metadata_path
             .parent()
             .is_some_and(|metadata_dir| path == metadata_dir)
-}
-
-fn chmod_mode_arg(mode: u32) -> String {
-    format!("{mode:o}")
-}
-
-fn seal_with_podman_unshare(record: &SessionAuditRecord) -> Result<(), RunnerError> {
-    let record_root = record.record_dir.display().to_string();
-    let metadata_dir = record
-        .metadata_path
-        .parent()
-        .expect("metadata path should have a parent directory")
-        .display()
-        .to_string();
-    let metadata_path = record.metadata_path.display().to_string();
-
-    run_podman_command(vec![
-        "unshare".to_string(),
-        "find".to_string(),
-        "-P".to_string(),
-        record_root.clone(),
-        "-mindepth".to_string(),
-        "1".to_string(),
-        "-type".to_string(),
-        "d".to_string(),
-        "!".to_string(),
-        "-path".to_string(),
-        metadata_dir,
-        "-exec".to_string(),
-        "chmod".to_string(),
-        chmod_mode_arg(SEALED_DIRECTORY_MODE),
-        "{}".to_string(),
-        "+".to_string(),
-    ])?;
-    run_podman_command(vec![
-        "unshare".to_string(),
-        "find".to_string(),
-        "-P".to_string(),
-        record_root,
-        "!".to_string(),
-        "-type".to_string(),
-        "d".to_string(),
-        "!".to_string(),
-        "-type".to_string(),
-        "l".to_string(),
-        "!".to_string(),
-        "-path".to_string(),
-        metadata_path,
-        "-exec".to_string(),
-        "chmod".to_string(),
-        chmod_mode_arg(SEALED_FILE_MODE),
-        "{}".to_string(),
-        "+".to_string(),
-    ])
-    .map(|_| ())
-}
-
-fn validate_sealable_tree_with_podman_unshare(path: &Path) -> Result<(), RunnerError> {
-    let output = run_podman_command(vec![
-        "unshare".to_string(),
-        "find".to_string(),
-        "-P".to_string(),
-        path.display().to_string(),
-        "!".to_string(),
-        "-type".to_string(),
-        "d".to_string(),
-        "!".to_string(),
-        "-type".to_string(),
-        "l".to_string(),
-        "-links".to_string(),
-        "+1".to_string(),
-        "-print".to_string(),
-    ])?;
-
-    if let Some(first_path) = output.lines().find(|line| !line.trim().is_empty()) {
-        return Err(RunnerError::Io(std::io::Error::other(format!(
-            "refusing to seal multi-linked audit entry {first_path}"
-        ))));
-    }
-
-    Ok(())
 }
 
 fn write_atomic(path: &Path, payload: &[u8], file_mode: Option<u32>) -> Result<(), RunnerError> {
@@ -756,6 +662,10 @@ mod tests {
         .expect("audit record should be created");
         fs::write(record.runa_dir.join("artifact.txt"), "persisted\n")
             .expect("runa artifact should be writable before sealing");
+        let nested_dir = record.runa_dir.join("nested");
+        fs::create_dir_all(&nested_dir).expect("nested runa dir should be created");
+        fs::write(nested_dir.join("nested-artifact.txt"), "nested\n")
+            .expect("nested runa artifact should be writable before sealing");
 
         super::finalize_session_audit_record(
             &record,
@@ -779,8 +689,38 @@ mod tests {
             .expect("metadata file should exist")
             .permissions()
             .mode();
+        let artifact_mode = fs::metadata(record.runa_dir.join("artifact.txt"))
+            .expect("runa artifact metadata should exist")
+            .permissions()
+            .mode();
+        let nested_dir_mode = fs::metadata(&nested_dir)
+            .expect("nested runa dir metadata should exist")
+            .permissions()
+            .mode();
+        let nested_artifact_mode = fs::metadata(nested_dir.join("nested-artifact.txt"))
+            .expect("nested runa artifact metadata should exist")
+            .permissions()
+            .mode();
+        let metadata_dir_mode = fs::metadata(
+            record
+                .metadata_path
+                .parent()
+                .expect("metadata path should have parent"),
+        )
+        .expect("metadata dir metadata should exist")
+        .permissions()
+        .mode();
+        let record_dir_mode = fs::metadata(&record.record_dir)
+            .expect("record dir metadata should exist")
+            .permissions()
+            .mode();
         assert_eq!(runa_mode & 0o777, 0o555);
+        assert_eq!(artifact_mode & 0o777, 0o444);
+        assert_eq!(nested_dir_mode & 0o777, 0o555);
+        assert_eq!(nested_artifact_mode & 0o777, 0o444);
         assert_eq!(metadata_mode & 0o777, 0o444);
+        assert_eq!(metadata_dir_mode & 0o777, 0o755);
+        assert_eq!(record_dir_mode & 0o777, 0o755);
 
         make_tree_writable(&root);
 
@@ -930,5 +870,23 @@ mod tests {
         let timestamp = current_timestamp().expect("timestamp should format");
         assert!(timestamp.ends_with('Z'));
         assert!(timestamp.contains('T'));
+    }
+
+    #[test]
+    fn audit_finalization_has_no_unshare_subprocess_dependency() {
+        let source = include_str!("audit.rs");
+        let implementation_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("audit.rs should contain implementation before tests");
+
+        assert!(
+            !implementation_source.contains("run_podman_command"),
+            "audit finalization must use direct filesystem operations, not podman subprocesses"
+        );
+        assert!(
+            !implementation_source.contains("\"unshare\""),
+            "audit finalization must not invoke a user-namespace helper"
+        );
     }
 }

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 #[cfg(test)]
 use std::cell::Cell;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
@@ -207,7 +207,7 @@ fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
     }
 
     if metadata.is_dir() {
-        for entry in fs::read_dir(path)? {
+        for entry in read_dir_for_audit_traversal(path, &metadata)? {
             let entry = entry?;
             preflight_validate_sealable_tree(&entry.path())?;
         }
@@ -231,7 +231,7 @@ fn seal_path_recursive(record: &SessionAuditRecord, path: &Path) -> Result<(), R
     }
 
     if metadata.is_dir() {
-        for entry in fs::read_dir(path)? {
+        for entry in read_dir_for_audit_traversal(path, &metadata)? {
             let entry = entry?;
             seal_path_recursive(record, &entry.path())?;
         }
@@ -242,6 +242,27 @@ fn seal_path_recursive(record: &SessionAuditRecord, path: &Path) -> Result<(), R
     }
 
     seal_path(path, metadata.is_dir())
+}
+
+fn read_dir_for_audit_traversal(
+    path: &Path,
+    metadata: &fs::Metadata,
+) -> Result<fs::ReadDir, RunnerError> {
+    match fs::read_dir(path) {
+        Ok(entries) => Ok(entries),
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => {
+            let mode = metadata.permissions().mode();
+            let traversal_mode = mode | 0o500;
+            if traversal_mode != mode {
+                fs::set_permissions(path, fs::Permissions::from_mode(traversal_mode))?;
+            }
+            // Preflight chmod-up is intentionally non-transactional: successful
+            // sealing overwrites this with 0555, and failed validation leaves an
+            // incomplete audit record for operator inspection.
+            fs::read_dir(path).map_err(RunnerError::from)
+        }
+        Err(error) => Err(RunnerError::from(error)),
+    }
 }
 
 fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
@@ -724,6 +745,79 @@ mod tests {
 
         make_tree_writable(&root);
 
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_audit_record_chmods_unreadable_directories_before_traversal() {
+        let root = unique_test_dir("agentd-audit-unreadable-dirs");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "1234567890abcdef",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let execute_only_dir = record.runa_dir.join("execute-only");
+        let no_access_dir = execute_only_dir.join("no-access");
+        let artifact_path = no_access_dir.join("artifact.txt");
+        fs::create_dir_all(&no_access_dir).expect("nested audit dirs should be created");
+        fs::write(&artifact_path, "persisted\n").expect("nested artifact should be writable");
+        fs::set_permissions(&no_access_dir, fs::Permissions::from_mode(0o000))
+            .expect("nested dir should become inaccessible");
+        fs::set_permissions(&execute_only_dir, fs::Permissions::from_mode(0o111))
+            .expect("parent dir should become execute-only");
+
+        let finalize_result = super::finalize_session_audit_record(
+            &record,
+            SessionAuditCompletion::Outcome(&SessionOutcome::Success { exit_code: 0 }),
+        );
+        if finalize_result.is_err() {
+            fs::set_permissions(&execute_only_dir, fs::Permissions::from_mode(0o755))
+                .expect("execute-only dir should become readable for cleanup");
+            fs::set_permissions(&no_access_dir, fs::Permissions::from_mode(0o755))
+                .expect("inaccessible dir should become readable for cleanup");
+        }
+        finalize_result.expect("audit record should finalize after chmod-up traversal");
+
+        let payload = fs::read_to_string(&record.metadata_path)
+            .expect("final session metadata should be readable");
+        let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
+        assert_eq!(json["outcome"], "success");
+        assert!(json["end_timestamp"].is_string());
+
+        assert_eq!(
+            fs::metadata(&execute_only_dir)
+                .expect("execute-only dir metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o555
+        );
+        assert_eq!(
+            fs::metadata(&no_access_dir)
+                .expect("inaccessible dir metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o555
+        );
+        assert_eq!(
+            fs::metadata(&artifact_path)
+                .expect("nested artifact metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o444
+        );
+
+        make_tree_writable(&root);
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
 

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -965,22 +965,4 @@ mod tests {
         assert!(timestamp.ends_with('Z'));
         assert!(timestamp.contains('T'));
     }
-
-    #[test]
-    fn audit_finalization_has_no_unshare_subprocess_dependency() {
-        let source = include_str!("audit.rs");
-        let implementation_source = source
-            .split("#[cfg(test)]")
-            .next()
-            .expect("audit.rs should contain implementation before tests");
-
-        assert!(
-            !implementation_source.contains("run_podman_command"),
-            "audit finalization must use direct filesystem operations, not podman subprocesses"
-        );
-        assert!(
-            !implementation_source.contains("\"unshare\""),
-            "audit finalization must not invoke a user-namespace helper"
-        );
-    }
 }

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 #[cfg(test)]
 use std::cell::Cell;
 use std::fs::{self, File, OpenOptions};
-use std::io::{ErrorKind, Write};
+use std::io::Write;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
@@ -104,6 +104,7 @@ pub(crate) fn finalize_session_audit_record(
     record: &SessionAuditRecord,
     completion: SessionAuditCompletion<'_>,
 ) -> Result<(), RunnerError> {
+    prepare_audit_tree_for_traversal(&record.record_dir)?;
     preflight_validate_sealable_tree(&record.record_dir)?;
     let (outcome, exit_code) = match completion {
         SessionAuditCompletion::Outcome(outcome) => (Some(outcome.label()), outcome.exit_code()),
@@ -200,6 +201,26 @@ fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerEr
     seal_path_recursive(record, &record.record_dir)
 }
 
+fn prepare_audit_tree_for_traversal(path: &Path) -> Result<(), RunnerError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(());
+    }
+
+    let mode = metadata.permissions().mode();
+    let traversal_mode = mode | SEALED_DIRECTORY_MODE;
+    if traversal_mode != mode {
+        fs::set_permissions(path, fs::Permissions::from_mode(traversal_mode))?;
+    }
+
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        prepare_audit_tree_for_traversal(&entry.path())?;
+    }
+
+    Ok(())
+}
+
 fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
     let metadata = fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() {
@@ -207,7 +228,7 @@ fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
     }
 
     if metadata.is_dir() {
-        for entry in read_dir_for_audit_traversal(path, &metadata)? {
+        for entry in fs::read_dir(path)? {
             let entry = entry?;
             preflight_validate_sealable_tree(&entry.path())?;
         }
@@ -231,7 +252,7 @@ fn seal_path_recursive(record: &SessionAuditRecord, path: &Path) -> Result<(), R
     }
 
     if metadata.is_dir() {
-        for entry in read_dir_for_audit_traversal(path, &metadata)? {
+        for entry in fs::read_dir(path)? {
             let entry = entry?;
             seal_path_recursive(record, &entry.path())?;
         }
@@ -242,31 +263,6 @@ fn seal_path_recursive(record: &SessionAuditRecord, path: &Path) -> Result<(), R
     }
 
     seal_path(path, metadata.is_dir())
-}
-
-fn read_dir_for_audit_traversal(
-    path: &Path,
-    metadata: &fs::Metadata,
-) -> Result<fs::ReadDir, RunnerError> {
-    match fs::read_dir(path) {
-        Ok(entries) => Ok(entries),
-        Err(error) if error.kind() == ErrorKind::PermissionDenied => {
-            let mode = metadata.permissions().mode();
-            let traversal_mode = audit_traversal_retry_mode(mode);
-            if traversal_mode != mode {
-                fs::set_permissions(path, fs::Permissions::from_mode(traversal_mode))?;
-            }
-            // Preflight chmod-up is intentionally non-transactional: successful
-            // sealing overwrites this with 0555, and failed validation leaves an
-            // incomplete audit record for operator inspection.
-            fs::read_dir(path).map_err(RunnerError::from)
-        }
-        Err(error) => Err(RunnerError::from(error)),
-    }
-}
-
-fn audit_traversal_retry_mode(mode: u32) -> u32 {
-    mode | SEALED_DIRECTORY_MODE
 }
 
 fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
@@ -753,92 +749,87 @@ mod tests {
     }
 
     #[test]
-    fn finalize_session_audit_record_chmods_unreadable_directories_before_traversal() {
-        let root = unique_test_dir("agentd-audit-unreadable-dirs");
-        let record = prepare_session_audit_record_at(
-            &root,
-            "1234567890abcdef",
-            &test_session_spec(),
-            &SessionInvocation {
-                repo_url: "https://example.com/agentd.git".to_string(),
-                repo_token: None,
-                work_unit: None,
-                input: None,
-                timeout: None,
-            },
-        )
-        .expect("audit record should be created");
-        let execute_only_dir = record.runa_dir.join("execute-only");
-        let no_access_dir = execute_only_dir.join("no-access");
-        let artifact_path = no_access_dir.join("artifact.txt");
-        fs::create_dir_all(&no_access_dir).expect("nested audit dirs should be created");
-        fs::write(&artifact_path, "persisted\n").expect("nested artifact should be writable");
-        fs::set_permissions(&no_access_dir, fs::Permissions::from_mode(0o000))
-            .expect("nested dir should become inaccessible");
-        fs::set_permissions(&execute_only_dir, fs::Permissions::from_mode(0o111))
-            .expect("parent dir should become execute-only");
+    fn finalize_session_audit_record_prepares_restrictive_directories_for_traversal() {
+        for initial_mode in [0o000, 0o111, 0o444, 0o700] {
+            let root = unique_test_dir(&format!("agentd-audit-restrictive-dir-{initial_mode:o}"));
+            let record = prepare_session_audit_record_at(
+                &root,
+                "1234567890abcdef",
+                &test_session_spec(),
+                &SessionInvocation {
+                    repo_url: "https://example.com/agentd.git".to_string(),
+                    repo_token: None,
+                    work_unit: None,
+                    input: None,
+                    timeout: None,
+                },
+            )
+            .expect("audit record should be created");
+            let restricted_dir = record.runa_dir.join(format!("mode-{initial_mode:o}"));
+            let artifact_path = restricted_dir.join("artifact.txt");
+            fs::create_dir_all(&restricted_dir).expect("restricted audit dir should be created");
+            fs::write(&artifact_path, "persisted\n").expect("audit artifact should be writable");
+            fs::set_permissions(&restricted_dir, fs::Permissions::from_mode(initial_mode))
+                .expect("restricted dir should enter session-written mode");
 
-        let finalize_result = super::finalize_session_audit_record(
-            &record,
-            SessionAuditCompletion::Outcome(&SessionOutcome::Success { exit_code: 0 }),
-        );
-        if finalize_result.is_err() {
-            fs::set_permissions(&execute_only_dir, fs::Permissions::from_mode(0o755))
-                .expect("execute-only dir should become readable for cleanup");
-            fs::set_permissions(&no_access_dir, fs::Permissions::from_mode(0o755))
-                .expect("inaccessible dir should become readable for cleanup");
+            let finalize_result = super::finalize_session_audit_record(
+                &record,
+                SessionAuditCompletion::Outcome(&SessionOutcome::Success { exit_code: 0 }),
+            );
+            if finalize_result.is_err() {
+                fs::set_permissions(&restricted_dir, fs::Permissions::from_mode(0o755))
+                    .expect("restricted dir should become traversable for cleanup");
+                make_tree_writable(&root);
+            }
+            finalize_result.expect("audit record should finalize from restrictive dir mode");
+
+            let payload = fs::read_to_string(&record.metadata_path)
+                .expect("final session metadata should be readable");
+            let json: Value =
+                serde_json::from_str(&payload).expect("metadata should be valid json");
+            assert_eq!(json["outcome"], "success");
+            assert!(json["end_timestamp"].is_string());
+
+            let metadata_dir = record
+                .metadata_path
+                .parent()
+                .expect("metadata path should have a parent");
+            assert_eq!(
+                fs::metadata(&restricted_dir)
+                    .expect("restricted dir metadata should exist")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o555
+            );
+            assert_eq!(
+                fs::metadata(&artifact_path)
+                    .expect("audit artifact metadata should exist")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o444
+            );
+            assert_eq!(
+                fs::metadata(metadata_dir)
+                    .expect("metadata dir metadata should exist")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o755
+            );
+            assert_eq!(
+                fs::metadata(&record.record_dir)
+                    .expect("record dir metadata should exist")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o755
+            );
+
+            make_tree_writable(&root);
+            fs::remove_dir_all(root).expect("temporary audit root should be removed");
         }
-        finalize_result.expect("audit record should finalize after chmod-up traversal");
-
-        let payload = fs::read_to_string(&record.metadata_path)
-            .expect("final session metadata should be readable");
-        let json: Value = serde_json::from_str(&payload).expect("metadata should be valid json");
-        assert_eq!(json["outcome"], "success");
-        assert!(json["end_timestamp"].is_string());
-
-        assert_eq!(
-            fs::metadata(&execute_only_dir)
-                .expect("execute-only dir metadata should exist")
-                .permissions()
-                .mode()
-                & 0o777,
-            0o555
-        );
-        assert_eq!(
-            fs::metadata(&no_access_dir)
-                .expect("inaccessible dir metadata should exist")
-                .permissions()
-                .mode()
-                & 0o777,
-            0o555
-        );
-        assert_eq!(
-            fs::metadata(&artifact_path)
-                .expect("nested artifact metadata should exist")
-                .permissions()
-                .mode()
-                & 0o777,
-            0o444
-        );
-
-        make_tree_writable(&root);
-        fs::remove_dir_all(root).expect("temporary audit root should be removed");
-    }
-
-    #[test]
-    fn audit_traversal_retry_mode_grants_non_owner_traversal_authority() {
-        let retry_mode = super::audit_traversal_retry_mode(0o700);
-
-        assert_eq!(
-            retry_mode & 0o050,
-            0o050,
-            "group accessors must receive read and execute authority"
-        );
-        assert_eq!(
-            retry_mode & 0o005,
-            0o005,
-            "other accessors must receive read and execute authority"
-        );
     }
 
     #[test]

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -834,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn run_session_finalizes_audit_without_invoking_namespace_helper() {
+    fn run_session_finalizes_direct_audit_entries() {
         let _guard = fake_podman_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -921,12 +921,6 @@ mod tests {
             metadata["end_timestamp"].is_string(),
             "successful audit finalization must publish end_timestamp"
         );
-        assert_eq!(
-            fixture.read_log("unshare-commands.log"),
-            "",
-            "audit finalization must not invoke a user-namespace helper"
-        );
-
         use std::os::unix::fs::PermissionsExt;
 
         let direct_dir = record_dir.join("runa/direct");

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -834,35 +834,25 @@ mod tests {
     }
 
     #[test]
-    fn run_session_leaves_metadata_incomplete_when_podman_unshare_sealing_fails_after_preflight() {
+    fn run_session_finalizes_audit_without_invoking_namespace_helper() {
         let _guard = fake_podman_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let fixture = FakePodmanFixture::new();
         fixture.install(
-            &FakePodmanScenario::new()
-                .with_start(CommandBehavior::from_outcome(
-                    CommandOutcome::new()
-                        .touch_file("start-blocked")
-                        .wait_for_file(
-                            "release-start",
-                            Duration::from_secs(5),
-                            "timed out waiting to release start",
-                            91,
-                        ),
-                ))
-                .with_unshare(CommandBehavior::sequence(vec![
-                    CommandOutcome::new()
-                        .append_args_with_prefix("unshare-commands.log", "validate"),
-                    CommandOutcome::new().append_args_with_prefix("unshare-commands.log", "dir"),
-                    CommandOutcome::new()
-                        .append_args_with_prefix("unshare-commands.log", "file")
-                        .stderr("podman unshare file chmod failed")
-                        .exit_code(61),
-                ])),
+            &FakePodmanScenario::new().with_start(CommandBehavior::from_outcome(
+                CommandOutcome::new()
+                    .touch_file("start-blocked")
+                    .wait_for_file(
+                        "release-start",
+                        Duration::from_secs(5),
+                        "timed out waiting to release start",
+                        91,
+                    ),
+            )),
         );
         let methodology_dir = fixture.create_methodology_dir("runner-methodology");
-        let audit_root = unique_temp_dir("runner-audit-unshare-finalization-failure");
+        let audit_root = unique_temp_dir("runner-audit-direct-finalization");
         fs::create_dir_all(&audit_root).expect("audit root should be created");
         let helper_audit_root = audit_root.clone();
 
@@ -883,14 +873,10 @@ mod tests {
 
                 let record_dir =
                     wait_for_only_session_record_dir(&helper_audit_root, "site-builder", deadline);
-                let sealed_by_unshare_dir = record_dir.join("runa/unshare-private");
-                fs::create_dir_all(&sealed_by_unshare_dir)
-                    .expect("fallback-private audit dir should be created");
-                fs::write(sealed_by_unshare_dir.join("artifact.txt"), "persisted\n")
-                    .expect("fallback-private audit file should be created");
-                use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(&sealed_by_unshare_dir, fs::Permissions::from_mode(0o111))
-                    .expect("fallback-private audit dir should become unreadable to the host");
+                let direct_dir = record_dir.join("runa/direct");
+                fs::create_dir_all(&direct_dir).expect("direct audit dir should be created");
+                fs::write(direct_dir.join("artifact.txt"), "persisted\n")
+                    .expect("direct audit file should be created");
                 fs::write(log_dir.join("release-start"), b"release\n")
                     .expect("start should be released");
             });
@@ -921,45 +907,51 @@ mod tests {
             events
         });
 
-        assert_eq!(events.len(), 4);
+        assert_eq!(events.len(), 3);
         assert_eq!(events[0]["fields"]["event"], "runner.session_started");
         assert_eq!(events[1]["fields"]["event"], "runner.session_outcome");
         assert_eq!(events[1]["fields"]["outcome"], "success");
-        assert_eq!(events[2]["fields"]["event"], "runner.lifecycle_failure");
-        assert_eq!(events[2]["fields"]["stage"], "session audit finalization");
-        assert_eq!(events[3]["fields"]["event"], "runner.session_teardown");
-        assert_eq!(events[3]["fields"]["result"], "error");
+        assert_eq!(events[2]["fields"]["event"], "runner.session_teardown");
+        assert_eq!(events[2]["fields"]["result"], "ok");
 
         let record_dir = only_session_record_dir(&audit_root, "site-builder");
         let metadata = read_session_metadata(&record_dir);
+        assert_eq!(metadata["outcome"], "success");
+        assert!(
+            metadata["end_timestamp"].is_string(),
+            "successful audit finalization must publish end_timestamp"
+        );
         assert_eq!(
             fixture.read_log("unshare-commands.log"),
-            format!(
-                "validate find -P {root} ! -type d ! -type l -links +1 -print\n\
-dir find -P {root} -mindepth 1 -type d ! -path {metadata_dir} -exec chmod 555 {{}} +\n\
-file find -P {root} ! -type d ! -type l ! -path {metadata_path} -exec chmod 444 {{}} +\n",
-                root = record_dir.display(),
-                metadata_dir = record_dir.join("agentd").display(),
-                metadata_path = record_dir.join("agentd/session.json").display(),
-            ),
-            "podman unshare fallback must invoke chmod with octal mode arguments"
-        );
-        assert!(
-            metadata.get("end_timestamp").is_none(),
-            "audit finalization failure must leave end_timestamp incomplete"
-        );
-        assert!(
-            metadata.get("outcome").is_none(),
-            "audit finalization failure must leave outcome incomplete"
+            "",
+            "audit finalization must not invoke a user-namespace helper"
         );
 
         use std::os::unix::fs::PermissionsExt;
 
-        fs::set_permissions(
-            record_dir.join("runa/unshare-private"),
-            fs::Permissions::from_mode(0o755),
-        )
-        .expect("fallback-private dir should become removable for test cleanup");
+        let direct_dir = record_dir.join("runa/direct");
+        let direct_file = direct_dir.join("artifact.txt");
+        assert_eq!(
+            fs::metadata(&direct_dir)
+                .expect("direct audit dir metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o555
+        );
+        assert_eq!(
+            fs::metadata(&direct_file)
+                .expect("direct audit file metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o444
+        );
+
+        fs::set_permissions(&direct_dir, fs::Permissions::from_mode(0o755))
+            .expect("direct dir should become removable for test cleanup");
+        fs::set_permissions(record_dir.join("runa"), fs::Permissions::from_mode(0o755))
+            .expect("runa dir should become removable for test cleanup");
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -113,7 +113,6 @@ impl Write for SharedBufferWriter {
 pub(crate) struct FakePodmanScenario {
     create: CommandBehavior,
     ps: CommandBehavior,
-    unshare: CommandBehavior,
     start: CommandBehavior,
     remove: CommandBehavior,
     secret_create: CommandBehavior,
@@ -131,7 +130,6 @@ impl FakePodmanScenario {
                     .set_container_state("created"),
             ),
             ps: CommandBehavior::from_outcome(CommandOutcome::new()),
-            unshare: CommandBehavior::from_outcome(CommandOutcome::new()),
             start: CommandBehavior::from_outcome(
                 CommandOutcome::new().set_container_state("running"),
             ),
@@ -161,11 +159,6 @@ impl FakePodmanScenario {
 
     pub(crate) fn with_start(mut self, behavior: CommandBehavior) -> Self {
         self.start = behavior;
-        self
-    }
-
-    pub(crate) fn with_unshare(mut self, behavior: CommandBehavior) -> Self {
-        self.unshare = behavior;
         self
     }
 
@@ -224,7 +217,6 @@ impl FakePodmanScenario {
 
         script.push_str(&render_command_branch("create", &self.create));
         script.push_str(&render_command_branch("ps", &self.ps));
-        script.push_str(&render_command_branch("unshare", &self.unshare));
         script.push_str(
             "    secret)\n\
                  subcommand=\"$1\"\n\

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -1481,12 +1481,19 @@ impl Drop for SessionFixture {
 }
 
 fn skip_if_podman_unavailable(test_name: &str) -> bool {
-    if podman_available() {
-        return false;
+    if !podman_available() {
+        eprintln!("skipping {test_name}: podman is unavailable");
+        return true;
     }
 
-    eprintln!("skipping {test_name}: podman is unavailable");
-    true
+    if !direct_audit_sealing_available() {
+        eprintln!(
+            "skipping {test_name}: current UID cannot directly chmod session-written audit files"
+        );
+        return true;
+    }
+
+    false
 }
 
 fn podman_available() -> bool {
@@ -1500,6 +1507,58 @@ fn podman_available() -> bool {
         Ok(status) => status.success(),
         Err(_) => false,
     }
+}
+
+fn direct_audit_sealing_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        let _guard = podman_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        probe_direct_audit_sealing()
+    })
+}
+
+fn probe_direct_audit_sealing() -> bool {
+    let audit_root = unique_temp_dir("agentd-runner-direct-audit-probe");
+    if fs::create_dir_all(&audit_root).is_err() {
+        return false;
+    }
+    if fs::set_permissions(&audit_root, fs::Permissions::from_mode(0o777)).is_err() {
+        let _ = fs::remove_dir_all(&audit_root);
+        return false;
+    }
+
+    let mount_arg = format!("{}:/audit:Z", audit_root.display());
+    // Real Podman lifecycle tests only model the supported direct-seal
+    // deployment when the host test process can chmod files written by the
+    // session user's mapped UID.
+    let status = Command::new("podman")
+        .args([
+            "run",
+            "--rm",
+            "--user",
+            "1000:1000",
+            "-v",
+            &mount_arg,
+            "docker.io/library/debian:bookworm-slim",
+            "sh",
+            "-lc",
+            "printf 'probe\\n' > /audit/probe-file",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    let can_seal = status.is_ok_and(|status| status.success())
+        && fs::set_permissions(
+            audit_root.join("probe-file"),
+            fs::Permissions::from_mode(0o444),
+        )
+        .is_ok();
+
+    let _ = fs::remove_dir_all(&audit_root);
+    can_seal
 }
 
 fn podman_test_lock() -> &'static Mutex<()> {

--- a/crates/agentd/src/audit_root.rs
+++ b/crates/agentd/src/audit_root.rs
@@ -1,10 +1,23 @@
+#[cfg(test)]
+use std::cell::Cell;
 use std::fs::{self, OpenOptions};
 use std::io;
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use getrandom::fill as fill_random_bytes;
 
 use crate::config::{ConfigError, DaemonConfig};
+
+const ACTIVE_AUDIT_PROBE_DIRECTORY_MODE: u32 = 0o755;
+const ACTIVE_AUDIT_PROBE_FILE_MODE: u32 = 0o644;
+const SEALED_AUDIT_PROBE_DIRECTORY_MODE: u32 = 0o555;
+const SEALED_AUDIT_PROBE_FILE_MODE: u32 = 0o444;
+
+#[cfg(test)]
+std::thread_local! {
+    static FAIL_PROBE_CHMOD_CALL_FOR_TESTS: Cell<bool> = const { Cell::new(false) };
+}
 
 pub(crate) fn prepare_audit_root(config: &DaemonConfig) -> Result<PathBuf, ConfigError> {
     let audit_root = config.resolve_audit_root()?;
@@ -19,15 +32,56 @@ pub(crate) fn prepare_audit_root(config: &DaemonConfig) -> Result<PathBuf, Confi
             error,
         })?;
     let probe_path = audit_root.join(probe_name);
+    let probe_file_path = probe_path.join("probe-file");
+    fs::create_dir(&probe_path).map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
     OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(&probe_path)
+        .open(&probe_file_path)
         .map_err(|error| ConfigError::AuditRootNotWritable {
             path: audit_root.clone(),
             error,
         })?;
-    fs::remove_file(&probe_path).map_err(|error| ConfigError::AuditRootNotWritable {
+    set_probe_permissions(
+        &probe_file_path,
+        fs::Permissions::from_mode(SEALED_AUDIT_PROBE_FILE_MODE),
+    )
+    .map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+    set_probe_permissions(
+        &probe_path,
+        fs::Permissions::from_mode(SEALED_AUDIT_PROBE_DIRECTORY_MODE),
+    )
+    .map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+    set_probe_permissions(
+        &probe_path,
+        fs::Permissions::from_mode(ACTIVE_AUDIT_PROBE_DIRECTORY_MODE),
+    )
+    .map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+    set_probe_permissions(
+        &probe_file_path,
+        fs::Permissions::from_mode(ACTIVE_AUDIT_PROBE_FILE_MODE),
+    )
+    .map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+    fs::remove_file(&probe_file_path).map_err(|error| ConfigError::AuditRootNotWritable {
+        path: audit_root.clone(),
+        error,
+    })?;
+    fs::remove_dir(&probe_path).map_err(|error| ConfigError::AuditRootNotWritable {
         path: audit_root.clone(),
         error,
     })?;
@@ -63,9 +117,77 @@ fn hex_encode(bytes: &[u8]) -> String {
     encoded
 }
 
+fn set_probe_permissions(path: &std::path::Path, permissions: fs::Permissions) -> io::Result<()> {
+    #[cfg(test)]
+    {
+        let should_fail = FAIL_PROBE_CHMOD_CALL_FOR_TESTS.with(Cell::get);
+        if should_fail {
+            return Err(io::Error::other("injected audit-root chmod probe failure"));
+        }
+    }
+
+    fs::set_permissions(path, permissions)
+}
+
+#[cfg(test)]
+fn with_probe_chmod_failure_for_tests<T>(run: impl FnOnce() -> T) -> T {
+    FAIL_PROBE_CHMOD_CALL_FOR_TESTS.with(|failure| {
+        assert!(
+            !failure.get(),
+            "audit-root chmod failure injection should not be nested"
+        );
+        failure.set(true);
+    });
+
+    struct ResetGuard;
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            FAIL_PROBE_CHMOD_CALL_FOR_TESTS.with(|failure| failure.set(false));
+        }
+    }
+
+    let _guard = ResetGuard;
+    run()
+}
+
 #[cfg(test)]
 mod tests {
     use super::lower_hex_random_suffix_with;
+    use crate::config::{Config, ConfigError};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::str::FromStr;
+
+    fn unique_test_dir(prefix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after the unix epoch")
+                .as_nanos()
+        ))
+    }
+
+    fn config_with_audit_root(audit_root: &Path) -> Config {
+        Config::from_str(&format!(
+            r#"
+[daemon]
+audit_root = "{audit_root}"
+
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+            audit_root = audit_root.display(),
+        ))
+        .expect("config should parse")
+    }
 
     #[test]
     fn prepare_audit_root_does_not_derive_probe_names_from_process_id_or_system_time() {
@@ -101,5 +223,61 @@ mod tests {
                 .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f')),
             "probe suffix should be lowercase hex: {suffix}"
         );
+    }
+
+    #[test]
+    fn prepare_audit_root_probes_create_chmod_restore_and_remove() {
+        let audit_root = unique_test_dir("agentd-audit-root-probe-pass");
+        let config = config_with_audit_root(&audit_root);
+
+        let prepared = super::prepare_audit_root(config.daemon())
+            .expect("audit root probe should pass for daemon-owned files");
+
+        assert_eq!(prepared, audit_root);
+        assert!(
+            fs::read_dir(&prepared)
+                .expect("audit root should be readable")
+                .next()
+                .is_none(),
+            "successful probe should remove the probe tree"
+        );
+
+        fs::remove_dir_all(&prepared).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn prepare_audit_root_reports_daemon_local_probe_scope_and_uid_alignment_requirement() {
+        let audit_root = unique_test_dir("agentd-audit-root-probe-chmod-fail");
+        let config = config_with_audit_root(&audit_root);
+
+        let error = super::with_probe_chmod_failure_for_tests(|| {
+            super::prepare_audit_root(config.daemon())
+                .expect_err("injected chmod failure should fail the audit-root probe")
+        });
+
+        match error {
+            ConfigError::AuditRootNotWritable { ref path, .. } => {
+                assert_eq!(path, &audit_root);
+            }
+            other => panic!("expected audit-root config error, got {other:?}"),
+        }
+
+        let message = error.to_string();
+        assert!(
+            message.contains("daemon-local create/chmod/remove probe"),
+            "error should name probe scope, got {message}"
+        );
+        assert!(
+            message.contains("UID-aligned"),
+            "error should name UID-alignment requirement, got {message}"
+        );
+        assert!(
+            message.contains(&audit_root.display().to_string()),
+            "error should include audit root path, got {message}"
+        );
+
+        if audit_root.exists() {
+            fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+        }
     }
 }

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -712,7 +712,7 @@ impl fmt::Display for ConfigError {
             ConfigError::AuditRootNotWritable { path, error } => {
                 write!(
                     f,
-                    "daemon audit root is not writable: {} ({error})",
+                    "daemon audit root failed daemon-local create/chmod/remove probe: {} ({error}); deployment must run agentd with a UID-aligned identity, or equivalent chmod authority, over session-written audit files",
                     path.display()
                 )
             }


### PR DESCRIPTION
## Summary

- Adds a runnable `agentd` daemon container image with the Podman client available for session spawning.
- Documents registryless local image distribution for Quadlet-managed daemon deployment.
- Documents host-side socket access and the daemon-container vs host-Podman path responsibilities.
- Aligns audit traversal retry permissions with the sealed `0555` directory mode so completed records remain traversable for non-owner accessors.

## Changes

- Add a root `Containerfile` and `.containerignore` for building `localhost/agentd:<tag>` from source.
- Update README deployment guidance to make the containerized daemon the supported shape and mark host-binary daemon supervision out of band.
- Update architecture docs with the host Podman socket boundary, session-container behavior, and path-classification table.
- Record the deployment-shape change in the changelog.
- Retry audit traversal with the same directory authority used for sealed audit directories.

## GitHub Issue(s)

Closes #95

## Test plan

- `cargo fmt --check`
- `cargo test -p agentd-runner audit_traversal_retry_mode_grants_non_owner_traversal_authority`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `podman build --tag localhost/agentd:test .`
- `podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:test --version`
- `podman run --rm localhost/agentd:test daemon --help`
- `podman inspect --format '{{range .Config.Env}}{{println .}}{{end}}' localhost/agentd:test`
- `git diff --check`
