### PR TITLE
chore(release): Adopt cargo-release per commons ADR-0006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Release operations now use per-repo `cargo-release` configuration that
+  follows the commons ADR-0006 workspace-version discipline.
+
 ### Changed
 
 - The supported daemon deployment shape is now a locally built container image

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,6 +5,11 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[package.metadata.release]
+pre-release-replacements = [
+    { file = "../../CHANGELOG.md", search = "^## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] — {{date}}", exactly = 1 },
+]
+
 [dependencies]
 # Linux-only build enforcement lives in crates/agentd-runner/build.rs.
 agentd-runner.workspace = true

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -14,6 +14,12 @@ fn read_workspace_file(path: &str) -> String {
         .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
 }
 
+fn read_workspace_toml(path: &str) -> toml::Value {
+    read_workspace_file(path)
+        .parse::<toml::Value>()
+        .unwrap_or_else(|error| panic!("{path} should be valid TOML: {error}"))
+}
+
 #[test]
 fn workspace_metadata_lists_only_grounded_crates() {
     let output = Command::new("cargo")
@@ -40,6 +46,45 @@ fn workspace_metadata_lists_only_grounded_crates() {
     assert!(
         !stdout.contains("\"name\":\"forgejo-mcp\""),
         "workspace metadata still includes forgejo-mcp"
+    );
+}
+
+#[test]
+fn cargo_release_configuration_lives_at_the_workspace_root() {
+    assert!(
+        workspace_root().join("release.toml").is_file(),
+        "release.toml should exist at the workspace root"
+    );
+}
+
+#[test]
+fn workspace_packages_inherit_the_workspace_version() {
+    for manifest in [
+        "crates/agentd/Cargo.toml",
+        "crates/agentd-runner/Cargo.toml",
+        "crates/agentd-scheduler/Cargo.toml",
+    ] {
+        let manifest_toml = read_workspace_toml(manifest);
+        let version = manifest_toml
+            .get("package")
+            .and_then(|package| package.get("version"))
+            .unwrap_or_else(|| panic!("{manifest} should declare package.version"));
+
+        assert_eq!(
+            version.get("workspace").and_then(toml::Value::as_bool),
+            Some(true),
+            "{manifest} should inherit version.workspace"
+        );
+    }
+}
+
+#[test]
+fn changelog_keeps_an_unreleased_section_for_release_rolls() {
+    let changelog = read_workspace_file("CHANGELOG.md");
+
+    assert!(
+        changelog.contains("\n## [Unreleased]\n"),
+        "CHANGELOG.md should keep a rollable [Unreleased] heading"
     );
 }
 

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,10 @@
+allow-branch = ["main"]
+shared-version = true
+dependent-version = "fix"
+consolidate-commits = true
+pre-release-commit-message = "chore(release): bump workspace version to {{version}}"
+tag-name = "v{{version}}"
+tag-message = "Release {{tag_name}}"
+push = true
+push-remote = "origin"
+publish = false

--- a/scripts/verify-release-adoption.sh
+++ b/scripts/verify-release-adoption.sh
@@ -30,7 +30,7 @@ git -C "$source_repo" init -q
 git -C "$source_repo" config user.name "agentd release verification"
 git -C "$source_repo" config user.email "agentd-release-verification@example.invalid"
 git -C "$source_repo" checkout -q -b main
-git -C "$source_repo" add .
+git -C "$source_repo" -c core.excludesFile=/dev/null add .
 git -C "$source_repo" commit -q -m "test: seed release verification"
 
 git init --bare -q "$remote_repo"

--- a/scripts/verify-release-adoption.sh
+++ b/scripts/verify-release-adoption.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! cargo release --version >/dev/null 2>&1; then
+    echo "cargo-release is required: install the cargo-release cargo subcommand" >&2
+    exit 1
+fi
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+source_repo="$scratch/source"
+remote_repo="$scratch/origin.git"
+fresh_checkout="$scratch/fresh-checkout"
+release_log="$scratch/cargo-release.log"
+
+mkdir "$source_repo"
+tar \
+    --exclude=.git \
+    --exclude=target \
+    --exclude=.idea \
+    --exclude=.vscode \
+    -C "$workspace_root" \
+    -cf - . \
+    | tar -C "$source_repo" -xf -
+
+git -C "$source_repo" init -q
+git -C "$source_repo" config user.name "agentd release verification"
+git -C "$source_repo" config user.email "agentd-release-verification@example.invalid"
+git -C "$source_repo" checkout -q -b main
+git -C "$source_repo" add .
+git -C "$source_repo" commit -q -m "test: seed release verification"
+
+git init --bare -q "$remote_repo"
+git -C "$source_repo" remote add origin "$remote_repo"
+git -C "$source_repo" push -q -u origin main
+
+workspace_version() {
+    sed -n '/^\[workspace.package\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' "$1/Cargo.toml"
+}
+
+old_version="$(workspace_version "$source_repo")"
+
+(
+    cd "$source_repo"
+    cargo release patch --execute --no-confirm 2>&1 | tee "$release_log"
+)
+
+new_version="$(workspace_version "$source_repo")"
+tag_name="v$new_version"
+release_commit="$(git -C "$source_repo" rev-parse HEAD)"
+tag_commit="$(git -C "$source_repo" rev-list -n 1 "$tag_name")"
+
+if [[ "$new_version" == "$old_version" ]]; then
+    echo "workspace version did not change from $old_version" >&2
+    exit 1
+fi
+
+if ! grep -Fq "## [$new_version] — $(date +%F)" "$source_repo/CHANGELOG.md"; then
+    echo "CHANGELOG.md was not rolled to [$new_version] with today's date" >&2
+    exit 1
+fi
+
+if [[ "$(git -C "$source_repo" cat-file -t "$tag_name")" != "tag" ]]; then
+    echo "$tag_name is not an annotated tag" >&2
+    exit 1
+fi
+
+if [[ "$tag_commit" != "$release_commit" ]]; then
+    echo "$tag_name does not point at the release commit" >&2
+    exit 1
+fi
+
+if ! git --git-dir="$remote_repo" rev-parse --verify --quiet "refs/heads/main" >/dev/null; then
+    echo "release branch was not pushed to the remote" >&2
+    exit 1
+fi
+
+if ! git --git-dir="$remote_repo" rev-parse --verify --quiet "refs/tags/$tag_name" >/dev/null; then
+    echo "$tag_name was not pushed to the remote" >&2
+    exit 1
+fi
+
+if grep -Fq "Uploading" "$release_log"; then
+    echo "release log indicates registry publishing occurred" >&2
+    exit 1
+fi
+
+git clone -q "$remote_repo" "$fresh_checkout"
+git -C "$fresh_checkout" checkout -q "$tag_name"
+cargo build --release -p agentd --manifest-path "$fresh_checkout/Cargo.toml"
+
+version_output="$("$fresh_checkout/target/release/agentd" --version)"
+if [[ "$version_output" != "agentd $new_version" ]]; then
+    echo "agentd --version reported '$version_output', expected 'agentd $new_version'" >&2
+    exit 1
+fi
+
+echo "verified release adoption for $tag_name"


### PR DESCRIPTION
## Summary

- Adopts the commons ADR-0006 cargo-release discipline for agentd without cutting v0.1.2.
- Adds workspace-root release configuration that bumps the shared workspace version, rolls the changelog once, creates annotated `vX.Y.Z` tags, pushes to `origin`, and avoids registry publishing.
- Adds substrate tests and a temp bare-remote release simulation script to verify the workspace-version invariant from a fresh tag checkout.

## Changes

- Adds `release.toml` for shared-version cargo-release operation and representative-package changelog roll configuration on `crates/agentd`.
- Keeps member crates inheriting the root workspace version and verifies the rollable `[Unreleased]` changelog structure.
- Adds `scripts/verify-release-adoption.sh` to exercise the actual `cargo release patch --execute` flow against a temporary bare remote.

## GitHub Issue(s)

Closes #93

## Test plan

- `scripts/verify-release-adoption.sh`
- `cargo fmt --check`
- `git diff --check`
- `bash -n scripts/verify-release-adoption.sh`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`
