### PR TITLE
fix(daemon): session secret cleanup fails on supported podman versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Session secret cleanup now works on the supported Debian Bookworm Podman
+  version floor by avoiding `podman secret rm --ignore` while preserving
+  idempotent cleanup for already-removed secrets.
 - Default socket resolution now fails explicitly when `XDG_RUNTIME_DIR` is
   unset, empty, or relative instead of silently selecting a fallback path that
   may belong to a different daemon.

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -941,6 +941,7 @@ fn run_session_injects_empty_environment_values_via_direct_env_args() {
             CommandOutcome::new()
                 .append_args_with_prefix("secret-commands.log", "create")
                 .capture_stdin_to("secret-value.log")
+                .track_secret_create()
                 .reject_empty_stdin("secret data must be larger than 0", 96),
         )),
     );
@@ -1085,6 +1086,50 @@ fn run_session_releases_session_secrets_after_container_reaches_running_state() 
 }
 
 #[test]
+fn run_session_cleans_up_session_secrets_on_bookworm_podman_floor() {
+    let _guard = fake_podman_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let fixture = FakePodmanFixture::new();
+    fixture.install(
+        &FakePodmanScenario::new().with_secret_rm(CommandBehavior::from_outcome(
+            CommandOutcome::new()
+                .append_args_with_prefix("secret-commands.log", "rm")
+                .reject_args_containing(
+                    "--ignore",
+                    "Error: unknown flag: --ignore\nSee 'podman secret rm --help'",
+                    125,
+                )
+                .track_secret_remove(),
+        )),
+    );
+
+    let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+    let outcome = fixture.run_with_fake_podman(crate::SessionSpec {
+        methodology_dir,
+        environment: vec![ResolvedEnvironmentVariable {
+            name: "GITHUB_TOKEN".to_string(),
+            value: "test-token".to_string(),
+        }],
+        ..test_session_spec()
+    });
+
+    assert_eq!(
+        outcome.expect("session should clean up secrets on the supported podman floor"),
+        SessionOutcome::Success { exit_code: 0 }
+    );
+    assert!(!fixture.secret_commands().contains("--ignore"));
+    assert_eq!(
+        fixture
+            .secret_commands()
+            .lines()
+            .filter(|line| line.starts_with("rm "))
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn run_session_continues_when_secret_release_fails_after_container_reaches_running_state() {
     let _guard = fake_podman_lock()
         .lock()
@@ -1146,6 +1191,9 @@ fn wait_for_container_exit_returns_timeout_when_secret_release_fails() {
     let fixture = FakePodmanFixture::new();
     fixture.install(
         &FakePodmanScenario::new()
+            .with_secret_ls(CommandBehavior::from_outcome(
+                CommandOutcome::new().stdout("secret"),
+            ))
             .with_secret_rm(CommandBehavior::from_outcome(
                 CommandOutcome::new()
                     .append_args_with_prefix("secret-commands.log", "rm")

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -466,7 +466,8 @@ mod tests {
                 .with_secret_create(CommandBehavior::sequence(vec![
                     CommandOutcome::new()
                         .append_args_with_prefix("secret-commands.log", "create")
-                        .capture_stdin_to("secret-value.log"),
+                        .capture_stdin_to("secret-value.log")
+                        .track_secret_create(),
                     CommandOutcome::new()
                         .append_args_with_prefix("secret-commands.log", "create")
                         .stderr("secret create failed")
@@ -1083,7 +1084,7 @@ mod tests {
         );
         assert_eq!(
             fixture.secret_commands(),
-            "rm --ignore agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0 agentd-1a2b3c4d-bbbbbbbbbbbbbbbb-0 agentd-1a2b3c4d-cccccccccccccccc-repo-token agentd-1a2b3c4d-dddddddddddddddd-0 agentd-1a2b3c4d-1212121212121212-0\n"
+            "rm agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0 agentd-1a2b3c4d-bbbbbbbbbbbbbbbb-0 agentd-1a2b3c4d-cccccccccccccccc-repo-token agentd-1a2b3c4d-dddddddddddddddd-0 agentd-1a2b3c4d-1212121212121212-0\n"
         );
     }
 
@@ -1194,7 +1195,7 @@ mod tests {
         );
         assert_eq!(
             fixture.secret_commands(),
-            "rm --ignore agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
+            "rm agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
         );
     }
 
@@ -1250,7 +1251,7 @@ mod tests {
         );
         assert_eq!(
             fixture.secret_commands(),
-            "rm --ignore agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
+            "rm agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
         );
     }
 
@@ -1299,7 +1300,7 @@ mod tests {
         );
         assert_eq!(
             fixture.secret_commands(),
-            "rm --ignore agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
+            "rm agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
         );
     }
 
@@ -1472,7 +1473,7 @@ mod tests {
         );
         assert_eq!(
             fixture.secret_commands(),
-            "rm --ignore agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
+            "rm agentd-1a2b3c4d-aaaaaaaaaaaaaaaa-0\n"
         );
     }
 }

--- a/crates/agentd-runner/src/reconcile.rs
+++ b/crates/agentd-runner/src/reconcile.rs
@@ -5,6 +5,7 @@ use crate::naming::{
     PODMAN_RESOURCE_PREFIX, is_daemon_instance_id, parse_container_name, parse_secret_name,
 };
 use crate::podman::run_podman_command;
+use crate::resources::cleanup_podman_secret_names;
 use crate::{RunnerError, StartupReconciliationReport};
 use serde::Deserialize;
 
@@ -147,15 +148,5 @@ fn remove_containers(container_names: &[String]) -> Result<(), RunnerError> {
 }
 
 fn remove_secrets(secret_names: &[String]) -> Result<(), RunnerError> {
-    if secret_names.is_empty() {
-        return Ok(());
-    }
-
-    let mut args = vec![
-        "secret".to_string(),
-        "rm".to_string(),
-        "--ignore".to_string(),
-    ];
-    args.extend(secret_names.iter().cloned());
-    run_podman_command(args).map(|_| ())
+    cleanup_podman_secret_names(secret_names)
 }

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -14,6 +14,7 @@ use crate::session_paths::session_internal_audit_runa_dir;
 use crate::types::{RunnerError, SessionInvocation, SessionSpec};
 use crate::validation::REPO_TOKEN_ENV;
 use getrandom::fill as fill_random_bytes;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -247,21 +248,45 @@ fn rollback_failed_staging_dir_allocation(
 }
 
 pub(crate) fn cleanup_podman_secrets(secret_bindings: &[SecretBinding]) -> Result<(), RunnerError> {
-    if secret_bindings.is_empty() {
+    let secret_names = secret_bindings
+        .iter()
+        .map(|binding| binding.secret_name.clone())
+        .collect::<Vec<_>>();
+    cleanup_podman_secret_names(&secret_names)
+}
+
+pub(crate) fn cleanup_podman_secret_names(secret_names: &[String]) -> Result<(), RunnerError> {
+    if secret_names.is_empty() {
         return Ok(());
     }
 
-    let mut args = vec![
-        "secret".to_string(),
-        "rm".to_string(),
-        "--ignore".to_string(),
-    ];
+    let existing_secret_names = list_podman_secret_names()?;
+    let mut args = vec!["secret".to_string(), "rm".to_string()];
     args.extend(
-        secret_bindings
+        secret_names
             .iter()
-            .map(|binding| binding.secret_name.clone()),
+            .filter(|name| existing_secret_names.contains(name.as_str()))
+            .cloned(),
     );
+    if args.len() == 2 {
+        return Ok(());
+    }
+
     crate::podman::run_podman_command(args).map(|_| ())
+}
+
+fn list_podman_secret_names() -> Result<HashSet<String>, RunnerError> {
+    Ok(crate::podman::run_podman_command(vec![
+        "secret".to_string(),
+        "ls".to_string(),
+        "--format".to_string(),
+        "{{.Name}}".to_string(),
+    ])?
+    .lines()
+    .map(str::trim)
+    .filter(|line| !line.is_empty())
+    .map(ToString::to_string)
+    .collect())
 }
 
 pub(crate) fn cleanup_methodology_staging_dir(path: &Path) -> Result<(), RunnerError> {
@@ -627,7 +652,8 @@ mod tests {
                 .with_secret_create(CommandBehavior::sequence(vec![
                     CommandOutcome::new()
                         .append_args_with_prefix("secret-commands.log", "create")
-                        .capture_stdin_to("secret-value.log"),
+                        .capture_stdin_to("secret-value.log")
+                        .track_secret_create(),
                     CommandOutcome::new()
                         .append_args_with_prefix("secret-commands.log", "create")
                         .stderr("secret create failed")
@@ -711,7 +737,8 @@ mod tests {
                 .with_secret_create(CommandBehavior::sequence(vec![
                     CommandOutcome::new()
                         .append_args_with_prefix("secret-commands.log", "create")
-                        .capture_stdin_to("secret-value.log"),
+                        .capture_stdin_to("secret-value.log")
+                        .track_secret_create(),
                     CommandOutcome::new()
                         .append_args_with_prefix("secret-commands.log", "create")
                         .stderr("repo token secret create failed")

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -137,11 +137,16 @@ impl FakePodmanScenario {
             secret_create: CommandBehavior::from_outcome(
                 CommandOutcome::new()
                     .append_args_with_prefix("secret-commands.log", "create")
-                    .capture_stdin_to("secret-value.log"),
+                    .capture_stdin_to("secret-value.log")
+                    .track_secret_create(),
             ),
-            secret_list: CommandBehavior::from_outcome(CommandOutcome::new()),
+            secret_list: CommandBehavior::from_outcome(
+                CommandOutcome::new().list_tracked_secrets(),
+            ),
             secret_remove: CommandBehavior::from_outcome(
-                CommandOutcome::new().append_args_with_prefix("secret-commands.log", "rm"),
+                CommandOutcome::new()
+                    .append_args_with_prefix("secret-commands.log", "rm")
+                    .track_secret_remove(),
             ),
             inspect: InspectBehavior::new(),
         }
@@ -277,6 +282,10 @@ pub(crate) struct CommandOutcome {
     append_args: Option<(String, String)>,
     stdin_file: Option<String>,
     reject_empty_stdin: Option<(String, i32)>,
+    reject_args_containing: Vec<(String, String, i32)>,
+    track_secret_create: bool,
+    track_secret_remove: bool,
+    list_tracked_secrets: bool,
     container_state: Option<String>,
     exec_sleep_ms: Option<u64>,
     record_pid_file: Option<String>,
@@ -309,6 +318,32 @@ impl CommandOutcome {
 
     pub(crate) fn reject_empty_stdin(mut self, message: &str, exit_code: i32) -> Self {
         self.reject_empty_stdin = Some((message.to_string(), exit_code));
+        self
+    }
+
+    pub(crate) fn reject_args_containing(
+        mut self,
+        needle: &str,
+        message: &str,
+        exit_code: i32,
+    ) -> Self {
+        self.reject_args_containing
+            .push((needle.to_string(), message.to_string(), exit_code));
+        self
+    }
+
+    pub(crate) fn track_secret_create(mut self) -> Self {
+        self.track_secret_create = true;
+        self
+    }
+
+    pub(crate) fn track_secret_remove(mut self) -> Self {
+        self.track_secret_remove = true;
+        self
+    }
+
+    pub(crate) fn list_tracked_secrets(mut self) -> Self {
+        self.list_tracked_secrets = true;
         self
     }
 
@@ -602,6 +637,25 @@ fn render_command_outcome(outcome: &CommandOutcome) -> String {
                 exit_code
             ));
         }
+    }
+    for (needle, message, exit_code) in &outcome.reject_args_containing {
+        body.push_str(&format!(
+            "for arg in \"$@\"; do\n    if [ \"$arg\" = {} ]; then\n        echo {} >&2\n        exit {}\n    fi\ndone\n",
+            sh_quote(needle),
+            sh_quote(message),
+            exit_code
+        ));
+    }
+    if outcome.track_secret_create {
+        body.push_str("printf '%s\\n' \"$1\" >> \"$log_root/secrets.log\"\n");
+    }
+    if outcome.track_secret_remove {
+        body.push_str(
+            "for secret_name in \"$@\"; do\n    if [ -f \"$log_root/secrets.log\" ]; then\n        grep -Fvx -- \"$secret_name\" \"$log_root/secrets.log\" > \"$log_root/secrets.next\" || true\n        mv \"$log_root/secrets.next\" \"$log_root/secrets.log\"\n    fi\ndone\n",
+        );
+    }
+    if outcome.list_tracked_secrets {
+        body.push_str("cat \"$log_root/secrets.log\" 2>/dev/null || true\n");
     }
     if let Some(state) = &outcome.container_state {
         body.push_str(&format!(


### PR DESCRIPTION
## Summary

- Fixes session secret cleanup on the supported Debian Bookworm Podman floor by avoiding `podman secret rm --ignore`.
- Preserves idempotent cleanup by listing existing secrets before removal and skipping already-absent names.
- Applies the same secret cleanup path to startup orphan-secret reconciliation while leaving container `podman rm --ignore` unchanged.

## Changes

- Adds an idempotent runner secret cleanup helper shared by session cleanup and startup reconciliation.
- Extends fake Podman support to track secret create/list/remove state and reject unsupported arguments for compatibility regression tests.
- Adds a Bookworm-floor regression test and updates expected secret removal commands.
- Records the operator-visible fix in `CHANGELOG.md`.

## GitHub Issue(s)

Closes #101

## Test plan

- `cargo fmt --check`
- `cargo test -p agentd-runner`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
