### PR TITLE
fix(runner): avoid recursive audit mount chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Session setup now prepares the internal audit mount without recursively
+  traversing the bind-mounted `runa/` directory, allowing containerized daemon
+  deployments to reach `runa init` when the audit mount is not readable during
+  recursive ownership transfer.
 - Session secret cleanup now works on the supported Debian Bookworm Podman
   version floor by avoiding `podman secret rm --ignore` while preserving
   idempotent cleanup for already-removed secrets.

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -208,7 +208,7 @@ fn build_container_script(
     script.push_str(&shell_quote(&internal_audit_runa_dir));
     script.push(' ');
     script.push_str(&shell_quote(&repo_runa_dir));
-    script.push_str("\nchown -R ");
+    script.push_str("\nchown ");
     script.push_str(&shell_quote(&user_group));
     script.push(' ');
     script.push_str(&shell_quote(&internal_audit_runa_dir));

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -323,6 +323,35 @@ fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent
 }
 
 #[test]
+fn build_container_script_prepares_audit_mount_root_without_recursive_traversal() {
+    let script = build_container_script(
+        &crate::SessionSpec {
+            agent_name: "myagent".to_string(),
+            ..test_session_spec()
+        },
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        },
+        None,
+    );
+
+    assert!(
+        script.contains(
+            "\nln -s '/home/myagent/.agentd/audit/runa' '/home/myagent/repo/.runa'\n\
+             chown 'myagent:myagent' '/home/myagent/.agentd/audit/runa'\n\
+             export HOME='/home/myagent'\n\
+             unset AGENTD_WORK_UNIT\n\
+             gosu 'myagent:myagent' runa init"
+        ),
+        "audit mount root should receive non-recursive ownership setup before runa init: {script}"
+    );
+}
+
+#[test]
 fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_targets() {
     let script = build_container_script(
         &crate::SessionSpec {


### PR DESCRIPTION
## Summary

- Stops session setup from recursively traversing the internal audit bind mount during ownership preparation.
- Keeps repo ownership recursive while making the audit mount root ready before `runa init`.
- Adds a regression test and changelog entry for the containerized daemon startup failure.

## Changes

- Generate non-recursive `chown` for `/home/{agent}/.agentd/audit/runa` after creating the repo `.runa` symlink.
- Cover the setup sequence with a positive script-generation regression test.
- Document the operator-visible fix in the unreleased changelog.

## GitHub Issue(s)

Closes #103

## Test plan

- `cargo test -p agentd-runner build_container_script_prepares_audit_mount_root_without_recursive_traversal --lib` failed before the fix and passed after it.
- `cargo test -p agentd-runner container::tests --lib`
- `cargo test -p agentd-runner`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

Not run locally: live babbie deployment acceptance with the supported containerized daemon.
