### PR TITLE
fix(runner): align audit mount identity for runa init

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,7 +179,7 @@ The runner prepares the execution environment:
 2. Sets identity inside the container, including `AGENT_NAME` and a unique container name derived from the agent.
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
-5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before `runa init` and the agent command start. Base images that lack `/bin/sh`, `find`, `git`, `useradd`, `gosu`, or `runa` are not supported.
+5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}` and UID/GID `1000`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `groupadd`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before `runa init` and the agent command start. Base images that lack `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, or `runa`, or that cannot reserve UID/GID `1000` for the session user, are not supported.
 6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{agent}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
 7. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets, the runner-owned audit leaf `/home/{username}/.agentd/audit/runa`, and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself, `/home/{username}/.agentd` plus its descendants, and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
 8. When manual invocation includes operator input, reads the active methodology's `manifest.toml` plus `schemas/<type>.schema.json` on the host, validates the input there, stages the final JSON under a runner-managed bind mount at `/agentd/invocation-input`, and rejects unsupported request canonical versions before any container is created. The runner-created invocation-input mount source is staged with explicit host-side read/traverse modes so session-user access does not depend on the daemon process's umask. In `v0.1.x`, request-text input supports canonical request version `1.0.0` only, keyed by `x-tesserine-canonical.version`.
@@ -264,6 +264,9 @@ bind mount so the persisted `runa/` subtree remains writable on
 SELinux-enforcing hosts such as Fedora CoreOS. `agentd/session.json` is not
 mounted into the container; it stays host-only so runa-written state and
 agentd-written metadata are distinguishable on disk without disambiguation.
+Session containers use `--userns keep-id:uid=1000,gid=1000`, and agentd creates
+the in-container agent user at UID/GID `1000`, so the audit bind mount appears
+owned by the same unprivileged identity that invokes `runa init`.
 
 Final audit sealing is daemon-local. agentd uses direct filesystem operations
 to refuse unsafe multi-linked entries and chmod completed audit records; it
@@ -275,13 +278,18 @@ The deployment contract supplies that second half: files written by the session
 container's unprivileged agent user must be owned by an identity the daemon can
 chmod.
 
-The primary supported contract is UID alignment. With the default rootless
-Podman user namespace mapping, a session container UID `N > 0` is represented
-on the host as `subuid_start + (N - 1)`. The daemon container's effective host
-identity must match the mapped host UID for the session's unprivileged agent
-user, or deployment must grant equivalent host-level chmod authority such as
-`CAP_FOWNER` over the audit tree. That daemon identity must also retain access
-to the mounted Podman socket and the configured runtime paths.
+The primary supported contract is daemon identity alignment through Podman's
+`keep-id` user namespace mode. The in-container session user is UID/GID `1000`,
+and that ID maps to the daemon's host UID/GID. That keeps runa's state
+ownership preflight and agentd's daemon-local audit sealing authority aligned
+without session-side audit mount chown. Mount-level idmapped bind mounts would
+fit this ownership mismatch more narrowly, but the supported daemon image uses
+Debian Bookworm's Podman 4.3 client and current rootless bind mounts do not
+provide that surface. The `keep-id` contract is therefore an explicit
+single-tenant security tradeoff: compared with default rootless subuid mapping,
+a session-user escape has the daemon's host-file authority over daemon-owned
+paths. The daemon identity must also retain access to the mounted Podman socket
+and the configured runtime paths.
 
 Host audit records live under the resolved audit root, by default
 `$XDG_STATE_HOME/tesserine/audit/<agent>/<session_id>/` or
@@ -309,12 +317,12 @@ records requires restoring write permission first, for example
 
 The host security model is intentionally single-tenant. While a session is
 running, agentd opens the mounted `runa/` subtree with mode `0o777` so writes
-through the rootless container's UID mapping succeed. Any user with host shell
-access can therefore read or write that subtree during the active session. On
-completion, agentd seals directories to `0555` and non-symlink entries to
-`0444`, making finished records world-readable on the host. For single-tenant
-deployments such as babbie, that tradeoff is acceptable; a multi-tenant host
-would need a different permission model before deployment.
+through the session user's mapped daemon identity succeed. Any user with host
+shell access can therefore read or write that subtree during the active
+session. On completion, agentd seals directories to `0555` and non-symlink
+entries to `0444`, making finished records world-readable on the host. For
+single-tenant deployments such as babbie, that tradeoff is acceptable; a
+multi-tenant host would need a different permission model before deployment.
 
 The startup audit-root probe is intentionally local-filesystem scoped. It
 verifies that the daemon can create, chmod, restore, and remove daemon-owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workspace from inside the rootless session container, and runner-created
   invocation-input staging now uses explicit host-side read modes, preserving
   the mode-based audit writability contract for credential-bearing runs.
+- Session containers now map the daemon host identity to the in-container
+  session user with `--userns keep-id:uid=1000,gid=1000`, so runa observes the
+  audit-backed `.runa` state as owned by the user invoking `runa init`. This is
+  an explicit single-tenant security tradeoff: a session-user escape has the
+  daemon's host-file authority over daemon-owned paths.
 - Session secret cleanup now works on the supported Debian Bookworm Podman
   version floor by avoiding `podman secret rm --ignore` while preserving
   idempotent cleanup for already-removed secrets.

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ targets under `/home/{agent}` remain supported, including read-only auth
 mounts such as `/home/site-builder/.claude`. Additional mounts are not
 relabelled; on SELinux-enabled hosts, operators must ensure each host path
 already has a container-compatible label. The base image must provide
-`/bin/sh`, `find`, `git`, `useradd`, `gosu`, `runa`, and whatever binaries the
-declared agent command uses. When an agent declares `schedule`, it must
-also declare `repo`. Schedules are evaluated in daemon-local time and missed
-fires are not backfilled after downtime. Persistent audit records default to
+`/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, `runa`, and whatever
+binaries the declared agent command uses. UID/GID `1000` must be available for
+the session user. When an agent declares `schedule`, it must also declare
+`repo`. Schedules are evaluated in daemon-local time and missed fires are not
+backfilled after downtime. Persistent audit records default to
 `$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set
 `daemon.audit_root` to override that for system installations.
 
@@ -189,15 +190,15 @@ absolute paths recorded in `agentd.toml` or used by `TMPDIR`.
 Audit sealing is performed by the daemon process with direct filesystem chmod
 operations; it does not enter Podman's user namespace during finalization. The
 startup probe verifies the daemon can create, chmod, restore, and remove its
-own probe entries under `audit_root`. That probe is necessary but not
-sufficient: deployment must also ensure files written by session containers are
-within the daemon's chmod authority. The primary supported contract is UID
-alignment. For a default rootless Podman map, session container UID `N > 0`
-appears on the host as `subuid_start + (N - 1)`, so the daemon's effective host
-identity must match the mapped writer UID for the unprivileged agent user, or
-the daemon must receive equivalent authority such as `CAP_FOWNER` over the
-audit tree. That same daemon identity still needs access to the mounted Podman
-socket and configured runtime paths.
+own probe entries under `audit_root`. Session containers are created with
+`--userns keep-id:uid=1000,gid=1000`, and agentd creates the in-container
+session user at UID/GID `1000`. The audit mount therefore appears owned by the
+same identity that runs `runa init`, and session-written audit files remain
+within the daemon's host-side chmod authority. This is a single-tenant security
+tradeoff: compared with default rootless subuid mapping, a session-user escape
+has the daemon's host-file authority over daemon-owned paths. That daemon
+identity still needs access to the mounted Podman socket and configured runtime
+paths.
 
 A host-installed `agentd` binary remains useful as a same-build CLI client for
 `agentd run`, but host-binary daemon supervision is out of band for supported

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -28,6 +28,8 @@ use std::time::{Duration, Instant};
 
 const ATTACHED_STDERR_TAIL_LIMIT: usize = 64 * 1024;
 const ATTACHED_STDERR_TRUNCATION_NOTICE: &str = "[stderr truncated to last 65536 bytes]\n";
+const SESSION_USER_ID: u32 = 1000;
+const SESSION_GROUP_ID: u32 = 1000;
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
 const METHODOLOGY_MANIFEST_PATH: &str = "/agentd/methodology/manifest.toml";
 const PODMAN_INFRASTRUCTURE_ERROR_EXIT_CODE: i32 = 125;
@@ -170,9 +172,17 @@ fn build_container_script(
     let repo_dir = repo_dir_path.display().to_string();
     let repo_runa_dir = session_repo_runa_dir(username).display().to_string();
     let user_group = format!("{username}:{username}");
-    let mut script = String::from("set -eu\nuseradd --create-home --home-dir ");
+    let mut script = String::from("set -eu\ngroupadd --gid ");
+    script.push_str(&SESSION_GROUP_ID.to_string());
+    script.push(' ');
+    script.push_str(&shell_quote(username));
+    script.push_str("\nuseradd --create-home --home-dir ");
     script.push_str(&shell_quote(&home_dir));
-    script.push_str(" --shell /bin/sh --user-group ");
+    script.push_str(" --shell /bin/sh --uid ");
+    script.push_str(&SESSION_USER_ID.to_string());
+    script.push_str(" --gid ");
+    script.push_str(&shell_quote(username));
+    script.push(' ');
     script.push_str(&shell_quote(username));
     script.push('\n');
     script.push_str("mkdir -p ");
@@ -334,6 +344,8 @@ fn build_create_container_args(
         "create".to_string(),
         "--name".to_string(),
         resources.container_name.clone(),
+        "--userns".to_string(),
+        format!("keep-id:uid={SESSION_USER_ID},gid={SESSION_GROUP_ID}"),
         "--mount".to_string(),
         format!(
             "type=bind,src={},target={},ro=true,relabel=shared",

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -121,6 +121,52 @@ fn create_container_args_force_root_user_and_entrypoint_before_image_argument() 
 }
 
 #[test]
+fn create_container_args_map_daemon_identity_to_session_user_id() {
+    let args = build_create_container_args(
+        &SessionResources {
+            container_name: "agentd-agent-session".to_string(),
+            methodology_staging_dir: PathBuf::from("/tmp/staging"),
+            methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+            audit_record: test_audit_record(),
+            audit_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/audit-runa"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
+            invocation_input_mount: None,
+            additional_mounts: Vec::new(),
+            environment_secret_bindings: Vec::new(),
+            repo_token_secret_binding: None,
+        },
+        &test_session_spec(),
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        },
+        None,
+    );
+
+    let userns_index = args
+        .iter()
+        .position(|arg| arg == "--userns")
+        .expect("podman create should receive --userns");
+    assert_eq!(
+        args.get(userns_index + 1).map(String::as_str),
+        Some("keep-id:uid=1000,gid=1000")
+    );
+
+    let image_index = args
+        .iter()
+        .position(|arg| arg == "image")
+        .expect("podman create should include the base image");
+    assert!(userns_index < image_index);
+}
+
+#[test]
 fn create_container_args_pass_shell_flags_after_image_argument() {
     let spec = test_session_spec();
     let invocation = SessionInvocation {
@@ -290,7 +336,8 @@ fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent
     );
 
     assert!(script.contains(
-        "useradd --create-home --home-dir '/home/myagent' --shell /bin/sh --user-group 'myagent'"
+        "groupadd --gid 1000 'myagent'\n\
+         useradd --create-home --home-dir '/home/myagent' --shell /bin/sh --uid 1000 --gid 'myagent' 'myagent'"
     ));
     assert!(script.contains("\nmkdir -p '/home/myagent/.agentd/audit'\n"));
     assert!(script.contains(

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -30,7 +30,8 @@ pub struct SessionSpec {
     pub agent_name: String,
     /// Container image reference. The image must provide `/bin/sh`, `git`,
     /// `find`, and the setup/session binaries required by the configured
-    /// agent command in `PATH`, including `useradd` and `gosu`.
+    /// agent command in `PATH`, including `groupadd`, `useradd`, and `gosu`.
+    /// UID/GID `1000` must be available for the session user.
     pub base_image: String,
     /// Host-side path to the methodology directory. Mounted read-only into
     /// the container at `/agentd/methodology`. Must contain `manifest.toml`.

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -1971,6 +1971,8 @@ case "$command_name" in
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "write-repo-audit-state" ]; then
             [ -L "${HOME}/repo/.runa" ]
             [ "$(readlink "${HOME}/repo/.runa")" = "${HOME}/.agentd/audit/runa" ]
+            [ "$(stat -Lc '%u:%g' "${HOME}/repo/.runa")" = "$(id -u):$(id -g)" ]
+            [ -w "${HOME}/repo/.runa" ]
             mkdir -p "${HOME}/repo/.runa/workspace" "${HOME}/repo/.runa/store/executions"
             printf 'persisted through repo bridge\n' > "${HOME}/repo/.runa/workspace/session-artifact.txt"
             printf '{"protocols":["begin"],"postconditions":["passed"]}\n' > "${HOME}/repo/.runa/store/executions/0001.json"

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -18,6 +18,8 @@ use agentd_runner::{
 use serde_json::Value;
 
 const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
+const SESSION_USER_ID: u32 = 1000;
+const SESSION_GROUP_ID: u32 = 1000;
 
 fn run_session_with_test_audit_root(
     audit_root: &Path,
@@ -1534,18 +1536,7 @@ fn probe_direct_audit_sealing() -> bool {
     // deployment when the host test process can chmod files written by the
     // session user's mapped UID.
     let status = Command::new("podman")
-        .args([
-            "run",
-            "--rm",
-            "--user",
-            "1000:1000",
-            "-v",
-            &mount_arg,
-            "docker.io/library/debian:bookworm-slim",
-            "sh",
-            "-lc",
-            "printf 'probe\\n' > /audit/probe-file",
-        ])
+        .args(probe_direct_audit_sealing_args(&mount_arg))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
@@ -1559,6 +1550,37 @@ fn probe_direct_audit_sealing() -> bool {
 
     let _ = fs::remove_dir_all(&audit_root);
     can_seal
+}
+
+fn probe_direct_audit_sealing_args(mount_arg: &str) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        "--rm".to_string(),
+        "--userns".to_string(),
+        format!("keep-id:uid={SESSION_USER_ID},gid={SESSION_GROUP_ID}"),
+        "--user".to_string(),
+        format!("{SESSION_USER_ID}:{SESSION_GROUP_ID}"),
+        "-v".to_string(),
+        mount_arg.to_string(),
+        "docker.io/library/debian:bookworm-slim".to_string(),
+        "sh".to_string(),
+        "-lc".to_string(),
+        "printf 'probe\\n' > /audit/probe-file".to_string(),
+    ]
+}
+
+#[test]
+fn direct_audit_sealing_probe_maps_daemon_identity_to_session_user_id() {
+    let args = probe_direct_audit_sealing_args("/tmp/audit:/audit:Z");
+
+    let userns_index = args
+        .iter()
+        .position(|arg| arg == "--userns")
+        .expect("podman probe should receive --userns");
+    assert_eq!(
+        args.get(userns_index + 1).map(String::as_str),
+        Some("keep-id:uid=1000,gid=1000")
+    );
 }
 
 fn podman_test_lock() -> &'static Mutex<()> {


### PR DESCRIPTION
## Summary

- Maps the daemon host identity to the session user with `--userns keep-id:uid=1000,gid=1000` so runa observes the audit-backed `.runa` target as owned by the user invoking `runa init`.
- Makes the session UID/GID contract explicit in runner setup, tests, README, ARCHITECTURE.md, and CHANGELOG.md.
- Records the fallback security tradeoff after mount-level idmapped binds were not viable on the supported daemon substrate.

## Changes

- Creates the in-container agent user and group at UID/GID `1000` and passes Podman `--userns keep-id:uid=1000,gid=1000` during session container creation.
- Extends container argument and lifecycle tests to assert the user namespace mapping, audit symlink owner alignment, and session-user writability.
- Updates operator-facing documentation to name the base-image UID/GID requirement and the single-tenant host-file authority tradeoff.

## GitHub Issue(s)

Closes #110

## Test plan

- `cargo fmt --check`
- `cargo test -p agentd-runner`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
