### PR TITLE
fix(runner): relabel canonical audit mount sources

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,16 +47,22 @@ service:
 | Daemon socket and PID file | daemon process; host clients use the socket through the host mount | Configure explicit daemon runtime paths inside the container and mount their parent directory from the host runtime location. |
 | Host Podman socket | daemon process through the Podman client | Mount the host rootless Podman socket to the path named by `CONTAINER_HOST`. |
 | Credential sources | daemon process environment | Inject the environment variables named by agent credentials into the daemon container. |
-| `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves staged bind sources | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
-| `audit_root` | daemon process creates/chmods; host Podman resolves staged bind sources; session containers write audit entries | Mount durable host storage at the configured audit root, with the daemon UID aligned to the session writer's mapped host UID or granted equivalent chmod authority. |
+| `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves direct relabelled methodology source | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
+| `audit_root` | daemon process creates/chmods; host Podman resolves direct relabelled audit sources; session containers write audit entries | Mount durable host storage at the configured audit root, with the daemon UID aligned to the session writer's mapped host UID or granted equivalent chmod authority. |
 | Agent-declared `mounts.source` | daemon process canonicalizes; host Podman resolves staged bind sources | Mount or expose each source so the daemon and host Podman agree on the source path. |
 | Runner staging directory | daemon process writes; host Podman resolves staged bind sources | The path named by `TMPDIR` must exist at the same absolute path for the daemon container and host Podman. The image default requires host `/var/lib/agentd/tmp` mounted to container `/var/lib/agentd/tmp`, or a changed `TMPDIR` exposed identically on both sides. |
 
 The path split follows directly from the current runner implementation. The
 daemon process validates and canonicalizes methodology, audit, additional
 mount, invocation-input, and staging paths, then sends bind-mount source
-strings to the host Podman service. Podman resolves those source strings on the
-host that owns the socket, not inside the daemon container. Any future
+strings to the host Podman service. Runner-owned relabelled sources are passed
+as direct canonical host paths so Podman's SELinux relabel operation applies to
+the real source tree; operator-declared mounts continue to use staged aliases.
+Runner-owned relabelled sources containing both `,` and `:` are rejected
+because neither Podman's comma-delimited `--mount` form nor its colon-delimited
+`--volume` fallback can encode that path unambiguously.
+Podman resolves those source strings on the host that owns the socket, not
+inside the daemon container. Any future
 host/container path translation would be a code change, not a deployment
 property.
 
@@ -246,12 +252,12 @@ Additional bind mounts are declared in agent configuration as `source`,
 `target`, and `read_only`. agentd validates absolute container targets plus a
 per-agent disjointness invariant: target paths must be unique and no target
 may be a path-component prefix of another. It then stages canonical host
-sources through runner-managed symlinks before calling Podman so host paths
-containing commas remain mountable. Subscription auth is the first read-only
-consumer of this mechanism; persistent audit storage in `#76` builds on the
-same path with read-write mounts. Additional mounts are not relabelled; on
-SELinux-enabled hosts, operators must pre-label those host paths with a
-container-compatible context.
+sources through runner-managed symlinks before calling Podman so additional
+mounts stay separate from runner-owned relabel handling. Subscription auth is
+the first read-only consumer of this mechanism; persistent audit storage in
+`#76` builds on the same path with read-write mounts. Additional mounts are not
+relabelled; on SELinux-enabled hosts, operators must pre-label those host paths
+with a container-compatible context.
 
 The invocation-input mount is runner-owned, not operator-owned. Its target
 `/agentd/invocation-input` is reserved alongside `/agentd/methodology`, so
@@ -259,9 +265,9 @@ agent-declared mounts cannot collide with the pre-command input-materialization
 path.
 
 The internal audit mount is different from operator-declared mounts. It is
-runner-owned, not operator-owned, and agentd applies `relabel=shared` to that
-bind mount so the persisted `runa/` subtree remains writable on
-SELinux-enforcing hosts such as Fedora CoreOS. `agentd/session.json` is not
+runner-owned, not operator-owned, and agentd applies shared SELinux relabeling
+to the canonical host `runa/` source so the persisted `runa/` subtree remains
+writable on SELinux-enforcing hosts such as Fedora CoreOS. `agentd/session.json` is not
 mounted into the container; it stays host-only so runa-written state and
 agentd-written metadata are distinguishable on disk without disambiguation.
 Session containers use `--userns keep-id:uid=1000,gid=1000`, and agentd creates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Runner-owned SELinux relabelled mounts now pass canonical host source paths
+  to Podman, so FCOS Enforcing deployments relabel the real audit `runa/`
+  subtree instead of a staging alias before `runa init`.
 - Session setup now prepares the internal audit mount without recursively
   traversing the bind-mounted `runa/` directory, allowing containerized daemon
   deployments to reach `runa init` when the audit mount is not readable during

--- a/README.md
+++ b/README.md
@@ -123,16 +123,18 @@ entries are bind mounts: `source` must be an absolute existing host path,
 `target` must be an absolute container path, targets must be unique within the
 agent, and runner-managed targets are reserved: `/agentd/methodology`,
 `/home/{agent}`, `/home/{agent}/.agentd`, and `/home/{agent}/repo` plus
-their descendants. Other
-targets under `/home/{agent}` remain supported, including read-only auth
-mounts such as `/home/site-builder/.claude`. Additional mounts are not
-relabelled; on SELinux-enabled hosts, operators must ensure each host path
-already has a container-compatible label. The base image must provide
-`/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, `runa`, and whatever
-binaries the declared agent command uses. UID/GID `1000` must be available for
-the session user. When an agent declares `schedule`, it must also declare
-`repo`. Schedules are evaluated in daemon-local time and missed fires are not
-backfilled after downtime. Persistent audit records default to
+their descendants. Other targets under `/home/{agent}` remain supported,
+including read-only auth mounts such as `/home/site-builder/.claude`.
+Additional mounts are not relabelled; on SELinux-enabled hosts, operators must
+ensure each host path already has a container-compatible label. Runner-owned
+mounts such as
+methodology, invocation input, and the internal audit `runa/` subtree are
+relabelled by Podman from their canonical host source paths. The base image
+must provide `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, `runa`,
+and whatever binaries the declared agent command uses. UID/GID `1000` must be
+available for the session user. When an agent declares `schedule`, it must also
+declare `repo`. Schedules are evaluated in daemon-local time and missed fires
+are not backfilled after downtime. Persistent audit records default to
 `$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set
 `daemon.audit_root` to override that for system installations.
 
@@ -179,7 +181,9 @@ environment, and mounted Podman socket must be reachable by the daemon process
 inside the daemon container. Session bind sources that the daemon opens and
 then forwards to host Podman must also be valid from the host Podman service's
 view: `methodology_dir`, each agent-declared `mounts.source`, `audit_root`, and
-the runner staging directory. This image sets `TMPDIR=/var/lib/agentd/tmp`, so
+the runner staging directory. Runner-owned relabelled sources are passed to
+Podman as canonical host paths so SELinux relabeling applies to the real tree,
+not to a staging alias. This image sets `TMPDIR=/var/lib/agentd/tmp`, so
 the host must also expose that staging directory at `/var/lib/agentd/tmp` when
 using the image default. Mount host `/var/lib/agentd/tmp` to container
 `/var/lib/agentd/tmp`, or set `TMPDIR` to another path the operator can expose

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -346,44 +346,24 @@ fn build_create_container_args(
         resources.container_name.clone(),
         "--userns".to_string(),
         format!("keep-id:uid={SESSION_USER_ID},gid={SESSION_GROUP_ID}"),
-        "--mount".to_string(),
-        format!(
-            "type=bind,src={},target={},ro=true,relabel=shared",
-            resources.methodology_mount_source.display(),
-            METHODOLOGY_MOUNT_PATH
-        ),
     ];
 
-    args.push("--mount".to_string());
-    args.push(format!(
-        "type=bind,src={},target={},ro={},relabel=shared",
-        resources.audit_mount.source.display(),
-        resources.audit_mount.target.display(),
-        resources.audit_mount.read_only
-    ));
+    push_bind_mount_arg(
+        &mut args,
+        resources.methodology_mount_source.as_path(),
+        Path::new(METHODOLOGY_MOUNT_PATH),
+        true,
+        true,
+    );
+
+    push_prepared_bind_mount_arg(&mut args, &resources.audit_mount);
 
     if let Some(mount) = &resources.invocation_input_mount {
-        args.push("--mount".to_string());
-        args.push(format!(
-            "type=bind,src={},target={},ro={},relabel=shared",
-            mount.source.display(),
-            mount.target.display(),
-            mount.read_only
-        ));
+        push_prepared_bind_mount_arg(&mut args, mount);
     }
 
     for mount in &resources.additional_mounts {
-        args.push("--mount".to_string());
-        let mut mount_value = format!(
-            "type=bind,src={},target={},ro={}",
-            mount.source.display(),
-            mount.target.display(),
-            mount.read_only
-        );
-        if mount.relabel_shared {
-            mount_value.push_str(",relabel=shared");
-        }
-        args.push(mount_value);
+        push_prepared_bind_mount_arg(&mut args, mount);
     }
 
     let mut secret_bindings = resources.environment_secret_bindings.iter();
@@ -433,6 +413,50 @@ fn build_create_container_args(
     args.push(build_container_script(spec, invocation, resolved_input));
 
     args
+}
+
+fn push_prepared_bind_mount_arg(
+    args: &mut Vec<String>,
+    mount: &crate::resources::PreparedBindMount,
+) {
+    push_bind_mount_arg(
+        args,
+        &mount.source,
+        &mount.target,
+        mount.read_only,
+        mount.relabel_shared,
+    );
+}
+
+fn push_bind_mount_arg(
+    args: &mut Vec<String>,
+    source: &Path,
+    target: &Path,
+    read_only: bool,
+    relabel_shared: bool,
+) {
+    if relabel_shared && source.to_string_lossy().contains(',') {
+        args.push("--volume".to_string());
+        args.push(format!(
+            "{}:{}:{},z",
+            source.display(),
+            target.display(),
+            if read_only { "ro" } else { "rw" }
+        ));
+        return;
+    }
+
+    args.push("--mount".to_string());
+    let mut mount_value = format!(
+        "type=bind,src={},target={},ro={}",
+        source.display(),
+        target.display(),
+        read_only
+    );
+    if relabel_shared {
+        mount_value.push_str(",relabel=shared");
+    }
+    args.push(mount_value);
 }
 
 fn cleanup_and_finalize_attached_start_after_wait_error(

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -6,7 +6,7 @@ use crate::test_support::{
     CommandBehavior, CommandOutcome, FakePodmanFixture, FakePodmanScenario, InspectBehavior,
     capture_tracing_events, exit_status, fake_podman_lock, test_session_spec,
 };
-use crate::{ResolvedEnvironmentVariable, SessionInvocation};
+use crate::{BindMount, ResolvedEnvironmentVariable, SessionInvocation};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -66,6 +66,50 @@ fn create_container_args_include_shared_relabel_for_methodology_mount() {
     assert!(
         mount_value.contains("relabel=shared"),
         "methodology bind mount should include shared SELinux relabeling: {mount_value}"
+    );
+}
+
+#[test]
+fn create_container_args_use_volume_for_shared_relabel_sources_containing_commas() {
+    let args = build_create_container_args(
+        &SessionResources {
+            container_name: "agentd-agent-session".to_string(),
+            methodology_staging_dir: PathBuf::from("/tmp/staging"),
+            methodology_mount_source: PathBuf::from("/tmp/source,with,commas/methodology"),
+            audit_record: test_audit_record(),
+            audit_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/audit,with,commas/runa"),
+                target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
+            invocation_input_mount: None,
+            additional_mounts: Vec::new(),
+            environment_secret_bindings: Vec::new(),
+            repo_token_secret_binding: None,
+        },
+        &test_session_spec(),
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        },
+        None,
+    );
+
+    let volume_values = argument_values(&args, "--volume");
+    assert_eq!(
+        volume_values,
+        vec![
+            "/tmp/source,with,commas/methodology:/agentd/methodology:ro,z".to_string(),
+            "/tmp/audit,with,commas/runa:/home/site-builder/.agentd/audit/runa:rw,z".to_string(),
+        ]
+    );
+    assert!(
+        argument_values(&args, "--mount").is_empty(),
+        "comma-containing shared relabel sources should not use --mount: {args:?}"
     );
 }
 
@@ -1105,9 +1149,15 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
     let agent_name = "myagent";
 
     let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+    let additional_mount_source = fixture.create_methodology_dir("runner-additional-mount");
     let outcome = fixture.run_with_fake_podman(crate::SessionSpec {
         agent_name: agent_name.to_string(),
         methodology_dir,
+        mounts: vec![BindMount {
+            source: additional_mount_source,
+            target: PathBuf::from("/home/myagent/.claude"),
+            read_only: true,
+        }],
         environment: vec![ResolvedEnvironmentVariable {
             name: "GITHUB_TOKEN".to_string(),
             value: "test-token".to_string(),
@@ -1123,8 +1173,14 @@ fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_name
     let create_args = fixture.create_args();
     let container_name =
         argument_value(&create_args, "--name").expect("podman create should receive a name");
-    let mount_value =
-        argument_value(&create_args, "--mount").expect("podman create should receive a mount");
+    let create_arg_parts = create_args
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let mount_value = argument_values(&create_arg_parts, "--mount")
+        .into_iter()
+        .find(|value| value.contains("/mount-0"))
+        .expect("podman create should receive a staged additional mount");
     let mount_source = mount_src_value(&mount_value).expect("mount should include src");
     let stage_dir_name = Path::new(&mount_source)
         .parent()

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -19,12 +19,10 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-const METHODOLOGY_STAGE_LINK_NAME: &str = "methodology";
 const INVOCATION_INPUT_STAGE_DIR_NAME: &str = "invocation-input";
 const INVOCATION_INPUT_FILE_NAME: &str = "document.json";
 const INVOCATION_INPUT_STAGE_DIR_MODE: u32 = 0o755;
 const INVOCATION_INPUT_FILE_MODE: u32 = 0o644;
-const AUDIT_RUNA_STAGE_LINK_NAME: &str = "audit-runa";
 const ADDITIONAL_MOUNT_STAGE_PREFIX: &str = "mount-";
 const SESSION_STAGE_PREFIX: &str = "agentd-session-stage-";
 
@@ -111,9 +109,9 @@ pub(crate) fn prepare_session_resources(
         ));
     }
 
-    let methodology_staging_dir = create_methodology_staging_dir(&spec.methodology_dir, session_id)
+    let methodology_staging_dir = create_session_staging_dir(session_id)
         .map_err(ResourceAllocationFailure::without_rollback_failure)?;
-    let audit_mount = match create_audit_mount(&audit_record, spec, &methodology_staging_dir) {
+    let audit_mount = match create_audit_mount(&audit_record, spec) {
         Ok(mount) => mount,
         Err(error) => {
             return Err(rollback_failed_staging_dir_allocation(
@@ -124,7 +122,21 @@ pub(crate) fn prepare_session_resources(
             ));
         }
     };
-    let methodology_mount_source = methodology_staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
+    let methodology_mount_source =
+        match canonical_mount_source(&spec.methodology_dir).and_then(|path| {
+            validate_shared_relabel_mount_source(&path)?;
+            Ok(path)
+        }) {
+            Ok(path) => path,
+            Err(error) => {
+                return Err(rollback_failed_staging_dir_allocation(
+                    container_name,
+                    session_id,
+                    &methodology_staging_dir,
+                    error,
+                ));
+            }
+        };
     let invocation_input_mount =
         match create_invocation_input_mount(resolved_input, &methodology_staging_dir) {
             Ok(mount) => mount,
@@ -300,23 +312,9 @@ pub(crate) fn cleanup_methodology_staging_dir(path: &Path) -> Result<(), RunnerE
     }
 }
 
-// Creates a staging directory containing a symlink to the canonical methodology
-// path. The symlink indirection ensures the podman bind-mount source is always
-// an absolute, canonical path free of characters that break mount syntax, even
-// when the original methodology_dir is relative or contains problematic chars.
-fn create_methodology_staging_dir(
-    methodology_dir: &Path,
-    session_id: &str,
-) -> Result<PathBuf, RunnerError> {
-    let canonical_methodology_dir = methodology_dir.canonicalize()?;
+fn create_session_staging_dir(session_id: &str) -> Result<PathBuf, RunnerError> {
     let staging_dir = safe_staging_root().join(format!("{SESSION_STAGE_PREFIX}{session_id}"));
     fs::create_dir_all(&staging_dir)?;
-    let staged_link = staging_dir.join(METHODOLOGY_STAGE_LINK_NAME);
-
-    if let Err(error) = create_path_symlink(&canonical_methodology_dir, &staged_link) {
-        let _ = fs::remove_dir_all(&staging_dir);
-        return Err(error);
-    }
 
     Ok(staging_dir)
 }
@@ -343,11 +341,9 @@ fn create_additional_mounts(
 fn create_audit_mount(
     audit_record: &SessionAuditRecord,
     spec: &SessionSpec,
-    staging_dir: &Path,
 ) -> Result<PreparedBindMount, RunnerError> {
-    create_prepared_bind_mount(
+    create_direct_prepared_bind_mount(
         &audit_record.runa_dir,
-        staging_dir.join(AUDIT_RUNA_STAGE_LINK_NAME),
         session_internal_audit_runa_dir(&spec.agent_name),
         false,
         true,
@@ -375,8 +371,11 @@ fn create_invocation_input_mount(
         fs::Permissions::from_mode(INVOCATION_INPUT_FILE_MODE),
     )?;
 
+    let canonical_staged_dir = canonical_mount_source(&staged_dir)?;
+    validate_shared_relabel_mount_source(&canonical_staged_dir)?;
+
     Ok(Some(PreparedBindMount {
-        source: staged_dir,
+        source: canonical_staged_dir,
         target: PathBuf::from(INVOCATION_INPUT_MOUNT_PATH),
         read_only: true,
         relabel_shared: true,
@@ -390,18 +389,51 @@ fn create_prepared_bind_mount(
     read_only: bool,
     relabel_shared: bool,
 ) -> Result<PreparedBindMount, RunnerError> {
-    let canonical_source = source.canonicalize().map_err(|error| match error.kind() {
-        std::io::ErrorKind::NotFound => RunnerError::MissingMountSource {
-            path: source.to_path_buf(),
-        },
-        _ => RunnerError::Io(error),
-    })?;
+    let canonical_source = canonical_mount_source(source)?;
     create_path_symlink(&canonical_source, &staged_source)?;
     Ok(PreparedBindMount {
         source: staged_source,
         target,
         read_only,
         relabel_shared,
+    })
+}
+
+fn create_direct_prepared_bind_mount(
+    source: &Path,
+    target: PathBuf,
+    read_only: bool,
+    relabel_shared: bool,
+) -> Result<PreparedBindMount, RunnerError> {
+    let canonical_source = canonical_mount_source(source)?;
+    if relabel_shared {
+        validate_shared_relabel_mount_source(&canonical_source)?;
+    }
+    Ok(PreparedBindMount {
+        source: canonical_source,
+        target,
+        read_only,
+        relabel_shared,
+    })
+}
+
+fn validate_shared_relabel_mount_source(source: &Path) -> Result<(), RunnerError> {
+    let source = source.to_string_lossy();
+    if source.contains(',') && source.contains(':') {
+        return Err(RunnerError::UnencodableRelabelMountSource {
+            path: PathBuf::from(source.as_ref()),
+        });
+    }
+
+    Ok(())
+}
+
+fn canonical_mount_source(source: &Path) -> Result<PathBuf, RunnerError> {
+    source.canonicalize().map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => RunnerError::MissingMountSource {
+            path: source.to_path_buf(),
+        },
+        _ => RunnerError::Io(error),
     })
 }
 
@@ -467,8 +499,9 @@ fn hex_encode(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        INVOCATION_INPUT_FILE_NAME, INVOCATION_INPUT_STAGE_DIR_NAME, create_invocation_input_mount,
-        prepare_session_resources, rollback_failed_staging_dir_allocation, unique_suffix_with,
+        INVOCATION_INPUT_FILE_NAME, INVOCATION_INPUT_STAGE_DIR_NAME,
+        cleanup_methodology_staging_dir, create_invocation_input_mount, prepare_session_resources,
+        rollback_failed_staging_dir_allocation, unique_suffix_with,
     };
     use crate::audit::SessionAuditRecord;
     use crate::input::{INVOCATION_INPUT_MOUNT_PATH, ResolvedInvocationInput};
@@ -617,6 +650,134 @@ mod tests {
         fs::set_permissions(&root, fs::Permissions::from_mode(0o755))
             .expect("rollback parent should become writable for cleanup");
         fs::remove_dir_all(&root).expect("temporary rollback root should be removed");
+    }
+
+    #[test]
+    fn prepare_session_resources_uses_canonical_audit_dir_as_shared_relabel_source() {
+        let root = unique_test_dir("agentd-audit-direct-relabel-source");
+        let methodology_dir = root.join("methodology");
+        fs::create_dir_all(&methodology_dir).expect("methodology dir should be created");
+        fs::write(methodology_dir.join("manifest.toml"), "name = \"test\"\n")
+            .expect("methodology manifest should be written");
+        let session_id = format!("session-audit-direct-source-{}", std::process::id());
+        let audit_record = test_audit_record(&session_id);
+        let canonical_runa_dir = audit_record
+            .runa_dir
+            .canonicalize()
+            .expect("test audit runa dir should canonicalize");
+
+        let resources = prepare_session_resources(
+            "agentd-agent-session",
+            &crate::SessionSpec {
+                methodology_dir,
+                ..test_session_spec()
+            },
+            &SessionInvocation {
+                repo_url: "https://example.com/repo.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+            &session_id,
+            audit_record,
+            None,
+        )
+        .expect("session resources should allocate");
+
+        assert_eq!(resources.audit_mount.source, canonical_runa_dir);
+        assert!(resources.audit_mount.relabel_shared);
+
+        cleanup_methodology_staging_dir(&resources.methodology_staging_dir)
+            .expect("staging dir should clean up");
+        fs::remove_dir_all(&resources.audit_record.record_dir)
+            .expect("temporary audit record should be removed");
+        fs::remove_dir_all(&root).expect("temporary root should be removed");
+    }
+
+    #[test]
+    fn prepare_session_resources_uses_canonical_methodology_dir_as_shared_relabel_source() {
+        let root = unique_test_dir("agentd-methodology-direct-relabel-source");
+        let methodology_dir = root.join("methodology");
+        fs::create_dir_all(&methodology_dir).expect("methodology dir should be created");
+        fs::write(methodology_dir.join("manifest.toml"), "name = \"test\"\n")
+            .expect("methodology manifest should be written");
+        let canonical_methodology_dir = methodology_dir
+            .canonicalize()
+            .expect("test methodology dir should canonicalize");
+        let session_id = format!("session-methodology-direct-source-{}", std::process::id());
+
+        let resources = prepare_session_resources(
+            "agentd-agent-session",
+            &crate::SessionSpec {
+                methodology_dir,
+                ..test_session_spec()
+            },
+            &SessionInvocation {
+                repo_url: "https://example.com/repo.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+            &session_id,
+            test_audit_record(&session_id),
+            None,
+        )
+        .expect("session resources should allocate");
+
+        assert_eq!(
+            resources.methodology_mount_source,
+            canonical_methodology_dir
+        );
+
+        cleanup_methodology_staging_dir(&resources.methodology_staging_dir)
+            .expect("staging dir should clean up");
+        fs::remove_dir_all(&resources.audit_record.record_dir)
+            .expect("temporary audit record should be removed");
+        fs::remove_dir_all(&root).expect("temporary root should be removed");
+    }
+
+    #[test]
+    fn prepare_session_resources_rejects_shared_relabel_sources_that_cannot_be_encoded() {
+        let root = unique_test_dir("agentd-relabel-source,with:colon");
+        let methodology_dir = root.join("methodology");
+        fs::create_dir_all(&methodology_dir).expect("methodology dir should be created");
+        fs::write(methodology_dir.join("manifest.toml"), "name = \"test\"\n")
+            .expect("methodology manifest should be written");
+        let session_id = format!("session-relabel-source-syntax-{}", std::process::id());
+        let audit_record = test_audit_record(&session_id);
+        let audit_record_dir = audit_record.record_dir.clone();
+
+        let error = prepare_session_resources(
+            "agentd-agent-session",
+            &crate::SessionSpec {
+                methodology_dir: methodology_dir.clone(),
+                ..test_session_spec()
+            },
+            &SessionInvocation {
+                repo_url: "https://example.com/repo.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+            &session_id,
+            audit_record,
+            None,
+        )
+        .expect_err("unencodable shared relabel sources should fail allocation")
+        .allocation_error;
+
+        assert!(
+            error
+                .to_string()
+                .contains("shared relabel bind mount source cannot contain both ',' and ':'"),
+            "expected explicit relabel source syntax error, got {error}"
+        );
+
+        fs::remove_dir_all(audit_record_dir).expect("temporary audit record should be removed");
+        fs::remove_dir_all(&root).expect("temporary root should be removed");
     }
 
     #[test]

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -362,6 +362,9 @@ pub enum RunnerError {
     Io(std::io::Error),
     /// A configured bind mount source path does not exist.
     MissingMountSource { path: PathBuf },
+    /// A runner-owned shared-relabel bind mount source cannot be encoded safely
+    /// for Podman.
+    UnencodableRelabelMountSource { path: PathBuf },
     /// A podman CLI invocation returned a non-zero exit status. Captures the
     /// argument list, exit status, and stderr for diagnostics.
     PodmanCommandFailed {
@@ -429,6 +432,11 @@ impl fmt::Display for RunnerError {
             RunnerError::MissingMountSource { path } => {
                 write!(f, "mount source path does not exist: {}", path.display())
             }
+            RunnerError::UnencodableRelabelMountSource { path } => write!(
+                f,
+                "shared relabel bind mount source cannot contain both ',' and ':': {}",
+                path.display()
+            ),
             RunnerError::PodmanCommandFailed {
                 args,
                 status,


### PR DESCRIPTION
## Summary

- Mount runner-owned methodology, invocation input, and audit paths from canonical host sources so Podman relabels the real directories under SELinux.
- Preserve staged, non-relabelled handling for operator-provided additional mounts while adding explicit validation for relabel source paths that cannot be encoded safely.
- Update runner path/SELinux documentation to match the new bind-mount contract.

## Changes

- `agentd-runner` now constructs shared-relabel bind mounts from canonical source paths for runner-owned resources.
- Container argument generation uses Podman volume syntax for comma-containing relabel sources and rejects sources containing both comma and colon.
- Regression coverage asserts canonical audit/methodology sources, encoding rejection, and comma-safe Podman arguments.
- README, architecture notes, and changelog now document canonical relabel sources and operator mount boundaries.

## GitHub Issue(s)

Refs #112

## Test plan

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

Not yet run: live FCOS Enforcing deployment validation on the target host to confirm `runa init` proceeds without AVC denials and post-session sealing remains clean.
