### PR TITLE
feat(runner): persist session transcripts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,7 +186,7 @@ The runner prepares the execution environment:
 3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
 4. Mounts the configured methodology directory read-only.
 5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}` and UID/GID `1000`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `groupadd`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, and `git://` repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before `runa init` and the agent command start. Base images that lack `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, or `runa`, or that cannot reserve UID/GID `1000` for the session user, are not supported.
-6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{agent}/{session_id}/`, writes start metadata to `agentd/session.json`, and bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa` before the runtime initializes runa state.
+6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{agent}/{session_id}/`, writes start metadata to `agentd/session.json`, bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa`, and bind-mounts `agentd/transcript/` at `/agentd/transcript` before the runtime initializes runa state.
 7. Recursively transfers ownership of pre-existing content under `/home/{username}` while pruning host-backed bind-mount targets, the runner-owned audit leaf `/home/{username}/.agentd/audit/runa`, and `/home/{username}/repo`, then transfers ownership of `/home/{username}/repo` after the clone, sets `HOME=/home/{username}`, and keeps setup privileged only until the workspace is ready. The runner reserves `/home/{username}` itself, `/home/{username}/.agentd` plus its descendants, and `/home/{username}/repo` plus its descendants so host-backed bind mounts cannot collide with runner-managed paths.
 8. When manual invocation includes operator input, reads the active methodology's `manifest.toml` plus `schemas/<type>.schema.json` on the host, validates the input there, stages the final JSON under a runner-managed bind mount at `/agentd/invocation-input`, and rejects unsupported request canonical versions before any container is created. The runner-created invocation-input mount source is staged with explicit host-side read/traverse modes so session-user access does not depend on the daemon process's umask. In `v0.1.x`, request-text input supports canonical request version `1.0.0` only, keyed by `x-tesserine-canonical.version`.
 9. Creates `/home/{username}/repo/.runa` as a symlink to `/home/{username}/.agentd/audit/runa`; writability comes from the host-side active `runa/` mode established during audit-record allocation, not from container-side ownership transfer. This is a runner-owned repo contract: cloned repositories must not contain a `.runa` entry at repo root. If the clone already contains one, setup fails explicitly rather than overwriting repository content.
@@ -195,18 +195,19 @@ The runner prepares the execution environment:
 
 ### Phase 3: Execution (`agentd-runner`)
 
-The runner drops privileges with `gosu` and launches `runa run [--work-unit <id>] --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange.
+The runner drops privileges with `gosu` and launches `runa run [--work-unit <id>] --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange. agentd sets `RUNA_TRANSCRIPT_DIR=/agentd/transcript` and `RUNA_TRANSCRIPT_REDACT_ENV` so runa can persist the execution events it observes.
 
 ### Phase 4: Teardown (`agentd-runner`)
 
 When the session ends or times out, the runner first force-removes the
-container. Only after cleanup succeeds does it finalize `agentd/session.json`
-with end timestamp and outcome through an atomic same-directory temp-file
-rename. Before that publish step it seals persisted non-metadata audit entries
-read-only on the host, then publishes a read-only `session.json` as the final
-commit point. Ancestor directories remain writable because the atomic replace
-requires a writable parent directory. The ephemeral container workspace still
-disappears, but the host audit record remains at
+container. Only after cleanup succeeds does it render transcript artifacts and
+finalize `agentd/session.json` with end timestamp and outcome through an
+atomic same-directory temp-file rename. Before that publish step it seals
+persisted non-metadata audit entries read-only on the host, then publishes a
+read-only `session.json` as the final commit point. Ancestor directories remain
+writable because the atomic replace requires a writable parent directory. The
+ephemeral container workspace still disappears, but the host audit record
+remains at
 `{audit_root}/{agent}/{session_id}/`.
 
 If agentd is interrupted after writing start metadata but before finalization,
@@ -260,9 +261,9 @@ relabelled; on SELinux-enabled hosts, operators must pre-label those host paths
 with a container-compatible context.
 
 The invocation-input mount is runner-owned, not operator-owned. Its target
-`/agentd/invocation-input` is reserved alongside `/agentd/methodology`, so
-agent-declared mounts cannot collide with the pre-command input-materialization
-path.
+`/agentd/invocation-input` is reserved alongside `/agentd/methodology` and
+`/agentd/transcript`, so agent-declared mounts cannot collide with
+runner-managed input or transcript paths.
 
 The internal audit mount is different from operator-declared mounts. It is
 runner-owned, not operator-owned, and agentd applies shared SELinux relabeling
@@ -305,14 +306,22 @@ Host audit records live under the resolved audit root, by default
 layout:
 
 - `runa/` — preserved runa state written naturally by the runtime
+- `agentd/transcript/events.jsonl` — structured transcript events emitted by
+  runa and runa-mcp when observable
+- `agentd/transcript/transcript.md` — human-readable rendering of the event
+  stream
+- `agentd/transcript/manifest.json` — transcript schema version and coverage:
+  `full`, `missing_mcp_events`, or `outer_streams_only`
 - `agentd/session.json` — agentd-written metadata (`schema_version: 2`,
   `session_id`, `agent`, `repo_url`, optional `work_unit`, timestamps, outcome,
   exit code when applicable) written by atomic temp-file replacement within the
   record directory
 
-Coverage is intentionally scoped to the repo-root `.runa/` tree. That captures
-`runa`'s non-configurable `.runa/store/` and `.runa/workspace/`, so persisted
-runtime state stays inside the audit mount.
+Audit state coverage is intentionally scoped to the repo-root `.runa/` tree.
+That captures `runa`'s non-configurable `.runa/store/` and `.runa/workspace/`,
+so persisted runtime state stays inside the audit mount. Transcript coverage is
+separate: it captures runa's observable execution boundary and only includes
+MCP tool events when the agent runtime actually launches `runa-mcp`.
 
 Retention is intentionally out of scope here. Audit records accumulate
 indefinitely under the resolved audit root; pruning and retention policy are

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -311,7 +311,7 @@ layout:
 - `agentd/transcript/transcript.md` — human-readable rendering of the event
   stream
 - `agentd/transcript/manifest.json` — transcript schema version and coverage:
-  `full`, `missing_mcp_events`, or `outer_streams_only`
+  `full`, `missing_mcp_events`, `outer_streams_only`, or `finalization_failed`
 - `agentd/session.json` — agentd-written metadata (`schema_version: 2`,
   `session_id`, `agent`, `repo_url`, optional `work_unit`, timestamps, outcome,
   exit code when applicable) written by atomic temp-file replacement within the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Session audit records now include agentd-managed transcript artifacts under
+  `agentd/transcript/`, with structured events, a human-readable Markdown
+  rendering, and a coverage manifest.
 - Release operations now use per-repo `cargo-release` configuration that
   follows the commons ADR-0006 workspace-version discipline and pins
   compliance-critical `cargo-release` behavior against user-level config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ version = "0.1.1"
 dependencies = [
  "getrandom 0.4.2",
  "jsonschema",
+ "libc",
  "serde",
  "serde_json",
  "time",

--- a/README.md
+++ b/README.md
@@ -311,10 +311,10 @@ persists on the host under the resolved audit root
 metadata in `agentd/session.json`, and transcript artifacts in
 `agentd/transcript/`. Transcript artifacts include structured JSON Lines events
 at `events.jsonl`, a human-readable `transcript.md`, and `manifest.json` with
-coverage of `full`, `missing_mcp_events`, or `outer_streams_only`. Full MCP
-tool-call coverage depends on the agent runtime launching `runa-mcp`; otherwise
-the transcript still records the observable runa boundary without claiming MCP
-events that never occurred.
+coverage of `full`, `missing_mcp_events`, `outer_streams_only`, or
+`finalization_failed`. Full MCP tool-call coverage depends on the agent runtime
+launching `runa-mcp`; otherwise the transcript still records the observable runa
+boundary without claiming MCP events that never occurred.
 
 If teardown cleanup fails, or if audit finalization attempts closeout and
 fails, metadata remains intentionally incomplete with no `end_timestamp` or

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ environment — export them before starting the daemon. Additional `mounts`
 entries are bind mounts: `source` must be an absolute existing host path,
 `target` must be an absolute container path, targets must be unique within the
 agent, and runner-managed targets are reserved: `/agentd/methodology`,
-`/home/{agent}`, `/home/{agent}/.agentd`, and `/home/{agent}/repo` plus
-their descendants. Other targets under `/home/{agent}` remain supported,
+`/agentd/transcript`, `/home/{agent}`, `/home/{agent}/.agentd`, and
+`/home/{agent}/repo` plus their descendants. Other targets under `/home/{agent}` remain supported,
 including read-only auth mounts such as `/home/site-builder/.claude`.
 Additional mounts are not relabelled; on SELinux-enabled hosts, operators must
 ensure each host path already has a container-compatible label. Runner-owned
@@ -307,14 +307,22 @@ the container, the agent sees:
 
 The container is force-removed on completion. The session's audit record
 persists on the host under the resolved audit root
-`<audit_root>/<agent>/<session_id>/`, with runa state in `runa/` and agentd
-metadata in `agentd/session.json`. If teardown cleanup fails, or if audit
-finalization attempts closeout and fails, that metadata remains intentionally
-incomplete with no `end_timestamp` or `outcome`. On successful finalization,
-agentd seals persisted runa entries read-only and publishes a read-only
-`session.json` as the final commit point. Ancestor directories remain writable
-so the final same-directory atomic replace can occur. The on-disk metadata does
-not encode which incomplete path occurred; operators should use
+`<audit_root>/<agent>/<session_id>/`, with runa state in `runa/`, agentd
+metadata in `agentd/session.json`, and transcript artifacts in
+`agentd/transcript/`. Transcript artifacts include structured JSON Lines events
+at `events.jsonl`, a human-readable `transcript.md`, and `manifest.json` with
+coverage of `full`, `missing_mcp_events`, or `outer_streams_only`. Full MCP
+tool-call coverage depends on the agent runtime launching `runa-mcp`; otherwise
+the transcript still records the observable runa boundary without claiming MCP
+events that never occurred.
+
+If teardown cleanup fails, or if audit finalization attempts closeout and
+fails, metadata remains intentionally incomplete with no `end_timestamp` or
+`outcome`. On successful finalization, agentd seals persisted runa and
+transcript entries read-only and publishes a read-only `session.json` as the
+final commit point. Ancestor directories remain writable so the final
+same-directory atomic replace can occur. The on-disk metadata does not encode
+which incomplete path occurred; operators should use
 `runner.lifecycle_failure` plus the surrounding `runner.session_outcome`,
 `runner.session_error`, and `runner.session_teardown` events to disambiguate
 cause.

--- a/crates/agentd-runner/Cargo.toml
+++ b/crates/agentd-runner/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 [dependencies]
 getrandom = "0.4.2"
 jsonschema = { version = "0.46.2", default-features = false }
+libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.44", features = ["formatting"] }

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -3,9 +3,11 @@ use serde::Serialize;
 use serde_json::Value;
 #[cfg(test)]
 use std::cell::Cell;
+use std::ffi::CString;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
@@ -139,7 +141,7 @@ pub(crate) fn finalize_session_audit_record(
 }
 
 pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result<(), RunnerError> {
-    fs::create_dir_all(&record.transcript_dir)?;
+    prepare_transcript_tree_for_finalization(&record.transcript_dir)?;
     match finalize_session_transcript_artifacts(record) {
         Ok(()) => Ok(()),
         Err(failure) => {
@@ -157,9 +159,12 @@ fn finalize_session_transcript_artifacts(
     record: &SessionAuditRecord,
 ) -> Result<(), TranscriptFinalizationFailure> {
     let events_path = record.transcript_dir.join(EVENTS_ARTIFACT);
-    let events = read_or_create_transcript_events(&events_path)?;
-    let coverage = transcript_coverage(&events);
-    write_transcript_markdown(record, &events)?;
+    let mut events = open_or_create_transcript_events(&events_path)?;
+    let coverage = transcript_coverage(&mut events)?;
+    events
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
+    write_transcript_markdown(record, &mut events)?;
     write_transcript_manifest(record, coverage, None)?;
     Ok(())
 }
@@ -257,46 +262,69 @@ fn write_transcript_manifest(
 
 fn write_transcript_markdown(
     record: &SessionAuditRecord,
-    events: &str,
+    events: &mut File,
 ) -> Result<(), TranscriptFinalizationFailure> {
-    let mut markdown = String::from("# Session Transcript\n\n");
-    if events.trim().is_empty() {
-        markdown.push_str("_No structured transcript events were emitted._\n");
-    } else {
-        for line in events.lines().filter(|line| !line.trim().is_empty()) {
-            match serde_json::from_str::<Value>(line) {
-                Ok(event) => {
-                    let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
-                    markdown.push_str("## ");
-                    markdown.push_str(kind);
-                    markdown.push_str("\n\n");
-                    if let Some(content) = event.get("content").and_then(Value::as_str) {
-                        push_fenced_code_block(&mut markdown, "text", content);
-                    } else {
-                        push_fenced_code_block(&mut markdown, "json", line);
-                    }
+    let mut markdown = create_new_transcript_artifact(
+        &record.transcript_dir.join(MARKDOWN_ARTIFACT),
+        MARKDOWN_ARTIFACT,
+    )?;
+    markdown
+        .write_all(b"# Session Transcript\n\n")
+        .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+
+    let mut reader = BufReader::new(events);
+    let mut line = String::new();
+    let mut wrote_event = false;
+    loop {
+        line.clear();
+        let bytes_read = reader
+            .read_line(&mut line)
+            .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        wrote_event = true;
+        match serde_json::from_str::<Value>(line) {
+            Ok(event) => {
+                let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
+                writeln!(markdown, "## {kind}\n")
+                    .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+                if let Some(content) = event.get("content").and_then(Value::as_str) {
+                    write_fenced_code_block(&mut markdown, "text", content)?;
+                } else {
+                    write_fenced_code_block(&mut markdown, "json", line)?;
                 }
-                Err(_) => {
-                    markdown.push_str("## unparsed_event\n\n");
-                    push_fenced_code_block(&mut markdown, "text", line);
-                }
+            }
+            Err(_) => {
+                markdown
+                    .write_all(b"## unparsed_event\n\n")
+                    .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+                write_fenced_code_block(&mut markdown, "text", line)?;
             }
         }
     }
-    write_new_transcript_artifact(
-        &record.transcript_dir.join(MARKDOWN_ARTIFACT),
-        MARKDOWN_ARTIFACT,
-        markdown.as_bytes(),
-    )?;
+
+    if !wrote_event {
+        markdown
+            .write_all(b"_No structured transcript events were emitted._\n")
+            .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+    }
+
     Ok(())
 }
 
-fn read_or_create_transcript_events(path: &Path) -> Result<String, TranscriptFinalizationFailure> {
+fn open_or_create_transcript_events(path: &Path) -> Result<File, TranscriptFinalizationFailure> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             create_empty_transcript_artifact(path, EVENTS_ARTIFACT)?;
-            return Ok(String::new());
+            fs::symlink_metadata(path).map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?
         }
         Err(error) => return Err(artifact_failure(EVENTS_ARTIFACT, error)),
     };
@@ -308,7 +336,7 @@ fn read_or_create_transcript_events(path: &Path) -> Result<String, TranscriptFin
         ));
     }
 
-    let mut file = OpenOptions::new()
+    let file = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
         .open(path)
@@ -316,10 +344,12 @@ fn read_or_create_transcript_events(path: &Path) -> Result<String, TranscriptFin
             Some(libc::ELOOP) => unsafe_artifact_failure(EVENTS_ARTIFACT, "is not a regular file"),
             _ => artifact_failure(EVENTS_ARTIFACT, error),
         })?;
-    if !file
+    let open_metadata = file
         .metadata()
-        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?
-        .is_file()
+        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
+    if !open_metadata.is_file()
+        || open_metadata.dev() != metadata.dev()
+        || open_metadata.ino() != metadata.ino()
     {
         return Err(unsafe_artifact_failure(
             EVENTS_ARTIFACT,
@@ -327,10 +357,7 @@ fn read_or_create_transcript_events(path: &Path) -> Result<String, TranscriptFin
         ));
     }
 
-    let mut events = String::new();
-    file.read_to_string(&mut events)
-        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
-    Ok(events)
+    Ok(file)
 }
 
 fn create_empty_transcript_artifact(
@@ -387,17 +414,24 @@ fn unsafe_artifact_failure(artifact: &'static str, reason: &str) -> TranscriptFi
     )
 }
 
-fn push_fenced_code_block(markdown: &mut String, language: &str, content: &str) {
+fn write_fenced_code_block(
+    markdown: &mut File,
+    language: &str,
+    content: &str,
+) -> Result<(), TranscriptFinalizationFailure> {
     let fence = "`".repeat(max_consecutive_backticks(content).saturating_add(1).max(3));
-    markdown.push_str(&fence);
-    markdown.push_str(language);
-    markdown.push('\n');
-    markdown.push_str(content);
+    writeln!(markdown, "{fence}{language}")
+        .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+    markdown
+        .write_all(content.as_bytes())
+        .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
     if !content.ends_with('\n') {
-        markdown.push('\n');
+        markdown
+            .write_all(b"\n")
+            .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
     }
-    markdown.push_str(&fence);
-    markdown.push_str("\n\n");
+    writeln!(markdown, "{fence}\n").map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+    Ok(())
 }
 
 fn max_consecutive_backticks(content: &str) -> usize {
@@ -414,20 +448,45 @@ fn max_consecutive_backticks(content: &str) -> usize {
     max
 }
 
-fn transcript_coverage(events: &str) -> &'static str {
-    if events.trim().is_empty() {
-        return "outer_streams_only";
+fn transcript_coverage(events: &mut File) -> Result<&'static str, TranscriptFinalizationFailure> {
+    let mut reader = BufReader::new(events);
+    let mut line = String::new();
+    let mut saw_event = false;
+    let mut saw_mcp_event = false;
+    loop {
+        line.clear();
+        let bytes_read = reader
+            .read_line(&mut line)
+            .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        saw_event = true;
+        if serde_json::from_str::<Value>(line)
+            .ok()
+            .and_then(|event| {
+                (event.get("source").and_then(Value::as_str) == Some("runa-mcp")).then_some(())
+            })
+            .is_some()
+        {
+            saw_mcp_event = true;
+        }
     }
-    if events.lines().filter(|line| !line.trim().is_empty()).any(
-        |line| match serde_json::from_str::<Value>(line) {
-            Ok(event) => event.get("source").and_then(Value::as_str) == Some("runa-mcp"),
-            Err(_) => false,
-        },
-    ) {
+
+    let coverage = if saw_mcp_event {
         "full"
-    } else {
+    } else if saw_event {
         "missing_mcp_events"
-    }
+    } else {
+        "outer_streams_only"
+    };
+    Ok(coverage)
 }
 
 fn rollback_record_dir_on_error<T, F>(record_dir: &Path, init: F) -> Result<T, RunnerError>
@@ -454,6 +513,66 @@ fn set_active_audit_directory_permissions(path: &Path) -> Result<(), RunnerError
         fs::Permissions::from_mode(ACTIVE_AUDIT_DIRECTORY_MODE),
     )?;
     Ok(())
+}
+
+fn prepare_transcript_tree_for_finalization(path: &Path) -> Result<(), RunnerError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(RunnerError::Io(std::io::Error::other(format!(
+                    "unsafe transcript directory: {} is not a directory",
+                    path.display()
+                ))));
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(path)?;
+        }
+        Err(error) => return Err(RunnerError::Io(error)),
+    }
+
+    repair_transcript_path_permissions(path)
+}
+
+fn repair_transcript_path_permissions(path: &Path) -> Result<(), RunnerError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    if metadata.is_dir() {
+        set_owner_permissions_no_follow(path, metadata.permissions().mode() | 0o700)?;
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            repair_transcript_path_permissions(&entry.path())?;
+        }
+    } else if metadata.is_file() {
+        set_owner_permissions_no_follow(path, metadata.permissions().mode() | 0o600)?;
+    }
+
+    Ok(())
+}
+
+fn set_owner_permissions_no_follow(path: &Path, mode: u32) -> Result<(), RunnerError> {
+    let path = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
+        RunnerError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("path contains interior nul byte: {error}"),
+        ))
+    })?;
+    let result = unsafe {
+        libc::fchmodat(
+            libc::AT_FDCWD,
+            path.as_ptr(),
+            mode as libc::mode_t,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(RunnerError::Io(std::io::Error::last_os_error()))
+    }
 }
 
 fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerError> {
@@ -649,6 +768,7 @@ mod tests {
     use crate::{RunnerError, SessionInvocation, SessionOutcome};
     use serde_json::Value;
     use std::fs;
+    use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -1273,6 +1393,129 @@ mod tests {
     }
 
     #[test]
+    fn finalize_session_transcript_repairs_restrictive_transcript_directory_before_rendering() {
+        let root = unique_test_dir("agentd-audit-restrictive-transcript-dir");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "restrictive-transcript-dir",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        fs::write(
+            record.transcript_dir.join("events.jsonl"),
+            "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"hello\"}\n",
+        )
+        .expect("events jsonl should be created");
+        fs::set_permissions(&record.transcript_dir, fs::Permissions::from_mode(0o000))
+            .expect("transcript dir should become restrictive");
+
+        let finalize_result = super::finalize_session_transcript(&record);
+        if finalize_result.is_err() {
+            let _ = fs::set_permissions(&record.transcript_dir, fs::Permissions::from_mode(0o755));
+        }
+        finalize_result.expect("transcript should finalize from restrictive directory mode");
+
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("transcript manifest should exist"),
+        )
+        .expect("manifest should be json");
+        assert_eq!(manifest["coverage"], "missing_mcp_events");
+        let markdown = fs::read_to_string(record.transcript_dir.join("transcript.md"))
+            .expect("transcript markdown should exist");
+        assert!(markdown.contains("agent_input"), "{markdown}");
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_repairs_restrictive_events_jsonl_before_reading() {
+        let root = unique_test_dir("agentd-audit-restrictive-transcript-events");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "restrictive-transcript-events",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let events_path = record.transcript_dir.join("events.jsonl");
+        fs::write(
+            &events_path,
+            "{\"schema_version\":1,\"source\":\"runa-mcp\",\"kind\":\"tool_call\"}\n",
+        )
+        .expect("events jsonl should be created");
+        fs::set_permissions(&events_path, fs::Permissions::from_mode(0o000))
+            .expect("events jsonl should become restrictive");
+
+        let finalize_result = super::finalize_session_transcript(&record);
+        if finalize_result.is_err() {
+            let _ = fs::set_permissions(&events_path, fs::Permissions::from_mode(0o644));
+        }
+        finalize_result.expect("transcript should finalize from restrictive events mode");
+
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("transcript manifest should exist"),
+        )
+        .expect("manifest should be json");
+        assert_eq!(manifest["coverage"], "full");
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_does_not_chmod_symlink_targets_while_repairing_modes() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_test_dir("agentd-audit-transcript-repair-symlink");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "repair-symlink",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let outside_target = root.join("outside-target.txt");
+        fs::write(&outside_target, "outside\n").expect("outside target should be created");
+        fs::set_permissions(&outside_target, fs::Permissions::from_mode(0o600))
+            .expect("outside target should start restrictive");
+        symlink(
+            &outside_target,
+            record.transcript_dir.join("unrelated-link"),
+        )
+        .expect("transcript symlink should be created");
+
+        super::finalize_session_transcript(&record).expect("transcript should finalize");
+
+        let outside_mode = fs::metadata(&outside_target)
+            .expect("outside target metadata should exist")
+            .permissions()
+            .mode();
+        assert_eq!(outside_mode & 0o777, 0o600);
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
     fn finalize_session_transcript_rejects_symlinked_events_jsonl_without_following_it() {
         use std::os::unix::fs::symlink;
 
@@ -1501,25 +1744,107 @@ mod tests {
 
     #[test]
     fn transcript_coverage_uses_parsed_event_sources() {
-        assert_eq!(super::transcript_coverage(""), "outer_streams_only");
+        assert_eq!(classify_transcript_fixture(""), "outer_streams_only");
         assert_eq!(
-            super::transcript_coverage(
+            classify_transcript_fixture(
                 r#"{"schema_version":1,"source":"runa","kind":"agent_input"}"#
             ),
             "missing_mcp_events"
         );
         assert_eq!(
-            super::transcript_coverage(
+            classify_transcript_fixture(
                 r#"{"schema_version":1,"source": "runa-mcp","kind":"tool_call"}"#
             ),
             "full"
         );
         assert_eq!(
-            super::transcript_coverage(
+            classify_transcript_fixture(
                 r#"{"schema_version":1,"source":"runa","kind":"agent_output","content":"{\"source\":\"runa-mcp\"}"}"#
             ),
             "missing_mcp_events"
         );
+    }
+
+    fn classify_transcript_fixture(events: &str) -> &'static str {
+        let root = unique_test_dir("agentd-audit-coverage-fixture");
+        fs::create_dir_all(&root).expect("coverage fixture dir should be created");
+        let events_path = root.join("events.jsonl");
+        fs::write(&events_path, events).expect("coverage fixture should be written");
+        let mut events_file = fs::File::open(&events_path).expect("coverage fixture should open");
+        let coverage = super::transcript_coverage(&mut events_file)
+            .expect("coverage classification should run");
+        fs::remove_dir_all(root).expect("coverage fixture dir should be removed");
+        coverage
+    }
+
+    #[test]
+    fn finalize_session_transcript_streams_large_events_without_large_rss_growth() {
+        const CHILD_ENV: &str = "AGENTD_LARGE_TRANSCRIPT_STREAMING_CHILD";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let current_exe = std::env::current_exe().expect("current test binary should exist");
+            let output = Command::new(current_exe)
+                .arg("--exact")
+                .arg("audit::tests::finalize_session_transcript_streams_large_events_without_large_rss_growth")
+                .arg("--nocapture")
+                .env(CHILD_ENV, "1")
+                .output()
+                .expect("child test process should run");
+            assert!(
+                output.status.success(),
+                "child streaming regression failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let root = unique_test_dir("agentd-audit-large-transcript");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "large-transcript",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let events_path = record.transcript_dir.join("events.jsonl");
+        let mut events_file =
+            fs::File::create(&events_path).expect("large events should be created");
+        let content = "x".repeat(512);
+        for index in 0..90_000 {
+            writeln!(
+                events_file,
+                "{{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_output\",\"content\":\"{content}-{index}\"}}"
+            )
+            .expect("large event should be written");
+        }
+        drop(events_file);
+
+        let before_kib =
+            current_rss_high_water_kib().expect("linux rss high-water should be readable");
+        super::finalize_session_transcript(&record).expect("large transcript should finalize");
+        let after_kib =
+            current_rss_high_water_kib().expect("linux rss high-water should be readable");
+        let growth_kib = after_kib.saturating_sub(before_kib);
+        assert!(
+            growth_kib < 32 * 1024,
+            "transcript finalization grew RSS high-water by {growth_kib} KiB"
+        );
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    fn current_rss_high_water_kib() -> Option<u64> {
+        let status = fs::read_to_string("/proc/self/status").ok()?;
+        status.lines().find_map(|line| {
+            let value = line.strip_prefix("VmHWM:")?;
+            value.split_whitespace().next()?.parse().ok()
+        })
     }
 
     #[test]

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -127,7 +127,10 @@ pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result
     let events_path = record.transcript_dir.join("events.jsonl");
     let events = match fs::read_to_string(&events_path) {
         Ok(events) => events,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::write(&events_path, [])?;
+            String::new()
+        }
         Err(error) => return Err(error.into()),
     };
     let coverage = transcript_coverage(&events);
@@ -225,22 +228,14 @@ fn write_transcript_markdown(record: &SessionAuditRecord, events: &str) -> Resul
                     markdown.push_str(kind);
                     markdown.push_str("\n\n");
                     if let Some(content) = event.get("content").and_then(Value::as_str) {
-                        markdown.push_str("```text\n");
-                        markdown.push_str(content);
-                        if !content.ends_with('\n') {
-                            markdown.push('\n');
-                        }
-                        markdown.push_str("```\n\n");
+                        push_fenced_code_block(&mut markdown, "text", content);
                     } else {
-                        markdown.push_str("```json\n");
-                        markdown.push_str(line);
-                        markdown.push_str("\n```\n\n");
+                        push_fenced_code_block(&mut markdown, "json", line);
                     }
                 }
                 Err(_) => {
-                    markdown.push_str("## unparsed_event\n\n```text\n");
-                    markdown.push_str(line);
-                    markdown.push_str("\n```\n\n");
+                    markdown.push_str("## unparsed_event\n\n");
+                    push_fenced_code_block(&mut markdown, "text", line);
                 }
             }
         }
@@ -249,14 +244,43 @@ fn write_transcript_markdown(record: &SessionAuditRecord, events: &str) -> Resul
     Ok(())
 }
 
+fn push_fenced_code_block(markdown: &mut String, language: &str, content: &str) {
+    let fence = "`".repeat(max_consecutive_backticks(content).saturating_add(1).max(3));
+    markdown.push_str(&fence);
+    markdown.push_str(language);
+    markdown.push('\n');
+    markdown.push_str(content);
+    if !content.ends_with('\n') {
+        markdown.push('\n');
+    }
+    markdown.push_str(&fence);
+    markdown.push_str("\n\n");
+}
+
+fn max_consecutive_backticks(content: &str) -> usize {
+    let mut current = 0;
+    let mut max = 0;
+    for character in content.chars() {
+        if character == '`' {
+            current += 1;
+            max = max.max(current);
+        } else {
+            current = 0;
+        }
+    }
+    max
+}
+
 fn transcript_coverage(events: &str) -> &'static str {
     if events.trim().is_empty() {
         return "outer_streams_only";
     }
-    if events
-        .lines()
-        .any(|line| line.contains("\"source\":\"runa-mcp\""))
-    {
+    if events.lines().filter(|line| !line.trim().is_empty()).any(
+        |line| match serde_json::from_str::<Value>(line) {
+            Ok(event) => event.get("source").and_then(Value::as_str) == Some("runa-mcp"),
+            Err(_) => false,
+        },
+    ) {
         "full"
     } else {
         "missing_mcp_events"
@@ -1060,6 +1084,111 @@ mod tests {
         make_tree_writable(&root);
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_creates_empty_events_jsonl_when_no_events_were_emitted() {
+        let root = unique_test_dir("agentd-audit-empty-transcript");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "empty-transcript",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+
+        super::finalize_session_transcript(&record).expect("transcript should finalize");
+
+        let events_path = record.transcript_dir.join("events.jsonl");
+        let events =
+            fs::read_to_string(&events_path).expect("empty structured transcript should exist");
+        assert!(
+            events.is_empty(),
+            "empty jsonl file should contain no events"
+        );
+        for line in events.lines() {
+            let _event: Value = serde_json::from_str(line).expect("jsonl line should be json");
+        }
+
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("transcript manifest should exist"),
+        )
+        .expect("manifest should be json");
+        assert_eq!(manifest["coverage"], "outer_streams_only");
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn write_transcript_markdown_uses_a_wrapper_fence_longer_than_content_fences() {
+        let root = unique_test_dir("agentd-audit-fenced-transcript");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "fenced-transcript",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let content = "example\n```python\nprint('hello')\n```\n```json\n{\"ok\":true}\n```\n```toml\nname = \"agentd\"\n```";
+        let event = serde_json::json!({
+            "schema_version": 1,
+            "source": "runa",
+            "kind": "agent_output",
+            "content": content,
+        });
+        fs::write(
+            record.transcript_dir.join("events.jsonl"),
+            format!("{event}\n"),
+        )
+        .expect("events jsonl should be writable");
+
+        super::finalize_session_transcript(&record).expect("transcript should finalize");
+
+        let markdown = fs::read_to_string(record.transcript_dir.join("transcript.md"))
+            .expect("human-readable transcript should exist");
+        let expected_block = format!("````text\n{content}\n````\n\n");
+        assert!(
+            markdown.contains(&expected_block),
+            "outer fence should remain open around fenced content:\n{markdown}"
+        );
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn transcript_coverage_uses_parsed_event_sources() {
+        assert_eq!(super::transcript_coverage(""), "outer_streams_only");
+        assert_eq!(
+            super::transcript_coverage(
+                r#"{"schema_version":1,"source":"runa","kind":"agent_input"}"#
+            ),
+            "missing_mcp_events"
+        );
+        assert_eq!(
+            super::transcript_coverage(
+                r#"{"schema_version":1,"source": "runa-mcp","kind":"tool_call"}"#
+            ),
+            "full"
+        );
+        assert_eq!(
+            super::transcript_coverage(
+                r#"{"schema_version":1,"source":"runa","kind":"agent_output","content":"{\"source\":\"runa-mcp\"}"}"#
+            ),
+            "missing_mcp_events"
+        );
     }
 
     #[test]

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -1,5 +1,6 @@
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
+use serde_json::Value;
 #[cfg(test)]
 use std::cell::Cell;
 use std::fs::{self, File, OpenOptions};
@@ -13,6 +14,7 @@ const METADATA_SCHEMA_VERSION: u32 = 2;
 const ACTIVE_AUDIT_DIRECTORY_MODE: u32 = 0o755;
 const SEALED_FILE_MODE: u32 = 0o444;
 const SEALED_DIRECTORY_MODE: u32 = 0o555;
+const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
 
 #[cfg(test)]
 std::thread_local! {
@@ -24,6 +26,7 @@ std::thread_local! {
 pub(crate) struct SessionAuditRecord {
     pub(crate) record_dir: PathBuf,
     pub(crate) runa_dir: PathBuf,
+    pub(crate) transcript_dir: PathBuf,
     pub(crate) metadata_path: PathBuf,
     pub(crate) session_id: String,
     pub(crate) agent: String,
@@ -72,21 +75,24 @@ fn prepare_session_audit_record_at(
     let record_dir = agent_dir.join(session_id);
     let runa_dir = record_dir.join("runa");
     let agentd_dir = record_dir.join("agentd");
+    let transcript_dir = agentd_dir.join("transcript");
     let metadata_path = agentd_dir.join("session.json");
 
     fs::create_dir_all(&runa_dir)?;
-    fs::create_dir_all(&agentd_dir)?;
+    fs::create_dir_all(&transcript_dir)?;
 
     rollback_record_dir_on_error(&record_dir, || {
         set_active_audit_directory_permissions(&agent_dir)?;
         set_active_audit_directory_permissions(&record_dir)?;
         set_active_audit_directory_permissions(&agentd_dir)?;
+        set_active_runa_permissions(&transcript_dir)?;
         set_active_runa_permissions(&runa_dir)?;
 
         let start_timestamp = current_timestamp()?;
         let record = SessionAuditRecord {
             record_dir: record_dir.clone(),
             runa_dir: runa_dir.clone(),
+            transcript_dir: transcript_dir.clone(),
             metadata_path: metadata_path.clone(),
             session_id: session_id.to_string(),
             agent: spec.agent_name.clone(),
@@ -114,6 +120,20 @@ pub(crate) fn finalize_session_audit_record(
 
     seal_session_audit_record(record)?;
     write_finalized_session_audit_metadata(record, &end_timestamp, outcome, exit_code)
+}
+
+pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result<(), RunnerError> {
+    fs::create_dir_all(&record.transcript_dir)?;
+    let events_path = record.transcript_dir.join("events.jsonl");
+    let events = match fs::read_to_string(&events_path) {
+        Ok(events) => events,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let coverage = transcript_coverage(&events);
+    write_transcript_manifest(record, coverage)?;
+    write_transcript_markdown(record, &events)?;
+    Ok(())
 }
 
 fn write_session_audit_metadata(
@@ -169,6 +189,78 @@ fn current_timestamp() -> Result<String, RunnerError> {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .map_err(|error| RunnerError::Io(std::io::Error::other(error)))
+}
+
+#[derive(Debug, Serialize)]
+struct TranscriptManifest<'a> {
+    schema_version: u32,
+    coverage: &'a str,
+}
+
+fn write_transcript_manifest(
+    record: &SessionAuditRecord,
+    coverage: &str,
+) -> Result<(), RunnerError> {
+    let manifest = TranscriptManifest {
+        schema_version: TRANSCRIPT_SCHEMA_VERSION,
+        coverage,
+    };
+    let mut payload = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| RunnerError::Io(std::io::Error::other(error)))?;
+    payload.push(b'\n');
+    fs::write(record.transcript_dir.join("manifest.json"), payload)?;
+    Ok(())
+}
+
+fn write_transcript_markdown(record: &SessionAuditRecord, events: &str) -> Result<(), RunnerError> {
+    let mut markdown = String::from("# Session Transcript\n\n");
+    if events.trim().is_empty() {
+        markdown.push_str("_No structured transcript events were emitted._\n");
+    } else {
+        for line in events.lines().filter(|line| !line.trim().is_empty()) {
+            match serde_json::from_str::<Value>(line) {
+                Ok(event) => {
+                    let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
+                    markdown.push_str("## ");
+                    markdown.push_str(kind);
+                    markdown.push_str("\n\n");
+                    if let Some(content) = event.get("content").and_then(Value::as_str) {
+                        markdown.push_str("```text\n");
+                        markdown.push_str(content);
+                        if !content.ends_with('\n') {
+                            markdown.push('\n');
+                        }
+                        markdown.push_str("```\n\n");
+                    } else {
+                        markdown.push_str("```json\n");
+                        markdown.push_str(line);
+                        markdown.push_str("\n```\n\n");
+                    }
+                }
+                Err(_) => {
+                    markdown.push_str("## unparsed_event\n\n```text\n");
+                    markdown.push_str(line);
+                    markdown.push_str("\n```\n\n");
+                }
+            }
+        }
+    }
+    fs::write(record.transcript_dir.join("transcript.md"), markdown)?;
+    Ok(())
+}
+
+fn transcript_coverage(events: &str) -> &'static str {
+    if events.trim().is_empty() {
+        return "outer_streams_only";
+    }
+    if events
+        .lines()
+        .any(|line| line.contains("\"source\":\"runa-mcp\""))
+    {
+        "full"
+    } else {
+        "missing_mcp_events"
+    }
 }
 
 fn rollback_record_dir_on_error<T, F>(record_dir: &Path, init: F) -> Result<T, RunnerError>

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -3,9 +3,10 @@ use serde::Serialize;
 use serde_json::Value;
 #[cfg(test)]
 use std::cell::Cell;
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
@@ -15,6 +16,9 @@ const ACTIVE_AUDIT_DIRECTORY_MODE: u32 = 0o755;
 const SEALED_FILE_MODE: u32 = 0o444;
 const SEALED_DIRECTORY_MODE: u32 = 0o555;
 const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+const EVENTS_ARTIFACT: &str = "events.jsonl";
+const MANIFEST_ARTIFACT: &str = "manifest.json";
+const MARKDOWN_ARTIFACT: &str = "transcript.md";
 
 #[cfg(test)]
 std::thread_local! {
@@ -55,6 +59,18 @@ struct SessionAuditMetadata<'a> {
     outcome: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     exit_code: Option<i32>,
+}
+
+#[derive(Debug)]
+struct TranscriptFinalizationFailure {
+    artifact: &'static str,
+    error: RunnerError,
+}
+
+impl fmt::Display for TranscriptFinalizationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
 }
 
 pub(crate) fn prepare_session_audit_record(
@@ -124,18 +140,27 @@ pub(crate) fn finalize_session_audit_record(
 
 pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result<(), RunnerError> {
     fs::create_dir_all(&record.transcript_dir)?;
-    let events_path = record.transcript_dir.join("events.jsonl");
-    let events = match fs::read_to_string(&events_path) {
-        Ok(events) => events,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            fs::write(&events_path, [])?;
-            String::new()
+    match finalize_session_transcript_artifacts(record) {
+        Ok(()) => Ok(()),
+        Err(failure) => {
+            let failure_message = failure.to_string();
+            if failure.artifact != MANIFEST_ARTIFACT {
+                write_transcript_manifest(record, "finalization_failed", Some(&failure_message))
+                    .map_err(|manifest_failure| manifest_failure.error)?;
+            }
+            Err(failure.error)
         }
-        Err(error) => return Err(error.into()),
-    };
+    }
+}
+
+fn finalize_session_transcript_artifacts(
+    record: &SessionAuditRecord,
+) -> Result<(), TranscriptFinalizationFailure> {
+    let events_path = record.transcript_dir.join(EVENTS_ARTIFACT);
+    let events = read_or_create_transcript_events(&events_path)?;
     let coverage = transcript_coverage(&events);
-    write_transcript_manifest(record, coverage)?;
     write_transcript_markdown(record, &events)?;
+    write_transcript_manifest(record, coverage, None)?;
     Ok(())
 }
 
@@ -198,24 +223,42 @@ fn current_timestamp() -> Result<String, RunnerError> {
 struct TranscriptManifest<'a> {
     schema_version: u32,
     coverage: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finalization_error: Option<&'a str>,
+}
+
+fn write_transcript_manifest_payload(
+    record: &SessionAuditRecord,
+    manifest: TranscriptManifest<'_>,
+) -> Result<(), TranscriptFinalizationFailure> {
+    let mut payload = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| artifact_failure(MANIFEST_ARTIFACT, std::io::Error::other(error)))?;
+    payload.push(b'\n');
+    write_new_transcript_artifact(
+        &record.transcript_dir.join(MANIFEST_ARTIFACT),
+        MANIFEST_ARTIFACT,
+        &payload,
+    )?;
+    Ok(())
 }
 
 fn write_transcript_manifest(
     record: &SessionAuditRecord,
     coverage: &str,
-) -> Result<(), RunnerError> {
+    finalization_error: Option<&str>,
+) -> Result<(), TranscriptFinalizationFailure> {
     let manifest = TranscriptManifest {
         schema_version: TRANSCRIPT_SCHEMA_VERSION,
         coverage,
+        finalization_error,
     };
-    let mut payload = serde_json::to_vec_pretty(&manifest)
-        .map_err(|error| RunnerError::Io(std::io::Error::other(error)))?;
-    payload.push(b'\n');
-    fs::write(record.transcript_dir.join("manifest.json"), payload)?;
-    Ok(())
+    write_transcript_manifest_payload(record, manifest)
 }
 
-fn write_transcript_markdown(record: &SessionAuditRecord, events: &str) -> Result<(), RunnerError> {
+fn write_transcript_markdown(
+    record: &SessionAuditRecord,
+    events: &str,
+) -> Result<(), TranscriptFinalizationFailure> {
     let mut markdown = String::from("# Session Transcript\n\n");
     if events.trim().is_empty() {
         markdown.push_str("_No structured transcript events were emitted._\n");
@@ -240,8 +283,108 @@ fn write_transcript_markdown(record: &SessionAuditRecord, events: &str) -> Resul
             }
         }
     }
-    fs::write(record.transcript_dir.join("transcript.md"), markdown)?;
+    write_new_transcript_artifact(
+        &record.transcript_dir.join(MARKDOWN_ARTIFACT),
+        MARKDOWN_ARTIFACT,
+        markdown.as_bytes(),
+    )?;
     Ok(())
+}
+
+fn read_or_create_transcript_events(path: &Path) -> Result<String, TranscriptFinalizationFailure> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            create_empty_transcript_artifact(path, EVENTS_ARTIFACT)?;
+            return Ok(String::new());
+        }
+        Err(error) => return Err(artifact_failure(EVENTS_ARTIFACT, error)),
+    };
+
+    if !metadata.is_file() {
+        return Err(unsafe_artifact_failure(
+            EVENTS_ARTIFACT,
+            "is not a regular file",
+        ));
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| match error.raw_os_error() {
+            Some(libc::ELOOP) => unsafe_artifact_failure(EVENTS_ARTIFACT, "is not a regular file"),
+            _ => artifact_failure(EVENTS_ARTIFACT, error),
+        })?;
+    if !file
+        .metadata()
+        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?
+        .is_file()
+    {
+        return Err(unsafe_artifact_failure(
+            EVENTS_ARTIFACT,
+            "is not a regular file",
+        ));
+    }
+
+    let mut events = String::new();
+    file.read_to_string(&mut events)
+        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
+    Ok(events)
+}
+
+fn create_empty_transcript_artifact(
+    path: &Path,
+    artifact: &'static str,
+) -> Result<(), TranscriptFinalizationFailure> {
+    let file = create_new_transcript_artifact(path, artifact)?;
+    drop(file);
+    Ok(())
+}
+
+fn write_new_transcript_artifact(
+    path: &Path,
+    artifact: &'static str,
+    payload: &[u8],
+) -> Result<(), TranscriptFinalizationFailure> {
+    let mut file = create_new_transcript_artifact(path, artifact)?;
+    file.write_all(payload)
+        .map_err(|error| artifact_failure(artifact, error))?;
+    Ok(())
+}
+
+fn create_new_transcript_artifact(
+    path: &Path,
+    artifact: &'static str,
+) -> Result<File, TranscriptFinalizationFailure> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                unsafe_artifact_failure(artifact, "already exists")
+            } else {
+                artifact_failure(artifact, error)
+            }
+        })
+}
+
+fn artifact_failure(
+    artifact: &'static str,
+    error: std::io::Error,
+) -> TranscriptFinalizationFailure {
+    TranscriptFinalizationFailure {
+        artifact,
+        error: RunnerError::Io(error),
+    }
+}
+
+fn unsafe_artifact_failure(artifact: &'static str, reason: &str) -> TranscriptFinalizationFailure {
+    artifact_failure(
+        artifact,
+        std::io::Error::other(format!("unsafe transcript artifact: {artifact} {reason}")),
+    )
 }
 
 fn push_fenced_code_block(markdown: &mut String, language: &str, content: &str) {
@@ -508,6 +651,9 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     fn unique_test_dir(prefix: &str) -> PathBuf {
         std::env::temp_dir().join(format!(
@@ -1122,6 +1268,191 @@ mod tests {
         )
         .expect("manifest should be json");
         assert_eq!(manifest["coverage"], "outer_streams_only");
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_rejects_symlinked_events_jsonl_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_test_dir("agentd-audit-symlinked-transcript-events");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "symlinked-events",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let outside_target = root.join("outside-events.jsonl");
+        fs::write(&outside_target, "outside secret\n").expect("outside target should be created");
+        symlink(&outside_target, record.transcript_dir.join("events.jsonl"))
+            .expect("symlinked events artifact should be created");
+
+        let error = super::finalize_session_transcript(&record)
+            .expect_err("symlinked transcript events should fail finalization");
+
+        assert!(
+            error.to_string().contains("events.jsonl"),
+            "error should name the unsafe artifact: {error}"
+        );
+        assert_eq!(
+            fs::read_to_string(&outside_target).expect("outside target should remain readable"),
+            "outside secret\n"
+        );
+        assert_eq!(
+            fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("failure manifest should be written"),
+            "{\n  \"schema_version\": 1,\n  \"coverage\": \"finalization_failed\",\n  \"finalization_error\": \"unsafe transcript artifact: events.jsonl is not a regular file\"\n}\n"
+        );
+
+        fs::remove_file(record.transcript_dir.join("events.jsonl"))
+            .expect("symlink should be removable");
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_rejects_fifo_events_jsonl_without_hanging() {
+        let root = unique_test_dir("agentd-audit-fifo-transcript-events");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "fifo-events",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let fifo_path = record.transcript_dir.join("events.jsonl");
+        let status = Command::new("mkfifo")
+            .arg(&fifo_path)
+            .status()
+            .expect("mkfifo should run");
+        assert!(status.success(), "mkfifo should create events fifo");
+
+        let finalize_record = record.clone();
+        let handle = thread::spawn(move || super::finalize_session_transcript(&finalize_record));
+        let deadline = Instant::now() + Duration::from_millis(250);
+        while Instant::now() < deadline && !handle.is_finished() {
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            handle.is_finished(),
+            "transcript finalization must not hang on fifo events"
+        );
+        let error = handle
+            .join()
+            .expect("finalization thread should not panic")
+            .expect_err("fifo transcript events should fail finalization");
+        assert!(
+            error.to_string().contains("events.jsonl"),
+            "error should name the unsafe artifact: {error}"
+        );
+
+        fs::remove_file(&fifo_path).expect("fifo should be removable");
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_rejects_preexisting_transcript_markdown_without_overwriting_it()
+    {
+        let root = unique_test_dir("agentd-audit-preexisting-transcript-markdown");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "preexisting-markdown",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        fs::write(
+            record.transcript_dir.join("events.jsonl"),
+            "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\"}\n",
+        )
+        .expect("events jsonl should be created");
+        fs::write(record.transcript_dir.join("transcript.md"), "preexisting\n")
+            .expect("preexisting markdown should be created");
+
+        let error = super::finalize_session_transcript(&record)
+            .expect_err("preexisting markdown should fail finalization");
+
+        assert!(
+            error.to_string().contains("transcript.md"),
+            "error should name the preexisting artifact: {error}"
+        );
+        assert_eq!(
+            fs::read_to_string(record.transcript_dir.join("transcript.md"))
+                .expect("preexisting markdown should remain readable"),
+            "preexisting\n"
+        );
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("failure manifest should be written"),
+        )
+        .expect("failure manifest should be json");
+        assert_eq!(manifest["coverage"], "finalization_failed");
+        assert!(
+            manifest["finalization_error"]
+                .as_str()
+                .expect("failure error should be a string")
+                .contains("transcript.md")
+        );
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_rejects_preexisting_manifest_without_overwriting_it() {
+        let root = unique_test_dir("agentd-audit-preexisting-transcript-manifest");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "preexisting-manifest",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        fs::write(
+            record.transcript_dir.join("events.jsonl"),
+            "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\"}\n",
+        )
+        .expect("events jsonl should be created");
+        fs::write(record.transcript_dir.join("manifest.json"), "preexisting\n")
+            .expect("preexisting manifest should be created");
+
+        let error = super::finalize_session_transcript(&record)
+            .expect_err("preexisting manifest should fail finalization");
+
+        assert!(
+            error.to_string().contains("manifest.json"),
+            "error should name the preexisting artifact: {error}"
+        );
+        assert_eq!(
+            fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("preexisting manifest should remain readable"),
+            "preexisting\n"
+        );
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -516,6 +516,13 @@ fn set_active_audit_directory_permissions(path: &Path) -> Result<(), RunnerError
 }
 
 fn prepare_transcript_tree_for_finalization(path: &Path) -> Result<(), RunnerError> {
+    ensure_transcript_directory(path)?;
+    prepare_audit_tree_for_traversal(path)?;
+    preflight_validate_sealable_tree(path)?;
+    repair_transcript_path_permissions(path)
+}
+
+fn ensure_transcript_directory(path: &Path) -> Result<(), RunnerError> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() || !metadata.is_dir() {
@@ -531,7 +538,7 @@ fn prepare_transcript_tree_for_finalization(path: &Path) -> Result<(), RunnerErr
         Err(error) => return Err(RunnerError::Io(error)),
     }
 
-    repair_transcript_path_permissions(path)
+    Ok(())
 }
 
 fn repair_transcript_path_permissions(path: &Path) -> Result<(), RunnerError> {
@@ -1472,6 +1479,63 @@ mod tests {
         )
         .expect("manifest should be json");
         assert_eq!(manifest["coverage"], "full");
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_refuses_hard_linked_events_jsonl_without_chmoding_target() {
+        let root = unique_test_dir("agentd-audit-transcript-hard-link");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "transcript-hard-link",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let runa_target = record.runa_dir.join("events-source.jsonl");
+        fs::write(
+            &runa_target,
+            "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\"}\n",
+        )
+        .expect("runa target should be created");
+        fs::set_permissions(&runa_target, fs::Permissions::from_mode(0o000))
+            .expect("runa target should start unreadable");
+        fs::hard_link(&runa_target, record.transcript_dir.join("events.jsonl"))
+            .expect("hard-linked transcript events should be created");
+
+        let before_mode = fs::metadata(&runa_target)
+            .expect("runa target metadata should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        let result = super::finalize_session_transcript(&record);
+
+        let after_mode = fs::metadata(&runa_target)
+            .expect("runa target metadata should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        if after_mode == 0o000 {
+            let _ = fs::set_permissions(&runa_target, fs::Permissions::from_mode(0o600));
+        }
+        let error =
+            result.expect_err("hard-linked transcript events should fail before permission repair");
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to seal multi-linked audit entry"),
+            "error should come from hard-link preflight: {error}"
+        );
+        assert_eq!(before_mode, 0o000);
+        assert_eq!(after_mode, 0o000);
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -14,7 +14,7 @@ use crate::podman::{run_podman_command, run_podman_command_until};
 use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
 use crate::session_paths::{
     session_home_dir, session_internal_audit_dir, session_internal_audit_runa_dir,
-    session_repo_dir, session_repo_runa_dir,
+    session_repo_dir, session_repo_runa_dir, session_transcript_mount_dir,
 };
 use crate::types::{BindMount, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
@@ -33,6 +33,8 @@ const SESSION_GROUP_ID: u32 = 1000;
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
 const METHODOLOGY_MANIFEST_PATH: &str = "/agentd/methodology/manifest.toml";
 const PODMAN_INFRASTRUCTURE_ERROR_EXIT_CODE: i32 = 125;
+const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
+const TRANSCRIPT_REDACT_ENV: &str = "RUNA_TRANSCRIPT_REDACT_ENV";
 
 pub(crate) fn create_container(
     resources: &SessionResources,
@@ -226,6 +228,17 @@ fn build_container_script(
     } else {
         script.push_str("\nunset AGENTD_WORK_UNIT");
     }
+    script.push_str("\nexport ");
+    script.push_str(TRANSCRIPT_DIR_ENV);
+    script.push('=');
+    script.push_str(&shell_quote(
+        &session_transcript_mount_dir().display().to_string(),
+    ));
+    let redact_env = transcript_redact_environment(spec, invocation);
+    script.push_str("\nexport ");
+    script.push_str(TRANSCRIPT_REDACT_ENV);
+    script.push('=');
+    script.push_str(&shell_quote(&redact_env));
     script.push_str("\ngosu ");
     script.push_str(&shell_quote(&user_group));
     script.push_str(" runa init --methodology ");
@@ -334,6 +347,22 @@ fn build_clone_command(invocation: &SessionInvocation, repo_dir: &str) -> String
     command
 }
 
+fn transcript_redact_environment(spec: &SessionSpec, invocation: &SessionInvocation) -> String {
+    let mut names = spec
+        .environment
+        .iter()
+        .map(|variable| variable.name.as_str())
+        .collect::<Vec<_>>();
+    if invocation
+        .repo_token
+        .as_deref()
+        .is_some_and(|token| !token.is_empty())
+    {
+        names.push(REPO_TOKEN_ENV);
+    }
+    names.join(",")
+}
+
 fn build_create_container_args(
     resources: &SessionResources,
     spec: &SessionSpec,
@@ -357,6 +386,7 @@ fn build_create_container_args(
     );
 
     push_prepared_bind_mount_arg(&mut args, &resources.audit_mount);
+    push_prepared_bind_mount_arg(&mut args, &resources.transcript_mount);
 
     if let Some(mount) = &resources.invocation_input_mount {
         push_prepared_bind_mount_arg(&mut args, mount);

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -17,7 +17,9 @@ use crate::session_paths::{
     session_repo_dir, session_repo_runa_dir, session_transcript_mount_dir,
 };
 use crate::types::{BindMount, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
-use crate::validation::{REPO_TOKEN_ENV, runner_managed_environment};
+use crate::validation::{
+    REPO_TOKEN_ENV, TRANSCRIPT_DIR_ENV, TRANSCRIPT_REDACT_ENV, runner_managed_environment,
+};
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::os::unix::process::ExitStatusExt;
@@ -33,8 +35,6 @@ const SESSION_GROUP_ID: u32 = 1000;
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
 const METHODOLOGY_MANIFEST_PATH: &str = "/agentd/methodology/manifest.toml";
 const PODMAN_INFRASTRUCTURE_ERROR_EXIT_CODE: i32 = 125;
-const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
-const TRANSCRIPT_REDACT_ENV: &str = "RUNA_TRANSCRIPT_REDACT_ENV";
 
 pub(crate) fn create_container(
     resources: &SessionResources,

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -19,6 +19,7 @@ fn test_audit_record() -> SessionAuditRecord {
     SessionAuditRecord {
         record_dir: PathBuf::from("/tmp/audit/site-builder/0123456789abcdef"),
         runa_dir: PathBuf::from("/tmp/audit/site-builder/0123456789abcdef/runa"),
+        transcript_dir: PathBuf::from("/tmp/audit/site-builder/0123456789abcdef/agentd/transcript"),
         metadata_path: PathBuf::from(
             "/tmp/audit/site-builder/0123456789abcdef/agentd/session.json",
         ),
@@ -41,6 +42,12 @@ fn create_container_args_include_shared_relabel_for_methodology_mount() {
             audit_mount: PreparedBindMount {
                 source: PathBuf::from("/tmp/staging/audit-runa"),
                 target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
+            transcript_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/transcript"),
+                target: PathBuf::from("/agentd/transcript"),
                 read_only: false,
                 relabel_shared: true,
             },
@@ -83,6 +90,12 @@ fn create_container_args_use_volume_for_shared_relabel_sources_containing_commas
                 read_only: false,
                 relabel_shared: true,
             },
+            transcript_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/transcript,with,commas"),
+                target: PathBuf::from("/agentd/transcript"),
+                read_only: false,
+                relabel_shared: true,
+            },
             invocation_input_mount: None,
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
@@ -105,6 +118,7 @@ fn create_container_args_use_volume_for_shared_relabel_sources_containing_commas
         vec![
             "/tmp/source,with,commas/methodology:/agentd/methodology:ro,z".to_string(),
             "/tmp/audit,with,commas/runa:/home/site-builder/.agentd/audit/runa:rw,z".to_string(),
+            "/tmp/transcript,with,commas:/agentd/transcript:rw,z".to_string(),
         ]
     );
     assert!(
@@ -124,6 +138,12 @@ fn create_container_args_force_root_user_and_entrypoint_before_image_argument() 
             audit_mount: PreparedBindMount {
                 source: PathBuf::from("/tmp/staging/audit-runa"),
                 target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
+            transcript_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/transcript"),
+                target: PathBuf::from("/agentd/transcript"),
                 read_only: false,
                 relabel_shared: true,
             },
@@ -175,6 +195,12 @@ fn create_container_args_map_daemon_identity_to_session_user_id() {
             audit_mount: PreparedBindMount {
                 source: PathBuf::from("/tmp/staging/audit-runa"),
                 target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+                read_only: false,
+                relabel_shared: true,
+            },
+            transcript_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/transcript"),
+                target: PathBuf::from("/agentd/transcript"),
                 read_only: false,
                 relabel_shared: true,
             },
@@ -232,6 +258,12 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
                 read_only: false,
                 relabel_shared: true,
             },
+            transcript_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/transcript"),
+                target: PathBuf::from("/agentd/transcript"),
+                read_only: false,
+                relabel_shared: true,
+            },
             invocation_input_mount: None,
             additional_mounts: Vec::new(),
             environment_secret_bindings: Vec::new(),
@@ -268,6 +300,12 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
                 read_only: false,
                 relabel_shared: true,
             },
+            transcript_mount: PreparedBindMount {
+                source: PathBuf::from("/tmp/staging/transcript"),
+                target: PathBuf::from("/agentd/transcript"),
+                read_only: false,
+                relabel_shared: true,
+            },
             invocation_input_mount: None,
             additional_mounts: vec![
                 PreparedBindMount {
@@ -298,27 +336,31 @@ fn create_container_args_include_configured_additional_mounts_after_methodology_
     );
 
     let mount_values = argument_values(&args, "--mount");
-    assert_eq!(mount_values.len(), 4);
+    assert_eq!(mount_values.len(), 5);
     assert!(mount_values[0].contains("src=/tmp/staging/methodology"));
     assert!(mount_values[1].contains("src=/tmp/staging/audit-runa"));
     assert!(mount_values[1].contains("target=/home/site-builder/.agentd/audit/runa"));
     assert!(mount_values[1].contains("ro=false"));
     assert!(mount_values[1].contains("relabel=shared"));
-    assert!(mount_values[2].contains("src=/tmp/staging/mount-0"));
-    assert!(mount_values[2].contains("target=/home/site-builder/.claude"));
-    assert!(mount_values[2].contains("ro=true"));
-    assert!(
-        !mount_values[2].contains("relabel="),
-        "operator-declared mounts should not mutate host SELinux labels: {}",
-        mount_values[2]
-    );
-    assert!(mount_values[3].contains("src=/tmp/staging/mount-1"));
-    assert!(mount_values[3].contains("target=/home/site-builder/.runa"));
-    assert!(mount_values[3].contains("ro=false"));
+    assert!(mount_values[2].contains("src=/tmp/staging/transcript"));
+    assert!(mount_values[2].contains("target=/agentd/transcript"));
+    assert!(mount_values[2].contains("ro=false"));
+    assert!(mount_values[2].contains("relabel=shared"));
+    assert!(mount_values[3].contains("src=/tmp/staging/mount-0"));
+    assert!(mount_values[3].contains("target=/home/site-builder/.claude"));
+    assert!(mount_values[3].contains("ro=true"));
     assert!(
         !mount_values[3].contains("relabel="),
         "operator-declared mounts should not mutate host SELinux labels: {}",
         mount_values[3]
+    );
+    assert!(mount_values[4].contains("src=/tmp/staging/mount-1"));
+    assert!(mount_values[4].contains("target=/home/site-builder/.runa"));
+    assert!(mount_values[4].contains("ro=false"));
+    assert!(
+        !mount_values[4].contains("relabel="),
+        "operator-declared mounts should not mutate host SELinux labels: {}",
+        mount_values[4]
     );
 }
 
@@ -435,6 +477,8 @@ fn build_container_script_uses_mode_based_audit_mount_writability_without_chown(
             "\nln -s '/home/myagent/.agentd/audit/runa' '/home/myagent/repo/.runa'\n\
              export HOME='/home/myagent'\n\
              unset AGENTD_WORK_UNIT\n\
+             export RUNA_TRANSCRIPT_DIR='/agentd/transcript'\n\
+             export RUNA_TRANSCRIPT_REDACT_ENV=''\n\
              gosu 'myagent:myagent' runa init"
         ),
         "audit mount root should rely on host-side mode setup before runa init: {script}"

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -37,7 +37,10 @@ pub use validation::{
     validate_repo_url,
 };
 
-use audit::{SessionAuditCompletion, finalize_session_audit_record, prepare_session_audit_record};
+use audit::{
+    SessionAuditCompletion, finalize_session_audit_record, finalize_session_transcript,
+    prepare_session_audit_record,
+};
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
 use input::resolve_invocation_input;
 use lifecycle::{
@@ -264,6 +267,7 @@ fn finalize_session_audit_record_if_cleanup_succeeded(
         return Ok(());
     }
 
+    finalize_session_transcript(record)?;
     finalize_session_audit_record(record, completion)
 }
 
@@ -288,6 +292,7 @@ mod tests {
     };
     use serde_json::Value;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::thread;
     use std::time::{Duration, Instant};
@@ -318,6 +323,24 @@ mod tests {
                 .expect("session metadata should be readable"),
         )
         .expect("session metadata should be valid json")
+    }
+
+    fn make_tree_writable(path: &Path) {
+        let metadata = fs::symlink_metadata(path).expect("path metadata should exist");
+        if metadata.file_type().is_symlink() {
+            return;
+        }
+
+        if metadata.is_dir() {
+            for entry in fs::read_dir(path).expect("directory should be readable") {
+                let entry = entry.expect("directory entry should be readable");
+                make_tree_writable(&entry.path());
+            }
+        }
+
+        let writable_mode = metadata.permissions().mode() | 0o700;
+        fs::set_permissions(path, fs::Permissions::from_mode(writable_mode))
+            .expect("path should become writable for cleanup");
     }
 
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
@@ -407,6 +430,7 @@ mod tests {
         );
         assert_eq!(metadata["outcome"], "success");
 
+        make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
@@ -552,6 +576,7 @@ mod tests {
             "allocation rollback failure must leave the top-level runa dir in its active writable mode"
         );
 
+        make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
@@ -637,6 +662,7 @@ mod tests {
             "cleanup failure must not seal the top-level runa dir"
         );
 
+        make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
@@ -729,6 +755,7 @@ mod tests {
             "cleanup failure must not seal the top-level runa dir"
         );
 
+        make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
@@ -831,6 +858,7 @@ mod tests {
 
         fs::set_permissions(record_dir.join("agentd"), fs::Permissions::from_mode(0o755))
             .expect("agentd dir should become removable for test cleanup");
+        make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 
@@ -947,6 +975,7 @@ mod tests {
             .expect("direct dir should become removable for test cleanup");
         fs::set_permissions(record_dir.join("runa"), fs::Permissions::from_mode(0o755))
             .expect("runa dir should become removable for test cleanup");
+        make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
     }
 

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -10,7 +10,7 @@ use crate::input::{INVOCATION_INPUT_MOUNT_PATH, ResolvedInvocationInput};
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::naming::{SESSION_ID_LEN, format_secret_name};
 use crate::podman::run_podman_command_with_input;
-use crate::session_paths::session_internal_audit_runa_dir;
+use crate::session_paths::{session_internal_audit_runa_dir, session_transcript_mount_dir};
 use crate::types::{RunnerError, SessionInvocation, SessionSpec};
 use crate::validation::REPO_TOKEN_ENV;
 use getrandom::fill as fill_random_bytes;
@@ -47,6 +47,7 @@ pub(crate) struct SessionResources {
     pub(crate) methodology_mount_source: PathBuf,
     pub(crate) audit_record: SessionAuditRecord,
     pub(crate) audit_mount: PreparedBindMount,
+    pub(crate) transcript_mount: PreparedBindMount,
     pub(crate) invocation_input_mount: Option<PreparedBindMount>,
     pub(crate) additional_mounts: Vec<PreparedBindMount>,
     pub(crate) environment_secret_bindings: Vec<SecretBinding>,
@@ -122,6 +123,17 @@ pub(crate) fn prepare_session_resources(
             ));
         }
     };
+    let transcript_mount = match create_transcript_mount(&audit_record) {
+        Ok(mount) => mount,
+        Err(error) => {
+            return Err(rollback_failed_staging_dir_allocation(
+                container_name,
+                session_id,
+                &methodology_staging_dir,
+                error,
+            ));
+        }
+    };
     let methodology_mount_source =
         match canonical_mount_source(&spec.methodology_dir).and_then(|path| {
             validate_shared_relabel_mount_source(&path)?;
@@ -166,6 +178,7 @@ pub(crate) fn prepare_session_resources(
         methodology_mount_source,
         audit_record,
         audit_mount,
+        transcript_mount,
         invocation_input_mount,
         additional_mounts,
         environment_secret_bindings: Vec::new(),
@@ -350,6 +363,17 @@ fn create_audit_mount(
     )
 }
 
+fn create_transcript_mount(
+    audit_record: &SessionAuditRecord,
+) -> Result<PreparedBindMount, RunnerError> {
+    create_direct_prepared_bind_mount(
+        &audit_record.transcript_dir,
+        session_transcript_mount_dir(),
+        false,
+        true,
+    )
+}
+
 fn create_invocation_input_mount(
     resolved_input: Option<&ResolvedInvocationInput>,
     staging_dir: &Path,
@@ -518,18 +542,15 @@ mod tests {
     fn test_audit_record(session_id: &str) -> SessionAuditRecord {
         let record_dir = std::env::temp_dir().join(format!("agentd-audit-record-{session_id}"));
         let runa_dir = record_dir.join("runa");
+        let transcript_dir = record_dir.join("agentd/transcript");
         let metadata_path = record_dir.join("agentd/session.json");
         std::fs::create_dir_all(&runa_dir).expect("test runa dir should be created");
-        std::fs::create_dir_all(
-            metadata_path
-                .parent()
-                .expect("metadata path should have a parent"),
-        )
-        .expect("test metadata dir should be created");
+        std::fs::create_dir_all(&transcript_dir).expect("test transcript dir should be created");
 
         SessionAuditRecord {
             record_dir,
             runa_dir,
+            transcript_dir,
             metadata_path,
             session_id: session_id.to_string(),
             agent: "site-builder".to_string(),

--- a/crates/agentd-runner/src/session_paths.rs
+++ b/crates/agentd-runner/src/session_paths.rs
@@ -5,6 +5,7 @@ const REPO_DIR_NAME: &str = "repo";
 const INTERNAL_AGENTD_DIR_NAME: &str = ".agentd";
 const INTERNAL_AUDIT_DIR_NAME: &str = "audit";
 const INTERNAL_AUDIT_RUNA_DIR_NAME: &str = "runa";
+const TRANSCRIPT_MOUNT_PATH: &str = "/agentd/transcript";
 const REPO_RUNA_DIR_NAME: &str = ".runa";
 
 pub(crate) fn session_home_dir(agent_name: &str) -> PathBuf {
@@ -29,4 +30,8 @@ pub(crate) fn session_internal_audit_runa_dir(agent_name: &str) -> PathBuf {
 
 pub(crate) fn session_repo_runa_dir(agent_name: &str) -> PathBuf {
     session_repo_dir(agent_name).join(REPO_RUNA_DIR_NAME)
+}
+
+pub(crate) fn session_transcript_mount_dir() -> PathBuf {
+    PathBuf::from(TRANSCRIPT_MOUNT_PATH)
 }

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -48,6 +48,9 @@ pub struct SessionSpec {
     /// Caller-resolved environment variables injected into the container.
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
+    /// Names reserved for runner-owned values such as `AGENT_NAME`,
+    /// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
+    /// `RUNA_TRANSCRIPT_REDACT_ENV` are rejected during validation.
     pub environment: Vec<ResolvedEnvironmentVariable>,
 }
 
@@ -70,7 +73,7 @@ pub struct BindMount {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedEnvironmentVariable {
     /// Variable name. Must not be empty, contain `,` or `=`, or collide with
-    /// runner-managed names (currently `AGENT_NAME`).
+    /// runner-managed names.
     pub name: String,
     /// Variable value. Empty values are legal and are injected as direct
     /// `--env NAME=` assignments rather than podman secrets, which reject
@@ -408,10 +411,20 @@ impl fmt::Display for RunnerError {
                 "environment variable names must not be empty and must not contain ',' or '=': {name}"
             ),
             RunnerError::ReservedEnvironmentName { name } => {
-                write!(
-                    f,
-                    "environment variable name is reserved by the runner: {name}"
-                )
+                if matches!(
+                    name.as_str(),
+                    "RUNA_TRANSCRIPT_DIR" | "RUNA_TRANSCRIPT_REDACT_ENV"
+                ) {
+                    write!(
+                        f,
+                        "environment variable name is reserved by the runner: {name} (runner-owned; set internally by transcript subsystem)"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "environment variable name is reserved by the runner: {name}"
+                    )
+                }
             }
             RunnerError::InvalidMountSource { path } => {
                 write!(

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -23,6 +23,7 @@ const RESERVED_AGENT_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys
 const SUPPORTED_REPO_URL_FORMS: &str = "https://, http://, or git://";
 const SUPPORTED_REPO_URL_PREFIXES: [&str; 3] = ["https://", "http://", "git://"];
 const METHODOLOGY_MOUNT_PATH: &str = "/agentd/methodology";
+const TRANSCRIPT_MOUNT_PATH: &str = "/agentd/transcript";
 
 pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     if !is_daemon_instance_id(&spec.daemon_instance_id) {
@@ -294,6 +295,7 @@ fn is_reserved_mount_target(target: &Path, agent_name: &str) -> bool {
     let repo_dir = session_repo_dir(agent_name);
     let methodology_dir = Path::new(METHODOLOGY_MOUNT_PATH);
     let invocation_input_dir = Path::new(INVOCATION_INPUT_MOUNT_PATH);
+    let transcript_dir = Path::new(TRANSCRIPT_MOUNT_PATH);
 
     // Each rule states the invariant for one runner-owned path. Intentional
     // overlap is part of the contract: targets like `/home` or `/` can
@@ -307,6 +309,10 @@ fn is_reserved_mount_target(target: &Path, agent_name: &str) -> bool {
     }
 
     if target.starts_with(invocation_input_dir) || invocation_input_dir.starts_with(target) {
+        return true;
+    }
+
+    if target.starts_with(transcript_dir) || transcript_dir.starts_with(target) {
         return true;
     }
 
@@ -610,6 +616,26 @@ mod tests {
         match error {
             RunnerError::ReservedMountTarget { target } => {
                 assert_eq!(target, PathBuf::from("/agentd/invocation-input"));
+            }
+            other => panic!("expected ReservedMountTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_mount_targets_that_collide_with_transcript_mount() {
+        let error = validate_spec(&SessionSpec {
+            mounts: vec![BindMount {
+                source: PathBuf::from("/home/core/.claude"),
+                target: PathBuf::from("/agentd/transcript"),
+                read_only: true,
+            }],
+            ..test_session_spec()
+        })
+        .expect_err("mount targets must not collide with the transcript mount");
+
+        match error {
+            RunnerError::ReservedMountTarget { target } => {
+                assert_eq!(target, PathBuf::from("/agentd/transcript"));
             }
             other => panic!("expected ReservedMountTarget, got {other:?}"),
         }

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -19,6 +19,8 @@ use std::path::Path;
 const AGENT_NAME_ENV: &str = "AGENT_NAME";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
 pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
+pub(crate) const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
+pub(crate) const TRANSCRIPT_REDACT_ENV: &str = "RUNA_TRANSCRIPT_REDACT_ENV";
 const RESERVED_AGENT_NAMES: [&str; 7] = ["root", "nobody", "daemon", "bin", "sys", "man", "mail"];
 const SUPPORTED_REPO_URL_FORMS: &str = "https://, http://, or git://";
 const SUPPORTED_REPO_URL_PREFIXES: [&str; 3] = ["https://", "http://", "git://"];
@@ -162,8 +164,9 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
 /// Validates an environment variable name against naming rules.
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
-/// runner-managed names (currently `AGENT_NAME`, `AGENTD_WORK_UNIT`, and
-/// `AGENTD_REPO_TOKEN`). Used both by
+/// runner-managed names such as `AGENT_NAME`, `AGENTD_WORK_UNIT`,
+/// `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
+/// `RUNA_TRANSCRIPT_REDACT_ENV`. Used both by
 /// [`run_session`](crate::run_session) during spec validation and by the
 /// configuration layer for credential name validation.
 pub fn validate_environment_name(name: &str) -> Result<(), EnvironmentNameValidationError> {
@@ -282,7 +285,14 @@ fn repo_token_requires_https_error() -> RunnerError {
 }
 
 fn is_reserved_environment_name(name: &str) -> bool {
-    matches!(name, AGENT_NAME_ENV | WORK_UNIT_ENV | REPO_TOKEN_ENV)
+    matches!(
+        name,
+        AGENT_NAME_ENV
+            | WORK_UNIT_ENV
+            | REPO_TOKEN_ENV
+            | TRANSCRIPT_DIR_ENV
+            | TRANSCRIPT_REDACT_ENV
+    )
 }
 
 fn is_reserved_agent_name(name: &str) -> bool {
@@ -389,7 +399,13 @@ mod tests {
 
     #[test]
     fn validate_spec_rejects_reserved_environment_names() {
-        for reserved_name in ["AGENT_NAME", WORK_UNIT_ENV, REPO_TOKEN_ENV] {
+        for reserved_name in [
+            "AGENT_NAME",
+            WORK_UNIT_ENV,
+            REPO_TOKEN_ENV,
+            "RUNA_TRANSCRIPT_DIR",
+            "RUNA_TRANSCRIPT_REDACT_ENV",
+        ] {
             let error = validate_spec(&SessionSpec {
                 environment: vec![ResolvedEnvironmentVariable {
                     name: reserved_name.to_string(),
@@ -399,11 +415,23 @@ mod tests {
             })
             .expect_err("reserved runner environment names should be rejected");
 
-            match error {
+            match &error {
                 RunnerError::ReservedEnvironmentName { name } => {
                     assert_eq!(name, reserved_name);
                 }
                 other => panic!("expected ReservedEnvironmentName, got {other:?}"),
+            }
+
+            let message = error.to_string();
+            assert!(
+                message.contains(reserved_name),
+                "reserved environment error should name {reserved_name}: {message}"
+            );
+            if reserved_name.starts_with("RUNA_TRANSCRIPT_") {
+                assert!(
+                    message.contains("transcript subsystem") && message.contains("set internally"),
+                    "transcript reserved environment error should explain ownership: {message}"
+                );
             }
         }
     }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -967,6 +967,154 @@ fn persists_session_transcript_under_agentd_audit_dir() {
 }
 
 #[test]
+fn finalizes_session_after_runtime_restricts_transcript_directory_permissions() {
+    if skip_if_podman_unavailable(
+        "finalizes_session_after_runtime_restricts_transcript_directory_permissions",
+    ) {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-transcript-dir-mode");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            agent_name: "audit-transcript-dir-mode".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "restrict-transcript-dir".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let record_dir = fixture.only_session_record_dir();
+    let transcript_dir = record_dir.join("agentd/transcript");
+    let manifest_result = fs::read_to_string(transcript_dir.join("manifest.json"));
+    if manifest_result.is_err() {
+        let _ = fs::set_permissions(&transcript_dir, fs::Permissions::from_mode(0o755));
+    }
+    let manifest: Value =
+        serde_json::from_str(&manifest_result.expect("transcript manifest should persist"))
+            .expect("transcript manifest should be json");
+    assert_eq!(manifest["coverage"], "missing_mcp_events");
+
+    let markdown = fs::read_to_string(transcript_dir.join("transcript.md"))
+        .expect("human-readable transcript should persist");
+    assert!(markdown.contains("agent_input"), "{markdown}");
+
+    let session: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/session.json"))
+            .expect("session metadata should persist"),
+    )
+    .expect("session metadata should be json");
+    assert_eq!(session["outcome"], "success");
+
+    let transcript_mode = fs::metadata(&transcript_dir)
+        .expect("transcript dir metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(transcript_mode, 0o555);
+
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn finalizes_session_after_runtime_restricts_events_jsonl_permissions() {
+    if skip_if_podman_unavailable(
+        "finalizes_session_after_runtime_restricts_events_jsonl_permissions",
+    ) {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-transcript-events-mode");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            agent_name: "audit-transcript-events-mode".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "restrict-transcript-events".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let record_dir = fixture.only_session_record_dir();
+    let transcript_dir = record_dir.join("agentd/transcript");
+    let events_path = transcript_dir.join("events.jsonl");
+    let manifest_result = fs::read_to_string(transcript_dir.join("manifest.json"));
+    if manifest_result.is_err() {
+        let _ = fs::set_permissions(&events_path, fs::Permissions::from_mode(0o644));
+    }
+    let manifest: Value =
+        serde_json::from_str(&manifest_result.expect("transcript manifest should persist"))
+            .expect("transcript manifest should be json");
+    assert_eq!(manifest["coverage"], "missing_mcp_events");
+
+    let events = fs::read_to_string(&events_path).expect("structured transcript should persist");
+    assert!(events.contains("\"kind\":\"agent_input\""), "{events}");
+
+    let session: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/session.json"))
+            .expect("session metadata should persist"),
+    )
+    .expect("session metadata should be json");
+    assert_eq!(session["outcome"], "success");
+
+    let events_mode = fs::metadata(&events_path)
+        .expect("events metadata should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(events_mode, 0o444);
+
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
 fn preserves_host_readability_for_restrictive_container_written_audit_entries_after_teardown() {
     if skip_if_podman_unavailable(
         "preserves_host_readability_for_restrictive_container_written_audit_entries_after_teardown",
@@ -2015,6 +2163,16 @@ case "$command_name" in
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "success-without-work-unit" ]; then
             [ "${AGENTD_WORK_UNIT+set}" != "set" ]
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "restrict-transcript-dir" ]; then
+            chmod 000 "${RUNA_TRANSCRIPT_DIR}"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "restrict-transcript-events" ]; then
+            chmod 000 "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
             exit 0
         fi
 

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -899,6 +899,74 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
 }
 
 #[test]
+fn persists_session_transcript_under_agentd_audit_dir() {
+    if skip_if_podman_unavailable("persists_session_transcript_under_agentd_audit_dir") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("audit-transcript-run");
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            agent_name: "audit-transcript-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            mounts: Vec::new(),
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "success-without-work-unit".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        },
+    )
+    .expect("session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let transcript_dir = fixture.only_session_record_dir().join("agentd/transcript");
+    let events = fs::read_to_string(transcript_dir.join("events.jsonl"))
+        .expect("structured transcript events should persist");
+    assert!(events.contains("\"kind\":\"agent_input\""), "{events}");
+    assert!(events.contains("\"kind\":\"agent_exit\""), "{events}");
+
+    let manifest: Value = serde_json::from_str(
+        &fs::read_to_string(transcript_dir.join("manifest.json"))
+            .expect("transcript manifest should persist"),
+    )
+    .expect("transcript manifest should be json");
+    assert_eq!(manifest["schema_version"], 1);
+    assert_eq!(manifest["coverage"], "missing_mcp_events");
+
+    let markdown = fs::read_to_string(transcript_dir.join("transcript.md"))
+        .expect("human-readable transcript should persist");
+    assert!(markdown.contains("# Session Transcript"), "{markdown}");
+    assert!(markdown.contains("agent_input"), "{markdown}");
+
+    let events_mode = fs::metadata(transcript_dir.join("events.jsonl"))
+        .expect("events permissions should exist")
+        .permissions()
+        .mode();
+    assert_eq!(events_mode & 0o222, 0, "transcript should be sealed");
+
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
 fn preserves_host_readability_for_restrictive_container_written_audit_entries_after_teardown() {
     if skip_if_podman_unavailable(
         "preserves_host_readability_for_restrictive_container_written_audit_entries_after_teardown",
@@ -1713,9 +1781,9 @@ const RUNA_STUB: &str = r#"#!/bin/sh
 set -eu
 
 subcommand="${1:-}"
-if [ "$#" -gt 0 ]; then
-    shift
-fi
+        if [ "$#" -gt 0 ]; then
+            shift
+        fi
 
 case "$subcommand" in
     init)
@@ -1768,6 +1836,11 @@ EOF
                         printf 'run --work-unit %s --agent-command -- %s\n' "$work_unit" "$*" >> .runa/calls.log
                     else
                         printf 'run --agent-command -- %s\n' "$*" >> .runa/calls.log
+                    fi
+                    if [ -n "${RUNA_TRANSCRIPT_DIR:-}" ]; then
+                        mkdir -p "${RUNA_TRANSCRIPT_DIR}"
+                        printf '{"schema_version":1,"source":"runa","kind":"agent_input","content":"stub prompt"}\n' >> "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
+                        printf '{"schema_version":1,"source":"runa","kind":"agent_exit","success":true}\n' >> "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
                     fi
                     exec "$@"
                     ;;

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -571,7 +571,7 @@ pub enum ConfigError {
     /// Two credentials within the same agent share a name.
     DuplicateCredentialName { agent: String, name: String },
     /// A credential name fails [`validate_environment_name`] (contains `,`
-    /// or `=`, or is the reserved `AGENT_NAME`).
+    /// or `=`, or uses a runner-owned environment name).
     InvalidCredentialName { agent: String, name: String },
     /// A required string field is empty or whitespace-only.
     EmptyField {

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -650,7 +650,7 @@ impl fmt::Display for ConfigError {
             ConfigError::InvalidCredentialName { agent, name } => {
                 write!(
                     f,
-                    "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use reserved name 'AGENT_NAME'"
+                    "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
                 )
             }
             ConfigError::EmptyField {

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -1590,8 +1590,13 @@ source = "AGENTD_GITHUB_TOKEN"
 
 #[test]
 fn rejects_reserved_credential_names() {
-    let error = Config::from_str(
-        r#"
+    for reserved_name in [
+        "AGENT_NAME",
+        "RUNA_TRANSCRIPT_DIR",
+        "RUNA_TRANSCRIPT_REDACT_ENV",
+    ] {
+        let config = format!(
+            r#"
 [[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
@@ -1601,18 +1606,32 @@ methodology_dir = "../groundwork"
 argv = ["site-builder", "exec"]
 
 [[agents.credentials]]
-name = "AGENT_NAME"
+name = "{reserved_name}"
 source = "AGENTD_GITHUB_TOKEN"
 "#,
-    )
-    .expect_err("runner-reserved credential names should be rejected");
+        );
+        let error = Config::from_str(&config)
+            .expect_err("runner-reserved credential names should be rejected");
 
-    match error {
-        ConfigError::InvalidCredentialName { agent, name } => {
-            assert_eq!(agent, "site-builder");
-            assert_eq!(name, "AGENT_NAME");
+        match &error {
+            ConfigError::InvalidCredentialName { agent, name } => {
+                assert_eq!(agent, "site-builder");
+                assert_eq!(name, reserved_name);
+            }
+            other => panic!("expected invalid credential name error, got {other}"),
         }
-        other => panic!("expected invalid credential name error, got {other}"),
+
+        let message = error.to_string();
+        assert!(
+            message.contains(reserved_name),
+            "reserved credential error should name {reserved_name}: {message}"
+        );
+        if reserved_name.starts_with("RUNA_TRANSCRIPT_") {
+            assert!(
+                message.contains("transcript subsystem") && message.contains("set internally"),
+                "transcript reserved credential error should explain ownership: {message}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Persists per-session transcript artifacts under the existing audit record for post-session observability.
- Mounts a runner-managed transcript directory into the container and configures runa transcript capture/redaction.
- Documents transcript coverage states, cross-repo sequencing, and the MCP wiring gate.

## Changes

- Adds `agentd/transcript/` to each session audit record with `events.jsonl`, `transcript.md`, and `manifest.json`.
- Binds `/agentd/transcript` into session containers and exports `RUNA_TRANSCRIPT_DIR` plus `RUNA_TRANSCRIPT_REDACT_ENV`.
- Rejects operator mounts that collide with the runner-managed transcript path.
- Finalizes transcript artifacts before sealing the audit record so they become read-only with the rest of successful teardown output.
- Updates README, ARCHITECTURE, and CHANGELOG to describe the transcript contract.

## GitHub Issue(s)

Closes #116
Refs #114
Refs tesserine/runa#149

## Cross-Repo Coordination

The runa-side companion is tesserine/runa#149. Preferred sequencing is runa first, then this agentd PR, or coordinated landing with the runtime image updated to include runa#149. If this agentd PR lands before the runa change reaches the session image, the minimal viable behavior is degraded but explicit: agentd still creates and seals transcript artifacts, and the manifest reports `outer_streams_only` or `missing_mcp_events` instead of claiming full transcript coverage.

Full MCP-mediated tool call/result coverage is also gated by #114. Until the runtime actually reaches `runa-mcp`, transcripts can show the runa execution boundary and agent stdout/stderr, but not MCP-layer events that were never observed.

## Test plan

- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
