### PR TITLE
fix(image): expose agentd source labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Container image builds now expose OCI labels and `org.tesserine.agentd.ref`
+  so operators can inspect the daemon source ref from image metadata.
 - Session audit records now include agentd-managed transcript artifacts under
   `agentd/transcript/`, with structured events, a human-readable Markdown
   rendering, and a coverage manifest.
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Deployment documentation now requires image builds to pin immutable tags or
+  full SHAs instead of mutable branch refs such as `main`.
 - The supported daemon deployment shape is now a locally built container image
   for Quadlet-managed operation; host-installed daemon supervision is out of
   band, while `agentd run` remains a host-side same-build client.

--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,8 @@ RUN cargo build --release --locked --bin agentd
 
 FROM docker.io/library/debian:bookworm-slim
 
+ARG AGENTD_REF=local
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates podman \
     && rm -rf /var/lib/apt/lists/* \
@@ -16,6 +18,12 @@ COPY --from=builder /workspace/target/release/agentd /usr/local/bin/agentd
 
 ENV CONTAINER_HOST=unix:///run/podman/podman.sock
 ENV TMPDIR=/var/lib/agentd/tmp
+
+LABEL org.opencontainers.image.title="agentd" \
+      org.opencontainers.image.description="Daemon that runs autonomous AI agent sessions in ephemeral Podman containers" \
+      org.opencontainers.image.source="https://github.com/tesserine/agentd" \
+      org.opencontainers.image.revision="${AGENTD_REF}" \
+      org.tesserine.agentd.ref="${AGENTD_REF}"
 
 ENTRYPOINT ["/usr/local/bin/agentd"]
 CMD ["daemon", "--config", "/etc/agentd/agentd.toml"]

--- a/README.md
+++ b/README.md
@@ -142,10 +142,22 @@ are not backfilled after downtime. Persistent audit records default to
 
 The supported daemon deployment shape is a locally built container image run by
 Quadlet. Build the image on the target host or another trusted build host with
-access to the checked-out source or release tag:
+access to the checked-out source or release tag. Deployment builds must pin the
+daemon source to an immutable tag or full commit SHA; do not deploy from `main`
+or another mutable branch ref. The shared release-candidate convention is
+defined in
+[commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md).
 
 ```bash
-podman build --tag localhost/agentd:0.1.1 .
+podman build \
+  --build-arg AGENTD_REF=v0.1.2-rc.1 \
+  --tag localhost/agentd:v0.1.2-rc.1 .
+```
+
+Confirm the deployed image metadata with:
+
+```bash
+podman inspect localhost/agentd:v0.1.2-rc.1 | jq '.[0].Config.Labels'
 ```
 
 The image's default command starts the daemon and reads
@@ -211,7 +223,7 @@ deployments.
 Confirm the image contents with:
 
 ```bash
-podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:0.1.1 --version
+podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:v0.1.2-rc.1 --version
 ```
 
 ## Running a Session


### PR DESCRIPTION
## Summary

- exposes OCI source/revision labels and org.tesserine.agentd.ref in the agentd image
- documents immutable deployment refs and image-label inspection
- updates deployment examples to the v0.1.2-rc.1 ref shape

Refs tesserine/ops#14.

## Verification

- git diff --check
- podman build --build-arg AGENTD_REF=issue-14-verify -t localhost/agentd:issue-14-verify -f Containerfile .
- podman inspect localhost/agentd:issue-14-verify | jq labels
- podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:issue-14-verify --version