### PR TITLE
fix(release-ceremony): align release tag validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - "v*"
 
 permissions:
   contents: read
@@ -21,6 +20,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
 
       - name: Require annotated tag
         run: |
@@ -68,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           release_flags=()
-          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+-rc[.][0-9]+$ ]]; then
+          if [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)-rc[.][1-9][0-9]*$ ]]; then
             release_flags+=(--prerelease)
           fi
           gh release create "$GITHUB_REF_NAME" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate release tag
-        run: ./scripts/release-check release "$GITHUB_REF_NAME"
-
       - name: Require annotated tag
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
@@ -34,6 +31,9 @@ jobs:
           git fetch --force origin refs/heads/main:refs/remotes/origin/main
           tag_commit="$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")"
           git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
 
       - name: Install Rust toolchain
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Release publication now uses a broad `v*` workflow trigger with early
-  `release-check` validation, and release-tag validation now rejects
-  leading-zero numeric identifiers and `rc.0` per the ecosystem SemVer grammar.
+- Release publication now uses a broad `v*` workflow trigger, validates tag
+  trust before running repository release code, and rejects leading-zero
+  numeric identifiers and `rc.0` per the ecosystem SemVer grammar.
 - Release governance checks now cover workflow tag matching behavior, decouple
   tag publication from path-filtered metadata checks, derive release metadata
   validation from workspace members, and use one workspace-version parser across

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release publication now uses a broad `v*` workflow trigger with early
+  `release-check` validation, and release-tag validation now rejects
+  leading-zero numeric identifiers and `rc.0` per the ecosystem SemVer grammar.
 - Release governance checks now cover workflow tag matching behavior, decouple
   tag publication from path-filtered metadata checks, derive release metadata
   validation from workspace members, and use one workspace-version parser across

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,11 @@ agentd uses one repository tag for the Rust workspace, daemon container image,
 and host CLI extracted from that image. The tag is `vX.Y.Z` for stable
 releases and `vX.Y.Z-rc.N` for deployment release candidates.
 
+Release tags follow Semantic Versioning 2.0.0 numeric grammar as codified by
+commons ADR-0012: each integer is either `0` or a non-zero digit followed by
+zero or more digits. Release candidate numbering starts at `rc.1`; `rc.0` and
+leading-zero numeric identifiers are not valid release tags.
+
 Artifacts built from the tag must report that identity:
 
 - `Cargo.toml` `[workspace.package].version` is `X.Y.Z` or `X.Y.Z-rc.N`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,10 +79,11 @@ the existing tag.
 ## Post-Release Gate
 
 The tag push runs `.github/workflows/release.yml`. That workflow verifies the
-annotated tag, builds the release binary, builds a local container image with
-`AGENTD_REF` set to the tag, verifies the workspace/binary/container identity,
-extracts release notes from `CHANGELOG.md`, and publishes the GitHub Release.
-Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
+annotated tag and main-branch ancestry with git-only checks before running
+repository release code, builds the release binary, builds a local container
+image with `AGENTD_REF` set to the tag, verifies the workspace/binary/container
+identity, extracts release notes from `CHANGELOG.md`, and publishes the GitHub
+Release. Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
 
 Manual GitHub Release creation, when needed after a workflow failure, uses the
 same notes source:

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -135,6 +135,28 @@ LABEL org.tesserine.agentd.ref="${AGENTD_REF}"
 COPY --from=builder /workspace/target/release/agentd /usr/local/bin/agentd
 "#,
     );
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
     fixture.install_release_check();
     fixture
 }
@@ -211,6 +233,17 @@ fn metadata_accepts_a_coherent_agentd_release_surface() {
     let output = fixture.run_release_check(&["metadata"]);
 
     assert_success(&output);
+}
+
+#[test]
+fn metadata_accepts_canonical_semver_release_versions() {
+    for version in ["0.0.0", "1.2.3-rc.1"] {
+        let fixture = valid_fixture(&format!("metadata-canonical-{version}"), version);
+
+        let output = fixture.run_release_check(&["metadata"]);
+
+        assert_success(&output);
+    }
 }
 
 #[test]
@@ -378,6 +411,20 @@ fn metadata_rejects_unsupported_workspace_prerelease_versions() {
 }
 
 #[test]
+fn metadata_rejects_workspace_versions_with_noncanonical_numeric_components() {
+    for version in ["01.2.3", "1.02.3", "1.2.03", "1.2.3-rc.01", "1.2.3-rc.0"] {
+        let fixture = valid_fixture(&format!("metadata-noncanonical-{version}"), version);
+
+        let output = fixture.run_release_check(&["metadata"]);
+
+        assert_failure_contains(
+            &output,
+            &format!("workspace version must look like X.Y.Z or X.Y.Z-rc.N: {version}"),
+        );
+    }
+}
+
+#[test]
 fn metadata_rejects_unsupported_changelog_prerelease_headings() {
     let fixture = valid_fixture("metadata-unsupported-changelog-prerelease", "1.2.3");
     fixture.write(
@@ -393,6 +440,90 @@ fn metadata_rejects_unsupported_changelog_prerelease_headings() {
     let output = fixture.run_release_check(&["metadata"]);
 
     assert_failure_contains(&output, "release heading is malformed");
+}
+
+#[test]
+fn metadata_rejects_changelog_headings_with_noncanonical_numeric_components() {
+    for version in ["01.2.3", "1.02.3", "1.2.03", "1.2.3-rc.01", "1.2.3-rc.0"] {
+        let fixture = valid_fixture(
+            &format!("metadata-changelog-noncanonical-{version}"),
+            "1.2.3",
+        );
+        fixture.write(
+            "CHANGELOG.md",
+            &format!(
+                r#"# Changelog
+
+## [Unreleased]
+
+## [{version}] — 2026-05-07
+"#
+            ),
+        );
+
+        let output = fixture.run_release_check(&["metadata"]);
+
+        assert_failure_contains(&output, "release heading is malformed");
+    }
+}
+
+#[test]
+fn metadata_rejects_release_workflows_without_early_tag_validation() {
+    let fixture = valid_fixture("metadata-workflow-missing-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(&output, "validate the release tag before container setup");
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_validate_tags_after_container_setup() {
+    let fixture = valid_fixture("metadata-workflow-late-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(&output, "validate the release tag before container setup");
 }
 
 #[test]
@@ -455,6 +586,26 @@ fn notes_rejects_unsupported_alpha_release_candidate_tags() {
         &output,
         "release version must look like vX.Y.Z or vX.Y.Z-rc.N: v1.2.3-alpha.2.3",
     );
+}
+
+#[test]
+fn notes_rejects_tags_with_noncanonical_numeric_components() {
+    let fixture = valid_fixture("notes-noncanonical-tags", "1.2.3");
+
+    for tag in [
+        "v01.2.3",
+        "v1.02.3",
+        "v1.2.03",
+        "v1.2.3-rc.01",
+        "v1.2.3-rc.0",
+    ] {
+        let output = fixture.run_release_check(&["notes", tag]);
+
+        assert_failure_contains(
+            &output,
+            &format!("release version must look like vX.Y.Z or vX.Y.Z-rc.N: {tag}"),
+        );
+    }
 }
 
 #[test]

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -150,6 +150,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
       - name: Validate release tag
         run: ./scripts/release-check release "$GITHUB_REF_NAME"
 
@@ -524,6 +530,46 @@ jobs:
     let output = fixture.run_release_check(&["metadata"]);
 
     assert_failure_contains(&output, "validate the release tag before container setup");
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_validate_tags_before_tag_trust() {
+    let fixture = valid_fixture("metadata-workflow-pretrust-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "establish tag trust before running repository code",
+    );
 }
 
 #[test]

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -54,60 +54,11 @@ fn release_workflow_tag_patterns() -> Vec<String> {
     patterns
 }
 
-fn documented_actions_pattern_matches(pattern: &str, candidate: &str) -> bool {
-    let pattern = pattern.as_bytes();
-    let candidate = candidate.as_bytes();
-    let mut pattern_index = 0;
-    let mut candidate_index = 0;
-
-    while pattern_index < pattern.len() {
-        if pattern[pattern_index] == b'[' {
-            let range_end = pattern[pattern_index..]
-                .iter()
-                .position(|byte| *byte == b']')
-                .map(|offset| pattern_index + offset)
-                .expect("test pattern character class should close");
-            assert_eq!(
-                &pattern[pattern_index..=range_end],
-                b"[0-9]",
-                "test matcher only models the documented digit class used by release tags"
-            );
-            let one_or_more = pattern.get(range_end + 1) == Some(&b'+');
-            let start = candidate_index;
-            while candidate
-                .get(candidate_index)
-                .is_some_and(u8::is_ascii_digit)
-            {
-                candidate_index += 1;
-            }
-            if one_or_more {
-                if candidate_index == start {
-                    return false;
-                }
-                pattern_index = range_end + 2;
-            } else {
-                if candidate_index != start + 1 {
-                    return false;
-                }
-                pattern_index = range_end + 1;
-            }
-            continue;
-        }
-
-        if candidate.get(candidate_index) != pattern.get(pattern_index) {
-            return false;
-        }
-        pattern_index += 1;
-        candidate_index += 1;
-    }
-
-    candidate_index == candidate.len()
-}
-
-fn matches_any_documented_actions_pattern(patterns: &[String], candidate: &str) -> bool {
-    patterns
-        .iter()
-        .any(|pattern| documented_actions_pattern_matches(pattern, candidate))
+fn line_number_containing(contents: &str, needle: &str) -> Option<usize> {
+    contents
+        .lines()
+        .position(|line| line.contains(needle))
+        .map(|index| index + 1)
 }
 
 #[test]
@@ -375,44 +326,32 @@ fn changelog_release_rolls_are_enabled_for_release_candidates() {
 }
 
 #[test]
-fn github_release_workflow_triggers_only_for_documented_tag_shapes() {
+fn github_release_workflow_delegates_v_prefixed_tags_to_release_check() {
     let patterns = release_workflow_tag_patterns();
 
-    assert!(
-        !patterns.iter().any(|pattern| pattern == "v*.*.*"),
-        "release workflow should not trigger on arbitrary v*.*.* tags"
-    );
     assert_eq!(
         patterns,
-        ["v[0-9]+.[0-9]+.[0-9]+", "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"],
-        "release workflow should trigger only documented stable and RC tag shapes"
+        ["v*"],
+        "release workflow should delegate v-prefixed tag shape validation to release-check"
     );
 }
 
 #[test]
-fn github_release_workflow_tag_filters_match_the_documented_release_contract() {
-    let patterns = release_workflow_tag_patterns();
+fn github_release_workflow_validates_tags_before_expensive_release_work() {
+    let workflow = read_workspace_file(".github/workflows/release.yml");
+    let validation_line = line_number_containing(
+        &workflow,
+        "run: ./scripts/release-check release \"$GITHUB_REF_NAME\"",
+    )
+    .expect("release workflow should validate the tag with release-check");
+    let container_setup_line = line_number_containing(&workflow, "sudo apt-get install -y podman")
+        .or_else(|| line_number_containing(&workflow, "podman build"))
+        .expect("release workflow should install or run container tooling");
 
-    for accepted in ["v0.1.2", "v10.20.300", "v0.1.2-rc.1", "v10.20.300-rc.400"] {
-        assert!(
-            matches_any_documented_actions_pattern(&patterns, accepted),
-            "release workflow tag filters should match documented tag {accepted}"
-        );
-    }
-
-    for rejected in [
-        "v0.1",
-        "v0.1.2.3",
-        "v0.1.2-beta.1",
-        "v0.1.2-rc",
-        "v0.1.2-rc.x",
-        "agentd-v0.1.2",
-    ] {
-        assert!(
-            !matches_any_documented_actions_pattern(&patterns, rejected),
-            "release workflow tag filters should reject undocumented tag {rejected}"
-        );
-    }
+    assert!(
+        validation_line < container_setup_line,
+        "release workflow should validate the release tag before container setup"
+    );
 }
 
 #[test]
@@ -456,7 +395,8 @@ fn github_release_workflow_marks_only_rc_tags_as_prereleases() {
     let workflow = read_workspace_file(".github/workflows/release.yml");
 
     assert!(
-        workflow.contains("^v[0-9]+[.][0-9]+[.][0-9]+-rc[.][0-9]+$"),
+        workflow
+            .contains("^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)-rc[.][1-9][0-9]*$"),
         "release workflow should mark only documented RC tags as GitHub prereleases"
     );
     assert!(

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -61,6 +61,13 @@ fn line_number_containing(contents: &str, needle: &str) -> Option<usize> {
         .map(|index| index + 1)
 }
 
+fn first_line_number_containing_any(contents: &str, needles: &[&str]) -> Option<usize> {
+    contents
+        .lines()
+        .position(|line| needles.iter().any(|needle| line.contains(needle)))
+        .map(|index| index + 1)
+}
+
 #[test]
 fn workspace_metadata_lists_only_grounded_crates() {
     let output = Command::new("cargo")
@@ -351,6 +358,29 @@ fn github_release_workflow_validates_tags_before_expensive_release_work() {
     assert!(
         validation_line < container_setup_line,
         "release workflow should validate the release tag before container setup"
+    );
+}
+
+#[test]
+fn github_release_workflow_establishes_tag_trust_before_repository_code_execution() {
+    let workflow = read_workspace_file(".github/workflows/release.yml");
+    let annotated_tag_line = line_number_containing(&workflow, "git cat-file -t")
+        .expect("release workflow should require an annotated tag");
+    let main_ancestry_line = line_number_containing(&workflow, "git merge-base --is-ancestor")
+        .expect("release workflow should require the tag target on main");
+    let repository_code_line = first_line_number_containing_any(
+        &workflow,
+        &[
+            "./scripts/release-check release \"$GITHUB_REF_NAME\"",
+            "cargo build",
+            "podman build",
+        ],
+    )
+    .expect("release workflow should run trusted repository release code");
+
+    assert!(
+        annotated_tag_line < repository_code_line && main_ancestry_line < repository_code_line,
+        "release workflow should establish tag trust before running repository code"
     );
 }
 

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -207,11 +207,18 @@ check_release_workflow_surface() {
     ! grep -Eq '^    paths:' "$workflow" \
         || die ".github/workflows/release.yml tag publication must not use paths filters"
 
-    local validation_line container_setup_line
+    local validation_line container_setup_line annotated_tag_line main_ancestry_line repository_code_line
     validation_line="$(awk 'index($0, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print NR; exit }' "$workflow")"
     container_setup_line="$(awk '/sudo apt-get install -y podman|podman build/ { print NR; exit }' "$workflow")"
     [[ -n "$validation_line" ]] && [[ -n "$container_setup_line" ]] && [[ "$validation_line" -lt "$container_setup_line" ]] \
         || die ".github/workflows/release.yml must validate the release tag before container setup"
+
+    annotated_tag_line="$(awk '/git cat-file -t/ { print NR; exit }' "$workflow")"
+    main_ancestry_line="$(awk '/git merge-base --is-ancestor/ { print NR; exit }' "$workflow")"
+    repository_code_line="$(awk 'index($0, "./scripts/release-check release \"$GITHUB_REF_NAME\"") || /cargo build|podman build/ { print NR; exit }' "$workflow")"
+    [[ -n "$annotated_tag_line" ]] && [[ -n "$main_ancestry_line" ]] && [[ -n "$repository_code_line" ]] \
+        && [[ "$annotated_tag_line" -lt "$repository_code_line" ]] && [[ "$main_ancestry_line" -lt "$repository_code_line" ]] \
+        || die ".github/workflows/release.yml must establish tag trust before running repository code"
 }
 
 check_changelog_structure() {

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -73,14 +73,14 @@ workspace_package_names() {
 
 release_from_tag() {
     local tag="$1"
-    [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-rc\.[0-9]+)?$ ]] \
+    [[ "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]] \
         || die "release version must look like vX.Y.Z or vX.Y.Z-rc.N: $tag"
     printf '%s.%s.%s%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
 }
 
 check_version_shape() {
     local version="$1"
-    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]] \
+    [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]] \
         || die "workspace version must look like X.Y.Z or X.Y.Z-rc.N: $version"
 }
 
@@ -174,6 +174,46 @@ check_containerfile_identity_surface() {
         || die "Containerfile must install the host CLI at /usr/local/bin/agentd"
 }
 
+workflow_tag_patterns() {
+    local workflow="$repo_root/.github/workflows/release.yml"
+
+    awk '
+        $0 == "    tags:" {
+            inside = 1
+            next
+        }
+        inside && $0 ~ /^      - / {
+            value = $0
+            sub(/^      - /, "", value)
+            gsub(/"/, "", value)
+            print value
+            next
+        }
+        inside {
+            exit
+        }
+    ' "$workflow"
+}
+
+check_release_workflow_surface() {
+    local workflow="$repo_root/.github/workflows/release.yml"
+    [[ -f "$workflow" ]] || die ".github/workflows/release.yml not found"
+
+    mapfile -t patterns < <(workflow_tag_patterns)
+    [[ "${#patterns[@]}" == "1" ]] \
+        || die ".github/workflows/release.yml must declare exactly one release tag pattern"
+    [[ "${patterns[0]}" == "v*" ]] \
+        || die ".github/workflows/release.yml tag pattern must delegate v-prefixed tags to release-check validation"
+    ! grep -Eq '^    paths:' "$workflow" \
+        || die ".github/workflows/release.yml tag publication must not use paths filters"
+
+    local validation_line container_setup_line
+    validation_line="$(awk 'index($0, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print NR; exit }' "$workflow")"
+    container_setup_line="$(awk '/sudo apt-get install -y podman|podman build/ { print NR; exit }' "$workflow")"
+    [[ -n "$validation_line" ]] && [[ -n "$container_setup_line" ]] && [[ "$validation_line" -lt "$container_setup_line" ]] \
+        || die ".github/workflows/release.yml must validate the release tag before container setup"
+}
+
 check_changelog_structure() {
     local changelog="$repo_root/CHANGELOG.md"
     [[ -f "$changelog" ]] || die "CHANGELOG.md not found"
@@ -193,7 +233,7 @@ check_changelog_structure() {
                 next
             }
 
-            if ($0 !~ /^## \[[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*(-rc\.[0-9][0-9]*)?\] — [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/) {
+            if ($0 !~ /^## \[(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?\] — [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/) {
                 print "CHANGELOG.md release heading is malformed: " $0 > "/dev/stderr"
                 exit 1
             }
@@ -319,6 +359,7 @@ run_metadata() {
     check_workspace_crates_inherit_version
     check_cargo_lock_versions
     check_containerfile_identity_surface
+    check_release_workflow_surface
     check_changelog_structure
 }
 


### PR DESCRIPTION
## Summary

- Makes release publication trigger on broad `v*` tag pushes and validates exact release grammar with `release-check` before container setup.
- Tightens release tag, workspace version, and changelog heading validation to the commons ADR-0012 grammar: no leading-zero numeric identifiers and no `rc.0`.
- Updates release operator docs and regression coverage for the workflow delegation and SemVer grammar edge cases.

## Changes

- Replaces the broken GitHub Actions `[0-9]+` tag filters with `v*` plus an early `./scripts/release-check release "$GITHUB_REF_NAME"` workflow step.
- Adds release workflow surface validation to `scripts/release-check metadata`.
- Removes the hand-rolled Actions-pattern matcher from workspace contract tests and covers the new behavior directly.

## GitHub Issue(s)

Closes #129

## Test plan

- `cargo test -p agentd --test release_check -- --nocapture`
- `cargo test -p agentd --test workspace_contract -- --nocapture`
- `cargo fmt --check`
- `./scripts/release-check metadata`
- real minimatch probe confirming old filters reject documented tags while `v*` accepts them
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`
