### PR TITLE
fix(release-ceremony): validate executable workflow content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release workflow metadata validation now checks executable `run:` content
+  instead of raw workflow text, so YAML and shell comments cannot satisfy
+  release ordering or tag-trust invariants.
 - Release publication now uses a broad `v*` workflow trigger, validates tag
   trust before running repository release code, and rejects leading-zero
   numeric identifiers and `rc.0` per the ecosystem SemVer grammar.

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -573,6 +573,125 @@ jobs:
 }
 
 #[test]
+fn metadata_ignores_yaml_comments_when_ordering_release_tag_validation() {
+    let fixture = valid_fixture("metadata-workflow-yaml-comment-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      # Note: validate via ./scripts/release-check release "$GITHUB_REF_NAME"
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(&output, "validate the release tag before container setup");
+}
+
+#[test]
+fn metadata_ignores_shell_comments_when_establishing_tag_trust() {
+    let fixture = valid_fixture("metadata-workflow-shell-comment-trust", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Commented annotated tag check
+        run: |
+          # git cat-file -t "refs/tags/$GITHUB_REF_NAME"
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "establish tag trust before running repository code",
+    );
+}
+
+#[test]
+fn metadata_ignores_inline_shell_comments_when_ordering_release_tag_validation() {
+    let fixture = valid_fixture("metadata-workflow-inline-comment-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Commented validation
+        run: true  # ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(&output, "validate the release tag before container setup");
+}
+
+#[test]
 fn notes_emit_the_matching_changelog_section_without_outer_blank_lines() {
     let fixture = valid_fixture("notes-success", "1.2.3");
 

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -195,6 +195,83 @@ workflow_tag_patterns() {
     ' "$workflow"
 }
 
+workflow_executable_lines() {
+    local workflow="$1"
+
+    awk '
+        function indent_of(line,    i, char) {
+            for (i = 1; i <= length(line); i++) {
+                char = substr(line, i, 1)
+                if (char != " ") {
+                    return i - 1
+                }
+            }
+            return length(line)
+        }
+
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        function unquote(value) {
+            if ((value ~ /^".*"$/) || (value ~ /^\047.*\047$/)) {
+                return substr(value, 2, length(value) - 2)
+            }
+            return value
+        }
+
+        function strip_shell_comment(value) {
+            sub(/(^|[[:space:]])#.*/, "", value)
+            return value
+        }
+
+        function emit(line_number, command) {
+            command = strip_shell_comment(command)
+            command = trim(command)
+            if (command == "" || command ~ /^#/) {
+                return
+            }
+            print line_number "\t" command
+        }
+
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            indent = indent_of(line)
+            stripped = trim(line)
+
+            if (in_run_block) {
+                if (stripped != "" && indent <= run_indent) {
+                    in_run_block = 0
+                } else {
+                    emit(NR, line)
+                    next
+                }
+            }
+
+            if (stripped ~ /^#/) {
+                next
+            }
+
+            if (line ~ /^[[:space:]]*(-[[:space:]]*)?run:[[:space:]]*/) {
+                value = line
+                sub(/^[[:space:]]*(-[[:space:]]*)?run:[[:space:]]*/, "", value)
+                value = trim(value)
+
+                if (value ~ /^[|>]/) {
+                    in_run_block = 1
+                    run_indent = indent
+                    next
+                }
+
+                emit(NR, unquote(value))
+            }
+        }
+    ' "$workflow"
+}
+
 check_release_workflow_surface() {
     local workflow="$repo_root/.github/workflows/release.yml"
     [[ -f "$workflow" ]] || die ".github/workflows/release.yml not found"
@@ -208,14 +285,14 @@ check_release_workflow_surface() {
         || die ".github/workflows/release.yml tag publication must not use paths filters"
 
     local validation_line container_setup_line annotated_tag_line main_ancestry_line repository_code_line
-    validation_line="$(awk 'index($0, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print NR; exit }' "$workflow")"
-    container_setup_line="$(awk '/sudo apt-get install -y podman|podman build/ { print NR; exit }' "$workflow")"
+    validation_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print $1; exit }')"
+    container_setup_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /sudo apt-get install -y podman|podman build/ { print $1; exit }')"
     [[ -n "$validation_line" ]] && [[ -n "$container_setup_line" ]] && [[ "$validation_line" -lt "$container_setup_line" ]] \
         || die ".github/workflows/release.yml must validate the release tag before container setup"
 
-    annotated_tag_line="$(awk '/git cat-file -t/ { print NR; exit }' "$workflow")"
-    main_ancestry_line="$(awk '/git merge-base --is-ancestor/ { print NR; exit }' "$workflow")"
-    repository_code_line="$(awk 'index($0, "./scripts/release-check release \"$GITHUB_REF_NAME\"") || /cargo build|podman build/ { print NR; exit }' "$workflow")"
+    annotated_tag_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git cat-file -t/ { print $1; exit }')"
+    main_ancestry_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git merge-base --is-ancestor/ { print $1; exit }')"
+    repository_code_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/") || $2 ~ /cargo build|podman build/ { print $1; exit }')"
     [[ -n "$annotated_tag_line" ]] && [[ -n "$main_ancestry_line" ]] && [[ -n "$repository_code_line" ]] \
         && [[ "$annotated_tag_line" -lt "$repository_code_line" ]] && [[ "$main_ancestry_line" -lt "$repository_code_line" ]] \
         || die ".github/workflows/release.yml must establish tag trust before running repository code"


### PR DESCRIPTION
## Summary
- Hardens release workflow metadata validation so ordering and trust checks consume executable `run:` content instead of raw workflow text.
- Ignores YAML comments, shell comment-only lines, and inline shell comments when matching release validation and tag-trust commands.
- Adds regression coverage for the comment-bypass cases and records the hardening in the changelog.

## Changes
- Adds a Bash/AWK executable workflow scanner that preserves source line numbers for ordering checks.
- Rewires release workflow surface validation to use scanner output for validation, container setup, tag-trust, and repository-code lookup.
- Covers YAML-level, shell-level, and inline shell-comment bypass regressions in `release_check` tests.

## GitHub Issue(s)

Closes #131

## Test plan
- `cargo fmt --check`
- `./scripts/release-check metadata`
- `cargo test -p agentd --test release_check`
- `cargo test -p agentd --test workspace_contract`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
