### PR TITLE
fix(transcript): report no-events coverage accurately

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -311,7 +311,7 @@ layout:
 - `agentd/transcript/transcript.md` — human-readable rendering of the event
   stream
 - `agentd/transcript/manifest.json` — transcript schema version and coverage:
-  `full`, `missing_mcp_events`, `outer_streams_only`, or `finalization_failed`
+  `full`, `missing_mcp_events`, `no_events`, or `finalization_failed`
 - `agentd/session.json` — agentd-written metadata (`schema_version: 2`,
   `session_id`, `agent`, `repo_url`, optional `work_unit`, timestamps, outcome,
   exit code when applicable) written by atomic temp-file replacement within the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Empty transcript event streams now report manifest coverage as `no_events`
+  instead of claiming an outer-stream classification not present in
+  `events.jsonl`.
 - Release workflow metadata validation now checks executable `run:` content
   instead of raw workflow text, so YAML and shell comments cannot satisfy
   release ordering or tag-trust invariants.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ persists on the host under the resolved audit root
 metadata in `agentd/session.json`, and transcript artifacts in
 `agentd/transcript/`. Transcript artifacts include structured JSON Lines events
 at `events.jsonl`, a human-readable `transcript.md`, and `manifest.json` with
-coverage of `full`, `missing_mcp_events`, `outer_streams_only`, or
+coverage of `full`, `missing_mcp_events`, `no_events`, or
 `finalization_failed`. Full MCP tool-call coverage depends on the agent runtime
 launching `runa-mcp`; otherwise the transcript still records the observable runa
 boundary without claiming MCP events that never occurred.

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -484,7 +484,7 @@ fn transcript_coverage(events: &mut File) -> Result<&'static str, TranscriptFina
     } else if saw_event {
         "missing_mcp_events"
     } else {
-        "outer_streams_only"
+        "no_events"
     };
     Ok(coverage)
 }
@@ -1394,7 +1394,7 @@ mod tests {
                 .expect("transcript manifest should exist"),
         )
         .expect("manifest should be json");
-        assert_eq!(manifest["coverage"], "outer_streams_only");
+        assert_eq!(manifest["coverage"], "no_events");
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
@@ -1808,7 +1808,8 @@ mod tests {
 
     #[test]
     fn transcript_coverage_uses_parsed_event_sources() {
-        assert_eq!(classify_transcript_fixture(""), "outer_streams_only");
+        assert_eq!(classify_transcript_fixture(""), "no_events");
+        assert_eq!(classify_transcript_fixture("\n  \n\t\n"), "no_events");
         assert_eq!(
             classify_transcript_fixture(
                 r#"{"schema_version":1,"source":"runa","kind":"agent_input"}"#


### PR DESCRIPTION
## Summary

- Reports empty or blank-only transcript event streams as `no_events` in `manifest.json`.
- Preserves existing `full`, `missing_mcp_events`, and `finalization_failed` coverage behavior.
- Updates README, architecture docs, and changelog to list the current manifest taxonomy.

## Changes

- Changed `transcript_coverage` to classify the no-event case explicitly.
- Updated audit regression coverage for empty and blank-only `events.jsonl` inputs.
- Replaced the obsolete `outer_streams_only` documented taxonomy value with `no_events`.

## GitHub Issue(s)

Closes #126

## Test plan

- RED: `cargo test -p agentd-runner transcript_coverage_uses_parsed_event_sources -- --nocapture` failed with `outer_streams_only` before the classifier change.
- RED: `cargo test -p agentd-runner finalize_session_transcript_creates_empty_events_jsonl_when_no_events_were_emitted -- --nocapture` failed with `outer_streams_only` before the classifier change.
- GREEN: both targeted tests pass after the classifier change.
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
