### PR TITLE
fix(release): restore annotated tag refs before trust checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Restore annotated tag refs
         run: git fetch --tags --force origin
 
+      - name: Verify restored tag matches event
+        run: |
+          set -euo pipefail
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
       - name: Require annotated tag
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
       - name: Require annotated tag
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Release publication now restores annotated tag refs after checkout before
+  tag-trust validation, preserving the annotated-tag security check under
+  `actions/checkout@v4` tag-push behavior. Refs tesserine/commons#34.
 
 ## [0.1.2-rc.2] — 2026-05-13
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,12 +78,14 @@ the existing tag.
 
 ## Post-Release Gate
 
-The tag push runs `.github/workflows/release.yml`. That workflow verifies the
-annotated tag and main-branch ancestry with git-only checks before running
-repository release code, builds the release binary, builds a local container
-image with `AGENTD_REF` set to the tag, verifies the workspace/binary/container
-identity, extracts release notes from `CHANGELOG.md`, and publishes the GitHub
-Release. Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
+The tag push runs `.github/workflows/release.yml`. That workflow restores the
+tag ref, verifies that its commit still matches the event commit, and verifies
+the annotated tag and main-branch ancestry with git-only checks before running
+repository release code. It then builds the release binary, builds a local
+container image with `AGENTD_REF` set to the tag, verifies the
+workspace/binary/container identity, extracts release notes from `CHANGELOG.md`,
+and publishes the GitHub Release.
+Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
 
 Manual GitHub Release creation, when needed after a workflow failure, uses the
 same notes source:

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -662,6 +662,49 @@ jobs:
 }
 
 #[test]
+fn metadata_rejects_release_workflows_that_restore_tag_refs_before_checkout() {
+    let fixture = valid_fixture("metadata-workflow-precheckout-tag-ref-restore", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "restore annotated tag refs after checkout and before checking tag type",
+    );
+}
+
+#[test]
 fn metadata_ignores_yaml_comments_when_ordering_release_tag_validation() {
     let fixture = valid_fixture("metadata-workflow-yaml-comment-validation", "1.2.3");
     fixture.write(

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -153,6 +153,14 @@ jobs:
       - name: Restore annotated tag refs
         run: git fetch --tags --force origin
 
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
       - name: Require annotated tag
         run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
 
@@ -559,6 +567,14 @@ jobs:
       - name: Restore annotated tag refs
         run: git fetch --tags --force origin
 
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
       - name: Require annotated tag
         run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
 
@@ -575,6 +591,100 @@ jobs:
     assert_failure_contains(
         &output,
         "establish tag trust before running repository code",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_do_not_verify_restored_tag_matches_event() {
+    let fixture = valid_fixture("metadata-workflow-missing-event-identity", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "verify the restored tag matches the triggering event before checking tag type",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_verify_event_identity_before_restoring_tag_refs() {
+    let fixture = valid_fixture("metadata-workflow-early-event-identity", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "verify the restored tag matches the triggering event before checking tag type",
     );
 }
 
@@ -762,6 +872,14 @@ jobs:
 
       - name: Restore annotated tag refs
         run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
 
       - name: Commented annotated tag check
         run: |

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -150,6 +150,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
       - name: Require annotated tag
         run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
 
@@ -553,6 +556,9 @@ jobs:
       - name: Validate release tag
         run: ./scripts/release-check release "$GITHUB_REF_NAME"
 
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
       - name: Require annotated tag
         run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
 
@@ -569,6 +575,89 @@ jobs:
     assert_failure_contains(
         &output,
         "establish tag trust before running repository code",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_do_not_restore_annotated_tag_refs() {
+    let fixture = valid_fixture("metadata-workflow-missing-tag-ref-restore", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "restore annotated tag refs before checking tag type",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_restore_tag_refs_after_checking_tag_type() {
+    let fixture = valid_fixture("metadata-workflow-late-tag-ref-restore", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install container tooling
+        run: sudo apt-get install -y podman
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        "restore annotated tag refs before checking tag type",
     );
 }
 
@@ -627,6 +716,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
 
       - name: Commented annotated tag check
         run: |

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -364,6 +364,8 @@ fn github_release_workflow_validates_tags_before_expensive_release_work() {
 #[test]
 fn github_release_workflow_establishes_tag_trust_before_repository_code_execution() {
     let workflow = read_workspace_file(".github/workflows/release.yml");
+    let tag_ref_restore_line = line_number_containing(&workflow, "git fetch --tags --force origin")
+        .expect("release workflow should restore annotated tag refs after checkout");
     let annotated_tag_line = line_number_containing(&workflow, "git cat-file -t")
         .expect("release workflow should require an annotated tag");
     let main_ancestry_line = line_number_containing(&workflow, "git merge-base --is-ancestor")
@@ -379,7 +381,9 @@ fn github_release_workflow_establishes_tag_trust_before_repository_code_executio
     .expect("release workflow should run trusted repository release code");
 
     assert!(
-        annotated_tag_line < repository_code_line && main_ancestry_line < repository_code_line,
+        tag_ref_restore_line < annotated_tag_line
+            && annotated_tag_line < repository_code_line
+            && main_ancestry_line < repository_code_line,
         "release workflow should establish tag trust before running repository code"
     );
 }

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -272,6 +272,46 @@ workflow_executable_lines() {
     ' "$workflow"
 }
 
+workflow_uses_lines() {
+    local workflow="$1"
+
+    awk '
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        function unquote(value) {
+            if ((value ~ /^".*"$/) || (value ~ /^\047.*\047$/)) {
+                return substr(value, 2, length(value) - 2)
+            }
+            return value
+        }
+
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            stripped = trim(line)
+
+            if (stripped ~ /^#/) {
+                next
+            }
+
+            if (line ~ /^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*/) {
+                value = line
+                sub(/^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*/, "", value)
+                value = trim(value)
+                sub(/[[:space:]]+#.*/, "", value)
+                value = trim(value)
+                if (value != "") {
+                    print NR "\t" unquote(value)
+                }
+            }
+        }
+    ' "$workflow"
+}
+
 check_release_workflow_surface() {
     local workflow="$repo_root/.github/workflows/release.yml"
     [[ -f "$workflow" ]] || die ".github/workflows/release.yml not found"
@@ -284,18 +324,21 @@ check_release_workflow_surface() {
     ! grep -Eq '^    paths:' "$workflow" \
         || die ".github/workflows/release.yml tag publication must not use paths filters"
 
-    local validation_line container_setup_line tag_ref_restore_line annotated_tag_line main_ancestry_line repository_code_line
+    local validation_line container_setup_line checkout_line tag_ref_restore_line annotated_tag_line main_ancestry_line repository_code_line
     validation_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print $1; exit }')"
     container_setup_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /sudo apt-get install -y podman|podman build/ { print $1; exit }')"
     [[ -n "$validation_line" ]] && [[ -n "$container_setup_line" ]] && [[ "$validation_line" -lt "$container_setup_line" ]] \
         || die ".github/workflows/release.yml must validate the release tag before container setup"
 
+    checkout_line="$(workflow_uses_lines "$workflow" | awk -F '\t' '$2 ~ /^actions\/checkout(@|$)/ { print $1; exit }')"
     tag_ref_restore_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 == "git fetch --tags --force origin" { print $1; exit }')"
     annotated_tag_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git cat-file -t/ { print $1; exit }')"
     main_ancestry_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git merge-base --is-ancestor/ { print $1; exit }')"
     repository_code_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/") || $2 ~ /cargo build|podman build/ { print $1; exit }')"
     [[ -n "$tag_ref_restore_line" ]] \
         || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
+    [[ -n "$checkout_line" ]] && [[ "$checkout_line" -lt "$tag_ref_restore_line" ]] \
+        || die ".github/workflows/release.yml must restore annotated tag refs after checkout and before checking tag type"
     [[ -z "$annotated_tag_line" ]] || [[ "$tag_ref_restore_line" -lt "$annotated_tag_line" ]] \
         || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
     [[ -n "$annotated_tag_line" ]] && [[ -n "$main_ancestry_line" ]] && [[ -n "$repository_code_line" ]] \

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -324,7 +324,7 @@ check_release_workflow_surface() {
     ! grep -Eq '^    paths:' "$workflow" \
         || die ".github/workflows/release.yml tag publication must not use paths filters"
 
-    local validation_line container_setup_line checkout_line tag_ref_restore_line annotated_tag_line main_ancestry_line repository_code_line
+    local validation_line container_setup_line checkout_line tag_ref_restore_line event_identity_verify_line annotated_tag_line main_ancestry_line repository_code_line
     validation_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print $1; exit }')"
     container_setup_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /sudo apt-get install -y podman|podman build/ { print $1; exit }')"
     [[ -n "$validation_line" ]] && [[ -n "$container_setup_line" ]] && [[ "$validation_line" -lt "$container_setup_line" ]] \
@@ -332,6 +332,16 @@ check_release_workflow_surface() {
 
     checkout_line="$(workflow_uses_lines "$workflow" | awk -F '\t' '$2 ~ /^actions\/checkout(@|$)/ { print $1; exit }')"
     tag_ref_restore_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 == "git fetch --tags --force origin" { print $1; exit }')"
+    event_identity_verify_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '
+        $2 == "restored_commit=$(git rev-parse \"refs/tags/$GITHUB_REF_NAME^{commit}\")" {
+            saw_restored_commit = 1
+            next
+        }
+        saw_restored_commit && $2 == "if [ \"$restored_commit\" != \"$GITHUB_SHA\" ]; then" {
+            print $1
+            exit
+        }
+    ')"
     annotated_tag_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git cat-file -t/ { print $1; exit }')"
     main_ancestry_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git merge-base --is-ancestor/ { print $1; exit }')"
     repository_code_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/") || $2 ~ /cargo build|podman build/ { print $1; exit }')"
@@ -341,6 +351,9 @@ check_release_workflow_surface() {
         || die ".github/workflows/release.yml must restore annotated tag refs after checkout and before checking tag type"
     [[ -z "$annotated_tag_line" ]] || [[ "$tag_ref_restore_line" -lt "$annotated_tag_line" ]] \
         || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
+    [[ -n "$event_identity_verify_line" ]] && [[ "$tag_ref_restore_line" -lt "$event_identity_verify_line" ]] \
+        && { [[ -z "$annotated_tag_line" ]] || [[ "$event_identity_verify_line" -lt "$annotated_tag_line" ]]; } \
+        || die ".github/workflows/release.yml must verify the restored tag matches the triggering event before checking tag type"
     [[ -n "$annotated_tag_line" ]] && [[ -n "$main_ancestry_line" ]] && [[ -n "$repository_code_line" ]] \
         && [[ "$annotated_tag_line" -lt "$repository_code_line" ]] && [[ "$main_ancestry_line" -lt "$repository_code_line" ]] \
         || die ".github/workflows/release.yml must establish tag trust before running repository code"

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -284,15 +284,20 @@ check_release_workflow_surface() {
     ! grep -Eq '^    paths:' "$workflow" \
         || die ".github/workflows/release.yml tag publication must not use paths filters"
 
-    local validation_line container_setup_line annotated_tag_line main_ancestry_line repository_code_line
+    local validation_line container_setup_line tag_ref_restore_line annotated_tag_line main_ancestry_line repository_code_line
     validation_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print $1; exit }')"
     container_setup_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /sudo apt-get install -y podman|podman build/ { print $1; exit }')"
     [[ -n "$validation_line" ]] && [[ -n "$container_setup_line" ]] && [[ "$validation_line" -lt "$container_setup_line" ]] \
         || die ".github/workflows/release.yml must validate the release tag before container setup"
 
+    tag_ref_restore_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 == "git fetch --tags --force origin" { print $1; exit }')"
     annotated_tag_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git cat-file -t/ { print $1; exit }')"
     main_ancestry_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git merge-base --is-ancestor/ { print $1; exit }')"
     repository_code_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/") || $2 ~ /cargo build|podman build/ { print $1; exit }')"
+    [[ -n "$tag_ref_restore_line" ]] \
+        || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
+    [[ -z "$annotated_tag_line" ]] || [[ "$tag_ref_restore_line" -lt "$annotated_tag_line" ]] \
+        || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
     [[ -n "$annotated_tag_line" ]] && [[ -n "$main_ancestry_line" ]] && [[ -n "$repository_code_line" ]] \
         && [[ "$annotated_tag_line" -lt "$repository_code_line" ]] && [[ "$main_ancestry_line" -lt "$repository_code_line" ]] \
         || die ".github/workflows/release.yml must establish tag trust before running repository code"


### PR DESCRIPTION
## Summary

- Restores annotated tag refs after `actions/checkout@v4` so release tag-push workflows validate the original annotated tag object instead of checkout's lightweight local rewrite.
- Extends release metadata validation and workspace contract coverage so the refetch stays before the annotated-tag trust check.
- Adds an Unreleased changelog entry for the release workflow fix.

## Changes

- Adds `git fetch --tags --force origin` immediately after release checkout and before tag-trust checks.
- Requires release workflows to restore annotated tag refs before checking `git cat-file -t`.
- Covers missing and late refetch cases in release metadata tests.

## GitHub Issue(s)

Refs tesserine/commons#34

## Test plan

- `cargo fmt --check`
- `./scripts/release-check metadata`
- `cargo test -p agentd --test release_check`
- `cargo test -p agentd --test workspace_contract`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
