### PR TITLE
fix(release-check): reject empty artifact values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Release verification now rejects empty `--agentd-bin` and
+  `--container-image` option values instead of treating supplied empty values
+  as omitted artifact checks.
 
 ## [0.1.2-rc.3] — 2026-05-14
 ### Fixed

--- a/crates/agentd/tests/release_check.rs
+++ b/crates/agentd/tests/release_check.rs
@@ -1039,6 +1039,106 @@ fn release_rejects_tag_versions_that_do_not_match_workspace_version() {
 }
 
 #[test]
+fn release_rejects_empty_artifact_validation_values() {
+    let fixture = valid_fixture("release-empty-artifact-values", "1.2.3");
+
+    let output = fixture.run_release_check(&[
+        "release",
+        "v1.2.3",
+        "--agentd-bin",
+        "",
+        "--container-image",
+        "",
+    ]);
+
+    assert_failure_contains(&output, "--agentd-bin requires a non-empty path");
+}
+
+#[test]
+fn release_rejects_empty_agentd_binary_path_even_with_container_image() {
+    let fixture = valid_fixture("release-empty-agentd-bin", "1.2.3");
+    fixture.write(
+        "fake-runtime",
+        r#"#!/usr/bin/env sh
+set -eu
+case "$1" in
+  inspect)
+    printf 'v1.2.3\n'
+    ;;
+  create)
+    printf 'fake-container\n'
+    ;;
+  cp)
+    destination="$3"
+    cat >"$destination" <<'EOF'
+#!/usr/bin/env sh
+printf 'agentd 1.2.3\n'
+EOF
+    chmod +x "$destination"
+    ;;
+  rm)
+    exit 0
+    ;;
+  *)
+    echo "unexpected fake-runtime command: $*" >&2
+    exit 64
+    ;;
+esac
+"#,
+    );
+    fs::set_permissions(
+        fixture.root.join("fake-runtime"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("fake runtime should be executable");
+
+    let output = Command::new("bash")
+        .arg(fixture.root.join("scripts/release-check"))
+        .args([
+            "release",
+            "v1.2.3",
+            "--agentd-bin",
+            "",
+            "--container-image",
+            "localhost/agentd:v1.2.3",
+        ])
+        .current_dir(&fixture.root)
+        .env(
+            "AGENTD_CONTAINER_RUNTIME",
+            fixture.root.join("fake-runtime"),
+        )
+        .output()
+        .expect("release-check should run");
+
+    assert_failure_contains(&output, "--agentd-bin requires a non-empty path");
+}
+
+#[test]
+fn release_rejects_empty_container_image_even_with_agentd_binary_path() {
+    let fixture = valid_fixture("release-empty-container-image", "1.2.3");
+    fixture.write(
+        "fake-agentd",
+        "#!/usr/bin/env sh\nprintf 'agentd 1.2.3\\n'\n",
+    );
+    fs::set_permissions(
+        fixture.root.join("fake-agentd"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("fake binary should be executable");
+
+    let output = fixture.run_release_check(&[
+        "release",
+        "v1.2.3",
+        "--agentd-bin",
+        "fake-agentd",
+        "--container-image",
+        "",
+    ]);
+
+    assert_failure_contains(&output, "--container-image requires a non-empty image");
+}
+
+#[test]
 fn release_checks_agentd_binary_identity_when_a_binary_is_supplied() {
     let fixture = valid_fixture("release-binary-success", "1.2.3");
     fixture.write(

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -519,11 +519,13 @@ run_release() {
         case "$1" in
             --agentd-bin)
                 [[ "$#" -ge 2 ]] || die "--agentd-bin requires a path"
+                [[ -n "$2" ]] || die "--agentd-bin requires a non-empty path"
                 agentd_bin="$2"
                 shift 2
                 ;;
             --container-image)
                 [[ "$#" -ge 2 ]] || die "--container-image requires an image"
+                [[ -n "$2" ]] || die "--container-image requires a non-empty image"
                 container_image="$2"
                 shift 2
                 ;;


### PR DESCRIPTION
## Summary

- Rejects supplied empty `--agentd-bin` and `--container-image` values during release-check option parsing.
- Preserves source-only release validation when artifact options are omitted.
- Records the release-operator-visible behavior change in the changelog.

## Changes

- Adds parse-time non-empty checks for release artifact option values.
- Adds regression coverage for both-empty values and mixed empty/non-empty artifact validation arguments.
- Updates `CHANGELOG.md` under Unreleased / Fixed.

## GitHub Issue(s)

Closes #135

## Test plan

- RED: `cargo test -p agentd --test release_check release_rejects_empty -- --nocapture` failed before the parser change because the empty-value cases unexpectedly succeeded.
- GREEN: `cargo test -p agentd --test release_check release_rejects_empty -- --nocapture`
- `cargo test -p agentd --test release_check`
- `./scripts/release-check release v0.1.2-rc.3 --agentd-bin ""` fails with `--agentd-bin requires a non-empty path`
- `./scripts/release-check release v0.1.2-rc.3 --container-image ""` fails with `--container-image requires a non-empty image`
- `./scripts/release-check release v0.1.2-rc.3`
- `./scripts/release-check metadata`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace`

## Documentation

- Updated `CHANGELOG.md` for the user-visible release-check behavior change.
- Reviewed `RELEASING.md`, `README.md`, `ARCHITECTURE.md`, and `AGENTS.md`; no drifted claims found for this parser hardening.
