### PR TITLE
feat(session-config): forge field injected as GROUNDWORK_FORGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+**/target/
 .grok/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,7 @@ service:
 | Daemon socket and PID file | daemon process; host clients use the socket through the host mount | Configure explicit daemon runtime paths inside the container and mount their parent directory from the host runtime location. |
 | Host Podman socket | daemon process through the Podman client | Mount the host rootless Podman socket to the path named by `CONTAINER_HOST`. |
 | Credential sources | daemon process environment | Inject the environment variables named by agent credentials into the daemon container. |
+| Active forge | agent config | Set one forge tag per session; omitted values default to `github` and are injected as `GROUNDWORK_FORGE`. |
 | `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves direct relabelled methodology source | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
 | `audit_root` | daemon process creates/chmods; host Podman resolves direct relabelled audit sources; session containers write audit entries | Mount durable host storage at the configured audit root, with the daemon UID aligned to the session writer's mapped host UID or granted equivalent chmod authority. |
 | Agent-declared `mounts.source` | daemon process canonicalizes; host Podman resolves staged bind sources | Mount or expose each source so the daemon and host Podman agree on the source path. |
@@ -68,7 +69,7 @@ property.
 
 ### Terminology
 
-- **Agent**: a named, reusable environment specification in the daemon config — base image, methodology, optional default repo, optional schedule, credentials, and command. What the operator declares.
+- **Agent**: a named, reusable environment specification in the daemon config — base image, methodology, optional active forge, optional default repo, optional schedule, credentials, and command. What the operator declares.
 - **Session**: a single execution created from an agent plus invocation parameters (repo, work unit, timeout). What the runner manages.
 
 ## 2. Agent Capability Needs
@@ -183,7 +184,7 @@ The runner prepares the execution environment:
 
 1. Creates an ephemeral Podman container from the agent's configured base image. That image must provide a POSIX-compatible shell at `/bin/sh` because the runner's container entrypoint executes through that path.
 2. Sets identity inside the container, including `AGENT_NAME` and a unique container name derived from the agent.
-3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments.
+3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments, and injects the non-secret active forge tag as `GROUNDWORK_FORGE`.
 4. Mounts the configured methodology directory read-only.
 5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}` and UID/GID `1000`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `groupadd`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, `git://`, `ssh://`, and `user@host:path` SSH repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. SSH clone runs as the session user with `HOME=/home/{username}` so OpenSSH reads agent-scoped mounted material under that home, typically `/home/{username}/.ssh`; it does not use `repo_token_source`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before `runa init` and the agent command start. Base images that lack `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, or `runa`, or that cannot reserve UID/GID `1000` for the session user, are not supported. SSH clone additionally requires an OpenSSH-compatible client in the base image.
 6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{agent}/{session_id}/`, writes start metadata to `agentd/session.json`, bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa`, and bind-mounts `agentd/transcript/` at `/agentd/transcript` before the runtime initializes runa state.
@@ -240,6 +241,7 @@ agentd runs sessions in ephemeral Podman containers so agents remain separated f
 
 From inside the environment, an agent should see:
 - identity-related environment variables
+- `GROUNDWORK_FORGE`, the active forge tag Groundwork reads to resolve forge-specific mechanics
 - `$HOME` set to `/home/{username}`
 - a read-only methodology mount rooted at `manifest.toml`
 - a read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Runner setup now supports SSH repository clone through agent-scoped mounted
   OpenSSH material, including `ssh://` and `user@host:path` repository URLs.
+- Agent configuration now accepts an optional `forge` field and injects the
+  selected value as `GROUNDWORK_FORGE`, defaulting omitted values to `github`.
 
 ## [0.1.2] — 2026-05-17
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ explicit override for root-owned installs such as `/var/lib/tesserine/audit/`.
 ## Configuration
 
 An agent is a named environment specification: base image, methodology
-directory, optional additional bind mounts, optional default repo, optional
-cron schedule, credentials, and exact command argv. Define agents in a TOML
+directory, optional active forge, optional additional bind mounts, optional
+default repo, optional cron schedule, credentials, and exact command argv. Define agents in a TOML
 config file — start from
 [`examples/agentd.toml`](examples/agentd.toml):
 
@@ -73,6 +73,9 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
+# Optional active forge tag injected as GROUNDWORK_FORGE for Groundwork.
+# Defaults to "github" when omitted.
+#forge = "github"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
 # and for every scheduled run of this agent. HTTPS, HTTP, git://, ssh://, and
 # user@host:path SSH forms are accepted.
@@ -138,9 +141,11 @@ relabelled by Podman from their canonical host source paths. The base image
 must provide `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, `runa`,
 and whatever binaries the declared agent command uses. SSH repository clone
 also requires an OpenSSH-compatible client in the base image. UID/GID `1000`
-must be available for the session user. When an agent declares `schedule`, it must also
-declare `repo`. Schedules are evaluated in daemon-local time and missed fires
-are not backfilled after downtime. Persistent audit records default to
+must be available for the session user. The optional `forge` value declares one
+active forge for each session and is injected as `GROUNDWORK_FORGE`; when
+omitted, agentd injects `github`. When an agent declares `schedule`, it must
+also declare `repo`. Schedules are evaluated in daemon-local time and missed
+fires are not backfilled after downtime. Persistent audit records default to
 `$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set
 `daemon.audit_root` to override that for system installations.
 
@@ -320,6 +325,7 @@ the container, the agent sees:
 - A runner-managed read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied
 - Any operator-declared additional bind mounts, read-only or read-write per agent
 - Credentials injected as environment variables
+- `GROUNDWORK_FORGE` with the configured active forge, defaulting to `github`
 - `AGENTD_WORK_UNIT` when the invocation includes one
 - A pre-materialized artifact under `.runa/workspace/...` when the invocation includes `--request` or `--artifact-file`
 - `runa init` state followed by `runa run --agent-command -- <argv>` from the repo directory

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -1207,6 +1207,30 @@ fn run_session_injects_empty_environment_values_via_direct_env_args() {
 }
 
 #[test]
+fn run_session_injects_active_forge_as_groundwork_forge_environment() {
+    let _guard = fake_podman_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let fixture = FakePodmanFixture::new();
+    fixture.install(&FakePodmanScenario::new());
+
+    let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+    let outcome = fixture.run_with_fake_podman(crate::SessionSpec {
+        methodology_dir,
+        forge: "sourcehut".to_string(),
+        ..test_session_spec()
+    });
+
+    assert_eq!(
+        outcome.expect("session should succeed with fake podman"),
+        SessionOutcome::Success { exit_code: 0 }
+    );
+
+    let create_args = fixture.create_args();
+    assert!(create_args.contains("--env GROUNDWORK_FORGE=sourcehut"));
+}
+
+#[test]
 fn run_session_reuses_one_session_identifier_for_container_stage_and_secret_names() {
     let _guard = fake_podman_lock()
         .lock()

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -18,6 +18,7 @@ pub(crate) fn test_session_spec() -> SessionSpec {
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
         audit_root: std::env::temp_dir().join("agentd-runner-test-audit-root"),
+        forge: "github".to_string(),
         mounts: Vec::new(),
         agent_command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 /// Static configuration for a session, derived from an agent.
 ///
-/// Describes the agent identity, container image, methodology, command, and
-/// caller-resolved environment variables. Validated by
+/// Describes the agent identity, container image, methodology, active forge,
+/// command, and caller-resolved environment variables. Validated by
 /// [`run_session`](crate::run_session) before any resources are allocated.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionSpec {
@@ -39,6 +39,9 @@ pub struct SessionSpec {
     /// Host-side root where persistent audit records are created. The runner
     /// stores each session under `<audit_root>/<agent>/<session_id>/`.
     pub audit_root: PathBuf,
+    /// Active forge tag exposed to the session as `GROUNDWORK_FORGE` so
+    /// Groundwork can resolve forge-invariant operations.
+    pub forge: String,
     /// Additional host bind mounts declared by the selected agent.
     pub mounts: Vec<BindMount>,
     /// Command array executed directly from the cloned repository after
@@ -49,8 +52,9 @@ pub struct SessionSpec {
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
     /// Names reserved for runner-owned values such as `AGENT_NAME`,
-    /// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
-    /// `RUNA_TRANSCRIPT_REDACT_ENV` are rejected during validation.
+    /// `GROUNDWORK_FORGE`, `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`,
+    /// `RUNA_TRANSCRIPT_DIR`, and `RUNA_TRANSCRIPT_REDACT_ENV` are rejected
+    /// during validation.
     pub environment: Vec<ResolvedEnvironmentVariable>,
 }
 
@@ -332,6 +336,9 @@ pub enum RunnerError {
     /// The configured audit root path is not absolute. Produced during spec
     /// validation.
     InvalidAuditRoot { path: PathBuf },
+    /// The active forge tag is empty or has surrounding whitespace. Produced
+    /// during spec validation.
+    InvalidForge { forge: String },
     /// The repository URL is not a supported remote form (`https://`,
     /// `http://`, `git://`), embeds credentials, or is paired with
     /// `repo_token` without using `https://`. Produced during invocation
@@ -401,6 +408,10 @@ impl fmt::Display for RunnerError {
             RunnerError::InvalidAuditRoot { path } => {
                 write!(f, "audit_root must be an absolute path: {}", path.display())
             }
+            RunnerError::InvalidForge { forge } => write!(
+                f,
+                "forge must not be empty or contain surrounding whitespace: {forge:?}"
+            ),
             RunnerError::InvalidRepoUrl { message } => write!(f, "repo_url {message}"),
             RunnerError::InvalidInvocationInput { message } => write!(f, "{message}"),
             RunnerError::InvalidCommand => {

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 const AGENT_NAME_ENV: &str = "AGENT_NAME";
+const GROUNDWORK_FORGE_ENV: &str = "GROUNDWORK_FORGE";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
 pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
 pub(crate) const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
@@ -39,6 +40,11 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
     if !spec.audit_root.is_absolute() {
         return Err(RunnerError::InvalidAuditRoot {
             path: spec.audit_root.clone(),
+        });
+    }
+    if spec.forge.trim().is_empty() || spec.forge != spec.forge.trim() {
+        return Err(RunnerError::InvalidForge {
+            forge: spec.forge.clone(),
         });
     }
     if spec.agent_command.is_empty() || spec.agent_command.iter().any(|arg| arg.is_empty()) {
@@ -164,8 +170,8 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
 /// Validates an environment variable name against naming rules.
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
-/// runner-managed names such as `AGENT_NAME`, `AGENTD_WORK_UNIT`,
-/// `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
+/// runner-managed names such as `AGENT_NAME`, `GROUNDWORK_FORGE`,
+/// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
 /// `RUNA_TRANSCRIPT_REDACT_ENV`. Used both by
 /// [`run_session`](crate::run_session) during spec validation and by the
 /// configuration layer for credential name validation.
@@ -224,8 +230,11 @@ pub fn validate_repo_url(repo_url: &str) -> Result<(), RunnerError> {
 ///
 /// These names are reserved — callers cannot use them in
 /// [`SessionSpec::environment`] because the runner injects them directly.
-pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> [(&str, &str); 1] {
-    [(AGENT_NAME_ENV, &spec.agent_name)]
+pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> [(&str, &str); 2] {
+    [
+        (AGENT_NAME_ENV, &spec.agent_name),
+        (GROUNDWORK_FORGE_ENV, &spec.forge),
+    ]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -363,6 +372,7 @@ fn is_reserved_environment_name(name: &str) -> bool {
     matches!(
         name,
         AGENT_NAME_ENV
+            | GROUNDWORK_FORGE_ENV
             | WORK_UNIT_ENV
             | REPO_TOKEN_ENV
             | TRANSCRIPT_DIR_ENV
@@ -476,6 +486,7 @@ mod tests {
     fn validate_spec_rejects_reserved_environment_names() {
         for reserved_name in [
             "AGENT_NAME",
+            "GROUNDWORK_FORGE",
             WORK_UNIT_ENV,
             REPO_TOKEN_ENV,
             "RUNA_TRANSCRIPT_DIR",
@@ -523,6 +534,31 @@ mod tests {
             assert!(
                 matches!(error, RunnerError::InvalidDaemonInstanceId),
                 "expected InvalidDaemonInstanceId for {daemon_instance_id:?}, got {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_spec_rejects_empty_or_whitespace_padded_forge() {
+        for forge in ["", " ", " sourcehut", "sourcehut "] {
+            let error = validate_spec(&SessionSpec {
+                forge: forge.to_string(),
+                ..test_session_spec()
+            })
+            .expect_err("forge values must be non-empty and trimmed");
+
+            match &error {
+                RunnerError::InvalidForge {
+                    forge: invalid_forge,
+                } => {
+                    assert_eq!(invalid_forge, forge);
+                }
+                other => panic!("expected InvalidForge, got {other:?}"),
+            }
+
+            assert!(
+                error.to_string().contains("forge"),
+                "invalid forge error should explain forge validation: {error}"
             );
         }
     }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -135,6 +135,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec![
                 "site-builder".to_string(),
@@ -190,6 +191,7 @@ fn materializes_request_text_input_before_session_command_runs() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -237,6 +239,7 @@ fn materializes_generic_artifact_input_before_session_command_runs() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -287,6 +290,7 @@ fn rejects_request_text_when_methodology_declares_an_unsupported_request_version
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),
@@ -331,6 +335,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -383,6 +388,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -427,6 +433,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -477,6 +484,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -528,6 +536,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -588,6 +597,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readonly-mount-run/.claude"),
@@ -657,6 +667,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readwrite-mount-run/.runa"),
@@ -730,6 +741,7 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/nested-home-mount-run/.config/claude"),
@@ -781,6 +793,7 @@ fn preserves_session_user_access_to_preexisting_home_content() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -823,6 +836,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -921,6 +935,7 @@ fn persists_session_transcript_under_agentd_audit_dir() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -991,6 +1006,7 @@ fn finalizes_session_after_runtime_restricts_transcript_directory_permissions() 
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1065,6 +1081,7 @@ fn finalizes_session_after_runtime_restricts_events_jsonl_permissions() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1139,6 +1156,7 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1238,6 +1256,7 @@ fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes(
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: audit_root.clone(),
+            forge: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/audit-hard-link-run/shared"),
@@ -1316,6 +1335,7 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1383,6 +1403,7 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -1435,6 +1456,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 base_image: image,
                 methodology_dir,
                 audit_root: audit_root.clone(),
+                forge: "github".to_string(),
                 mounts: Vec::new(),
                 agent_command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![
@@ -1493,6 +1515,7 @@ fn clones_ssh_repo_with_agent_scoped_mounted_identity() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: vec![BindMount {
                 source: ssh_dir,
                 target: PathBuf::from("/home/ssh-clone-run/.ssh"),
@@ -1540,6 +1563,7 @@ fn ssh_repo_clone_cannot_use_another_agents_unmounted_identity() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
+            forge: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -3,10 +3,10 @@
 //! Bridges operator-facing configuration to daemon dispatch and the runner's
 //! [`SessionSpec`] model. Validation here is stricter than the runner's own
 //! validation — it enforces uniqueness (no duplicate agent or credential
-//! names), non-empty fields, and whitespace hygiene in addition to the
-//! runner's format and reservation rules. Relative daemon runtime paths and
-//! `methodology_dir` are resolved against the configuration file location when
-//! loaded from disk.
+//! names), non-empty fields, active forge defaulting, and whitespace hygiene
+//! in addition to the runner's format and reservation rules. Relative daemon
+//! runtime paths and `methodology_dir` are resolved against the configuration
+//! file location when loaded from disk.
 //!
 //! [`SessionSpec`]: agentd_runner::SessionSpec
 
@@ -25,13 +25,15 @@ use sha2::{Digest, Sha256};
 
 use crate::runtime_paths::{RuntimePathError, default_daemon_runtime_paths};
 
+const DEFAULT_ACTIVE_FORGE: &str = "github";
+
 /// Validated daemon and agent registry parsed from a TOML configuration file.
 ///
 /// Guarantees that daemon runtime paths are present, all agent names are
-/// unique and valid, all required fields are non-empty, and all credential
-/// names are valid environment variable names. Relative daemon runtime paths
-/// and `methodology_dir` paths are resolved against the configuration file's
-/// parent directory.
+/// unique and valid, all required fields are non-empty, active forge defaults
+/// are applied, and all credential names are valid environment variable names.
+/// Relative daemon runtime paths and `methodology_dir` paths are resolved
+/// against the configuration file's parent directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     daemon: DaemonConfig,
@@ -137,6 +139,13 @@ impl Config {
                     Some(value)
                 }
                 None => None,
+            };
+            let forge = match raw_agent.forge {
+                Some(value) => {
+                    validate_lookup_key("forge", &value, Some(raw_agent.name.as_str()), None)?;
+                    value
+                }
+                None => DEFAULT_ACTIVE_FORGE.to_string(),
             };
 
             if raw_agent.command.argv.is_empty() {
@@ -263,6 +272,7 @@ impl Config {
                 repo,
                 schedule,
                 repo_token_source,
+                forge,
                 credentials,
                 agent_command,
             });
@@ -300,6 +310,7 @@ pub struct Agent {
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
+    forge: String,
     credentials: Vec<CredentialConfig>,
     agent_command: Vec<String>,
 }
@@ -342,6 +353,12 @@ impl Agent {
     /// not injected into the session runtime environment.
     pub fn repo_token_source(&self) -> Option<&str> {
         self.repo_token_source.as_deref()
+    }
+
+    /// Active forge tag injected into each launched session for Groundwork
+    /// forge-specific operation resolution.
+    pub fn forge(&self) -> &str {
+        &self.forge
     }
 
     /// Declared credentials for this agent. Each credential's name is a
@@ -647,12 +664,10 @@ impl fmt::Display for ConfigError {
                     "agent '{agent}' defines duplicate credential name '{name}'"
                 )
             }
-            ConfigError::InvalidCredentialName { agent, name } => {
-                write!(
-                    f,
-                    "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
-                )
-            }
+            ConfigError::InvalidCredentialName { agent, name } => write!(
+                f,
+                "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, GROUNDWORK_FORGE, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
+            ),
             ConfigError::EmptyField {
                 field,
                 agent,
@@ -826,6 +841,7 @@ struct RawAgent {
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
+    forge: Option<String>,
     #[serde(default)]
     credentials: Vec<RawCredentialConfig>,
 }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -170,7 +170,8 @@ pub fn run_daemon_until_shutdown(
     })
 }
 
-fn run_daemon_until_shutdown_with_reconciler<F>(
+#[doc(hidden)]
+pub fn run_daemon_until_shutdown_with_reconciler<F>(
     config: Config,
     executor: impl SessionExecutor + Send + Sync + Clone + 'static,
     shutdown: Arc<AtomicBool>,

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -157,6 +157,7 @@ pub fn dispatch_run(
                 base_image: agent.base_image().to_string(),
                 methodology_dir: agent.methodology_dir().to_path_buf(),
                 audit_root,
+                forge: agent.forge().to_string(),
                 mounts: agent
                     .mounts()
                     .iter()

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -106,8 +106,12 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
-    use crate::{SessionExecutor, run_daemon_until_shutdown};
-    use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+    use agentd_runner::{
+        RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    };
+
+    use crate::SessionExecutor;
+    use crate::daemon::run_daemon_until_shutdown_with_reconciler;
 
     #[derive(Clone)]
     struct RecordingExecutor {
@@ -227,7 +231,12 @@ argv = ["site-builder", "exec"]
         let daemon_shutdown = Arc::clone(&shutdown);
         let (executor, invocations) = RecordingExecutor::new();
         let handle = thread::spawn(move || {
-            run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown)
+            run_daemon_until_shutdown_with_reconciler(
+                daemon_config,
+                executor,
+                daemon_shutdown,
+                || Ok(StartupReconciliationReport::default()),
+            )
         });
         wait_for_path(config.daemon().socket_path());
 

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -1,4 +1,6 @@
+use std::ffi::OsString;
 use std::io;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -6,9 +8,13 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use agentd::SessionExecutor;
 use agentd::config::Config;
-use agentd::{SessionExecutor, run_daemon_until_shutdown};
-use agentd_runner::{InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
+use agentd_runner::{
+    InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
+    StartupReconciliationReport,
+};
 use serde_json::json;
 
 type DaemonHandle = thread::JoinHandle<Result<(), agentd::DaemonError>>;
@@ -163,6 +169,63 @@ fn wait_for_path(path: &Path) {
     panic!("timed out waiting for {}", path.display());
 }
 
+fn fake_podman_path(name: &str) -> OsString {
+    let unique = format!(
+        "agentd-cli-fake-podman-{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    );
+    let bin_dir = std::env::temp_dir().join(unique).join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("fake podman bin dir should be created");
+    let podman_path = bin_dir.join("podman");
+    std::fs::write(
+        &podman_path,
+        r#"#!/bin/sh
+case "$1" in
+  ps)
+    printf '[]\n'
+    ;;
+  secret)
+    case "$2" in
+      ls)
+        exit 0
+        ;;
+      rm)
+        exit 0
+        ;;
+      *)
+        echo "unexpected podman secret command: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  rm)
+    exit 0
+    ;;
+  *)
+    echo "unexpected podman command: $*" >&2
+    exit 1
+    ;;
+esac
+"#,
+    )
+    .expect("fake podman script should be written");
+    let mut permissions = std::fs::metadata(&podman_path)
+        .expect("fake podman metadata should be readable")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&podman_path, permissions)
+        .expect("fake podman script should be executable");
+
+    std::env::join_paths(std::iter::once(bin_dir).chain(std::env::split_paths(
+        &std::env::var_os("PATH").expect("PATH should exist for tests"),
+    )))
+    .expect("fake podman PATH should be constructible")
+}
+
 fn terminate(child: &mut Child) -> io::Result<()> {
     let status = Command::new("kill")
         .args(["-TERM", &child.id().to_string()])
@@ -181,8 +244,11 @@ fn start_test_daemon(
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let executor = FixedOutcomeExecutor { outcome };
-    let handle =
-        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_with_reconciler(daemon_config, executor, daemon_shutdown, || {
+            Ok(StartupReconciliationReport::default())
+        })
+    });
     wait_for_path(config.daemon().socket_path());
     (shutdown, handle, config)
 }
@@ -196,8 +262,11 @@ fn start_recording_test_daemon(
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let (executor, invocations) = RecordingInvocationExecutor::new(outcome);
-    let handle =
-        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_with_reconciler(daemon_config, executor, daemon_shutdown, || {
+            Ok(StartupReconciliationReport::default())
+        })
+    });
     wait_for_path(config.daemon().socket_path());
     (shutdown, handle, config, invocations)
 }
@@ -267,6 +336,7 @@ fn binary_daemon_subcommand_starts_daemon_mode() {
             config_path.to_str().expect("config path should be utf-8"),
         ])
         .env("AGENTD_LOG_FORMAT", "text")
+        .env("PATH", fake_podman_path("daemon-subcommand"))
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
@@ -316,6 +386,7 @@ fn binary_bare_command_with_config_starts_daemon_mode() {
             config_path.to_str().expect("config path should be utf-8"),
         ])
         .env("AGENTD_LOG_FORMAT", "text")
+        .env("PATH", fake_podman_path("bare-command"))
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -192,6 +192,7 @@ fn parses_example_config_into_static_agent_settings() {
         site_builder.repo_token_source(),
         Some("SITE_BUILDER_REPO_TOKEN")
     );
+    assert_eq!(site_builder.forge(), "github");
     assert_eq!(site_builder.agent_command(), ["site-builder", "exec"]);
     assert_eq!(site_builder.credentials().len(), 1);
     assert_eq!(site_builder.credentials()[0].name(), "GITHUB_TOKEN");
@@ -216,6 +217,7 @@ fn parses_example_config_into_static_agent_settings() {
         code_reviewer.repo_token_source(),
         Some("CODE_REVIEWER_REPO_TOKEN")
     );
+    assert_eq!(code_reviewer.forge(), "github");
     assert_eq!(code_reviewer.agent_command(), ["code-reviewer", "exec"]);
     assert_eq!(code_reviewer.credentials().len(), 1);
     assert_eq!(code_reviewer.credentials()[0].name(), "GITHUB_TOKEN");
@@ -827,6 +829,61 @@ argv = ["site-builder", "exec"]
 }
 
 #[test]
+fn parses_agent_forge_as_active_session_forge() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-forge");
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+forge = "sourcehut"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse active forge");
+
+    let agent = config.agent("site-builder").expect("agent should exist");
+
+    assert_eq!(agent.forge(), "sourcehut");
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+
+#[test]
+fn defaults_agent_forge_to_github_when_omitted() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("default-agent-forge");
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should default active forge");
+
+    let agent = config.agent("site-builder").expect("agent should exist");
+
+    assert_eq!(agent.forge(), "github");
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+
+#[test]
 fn parses_agent_repo_as_optional_default_clone_url() {
     let _guard = env_lock()
         .lock()
@@ -1314,6 +1371,68 @@ argv = ["site-builder", "exec"]
             }
             other => panic!("expected whitespace validation error, got {other}"),
         }
+    }
+}
+
+#[test]
+fn rejects_agent_forge_with_outer_whitespace() {
+    for forge in [" sourcehut", "sourcehut "] {
+        let error = Config::from_str(&format!(
+            r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+forge = "{forge}"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#
+        ))
+        .expect_err("whitespace-padded forge values should be rejected");
+
+        match error {
+            ConfigError::FieldHasOuterWhitespace {
+                field,
+                agent,
+                credential,
+            } => {
+                assert_eq!(field, "forge");
+                assert_eq!(agent.as_deref(), Some("site-builder"));
+                assert_eq!(credential, None);
+            }
+            other => panic!("expected whitespace validation error, got {other}"),
+        }
+    }
+}
+
+#[test]
+fn rejects_empty_agent_forge() {
+    let error = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+forge = ""
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect_err("empty forge values should be rejected");
+
+    match error {
+        ConfigError::EmptyField {
+            field,
+            agent,
+            credential,
+        } => {
+            assert_eq!(field, "forge");
+            assert_eq!(agent.as_deref(), Some("site-builder"));
+            assert_eq!(credential, None);
+        }
+        other => panic!("expected empty field validation error, got {other}"),
     }
 }
 

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -7,12 +7,14 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use agentd::config::{Config, ConfigError};
+use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
 use agentd::{
     ClientError, DaemonError, RunRequest, RunnerSessionExecutor, SessionExecutor, request_run,
-    run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
-use agentd_runner::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
+use agentd_runner::{
+    RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+};
 use serde_json::json;
 
 fn env_lock() -> &'static Mutex<()> {
@@ -205,6 +207,17 @@ fn wait_for_path_removal(path: &std::path::Path) {
     panic!("timed out waiting for removal of {}", path.display());
 }
 
+fn run_daemon_until_shutdown_for_test(
+    config: Config,
+    executor: impl SessionExecutor + Send + Sync + Clone + 'static,
+    shutdown: Arc<AtomicBool>,
+) -> Result<(), DaemonError> {
+    let _daemon_instance_id = config.daemon().daemon_instance_id()?;
+    run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
+        Ok(StartupReconciliationReport::default())
+    })
+}
+
 #[test]
 fn daemon_reports_run_outcome_back_through_client_request() {
     let _guard = env_lock()
@@ -221,8 +234,9 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     let executor = FixedOutcomeExecutor {
         outcome: SessionOutcome::GenericFailure { exit_code: 23 },
     };
-    let handle =
-        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
     wait_for_path(config.daemon().socket_path());
 
     let outcome = request_run(
@@ -287,8 +301,9 @@ fn daemon_round_trips_typed_invocation_input_through_the_socket_protocol() {
     let daemon_shutdown = shutdown.clone();
     let (executor, invocations) =
         RecordingInvocationExecutor::new(SessionOutcome::Success { exit_code: 0 });
-    let handle =
-        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
     wait_for_path(config.daemon().socket_path());
 
     let outcome = request_run(
@@ -341,7 +356,7 @@ fn daemon_rejects_conflicting_work_unit_and_input_from_socket_callers() {
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, RunnerSessionExecutor, daemon_shutdown)
+        run_daemon_until_shutdown_for_test(daemon_config, RunnerSessionExecutor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -398,11 +413,12 @@ fn starting_second_daemon_instance_fails_with_existing_pid() {
     let executor = FixedOutcomeExecutor {
         outcome: SessionOutcome::Success { exit_code: 0 },
     };
-    let first_handle =
-        thread::spawn(move || run_daemon_until_shutdown(first_config, executor, first_shutdown));
+    let first_handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(first_config, executor, first_shutdown)
+    });
     wait_for_path(config.daemon().socket_path());
 
-    let second_result = run_daemon_until_shutdown(
+    let second_result = run_daemon_until_shutdown_for_test(
         config.clone(),
         FixedOutcomeExecutor {
             outcome: SessionOutcome::Success { exit_code: 0 },
@@ -443,8 +459,9 @@ fn daemon_shutdown_removes_pid_file_and_socket() {
     let executor = FixedOutcomeExecutor {
         outcome: SessionOutcome::Success { exit_code: 0 },
     };
-    let handle =
-        thread::spawn(move || run_daemon_until_shutdown(daemon_config, executor, daemon_shutdown));
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
     wait_for_path(config.daemon().socket_path());
     wait_for_path(config.daemon().pid_file());
 
@@ -486,7 +503,7 @@ fn daemon_accepts_additional_runs_while_a_previous_run_is_still_executing() {
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -581,7 +598,7 @@ fn daemon_shutdown_waits_for_an_in_flight_run_to_finish() {
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -645,7 +662,7 @@ fn daemon_shutdown_stops_accepting_new_runs() {
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(daemon_config, daemon_executor, daemon_shutdown)
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
     });
     wait_for_path(config.daemon().socket_path());
 
@@ -737,7 +754,7 @@ source = "AGENTD_GITHUB_TOKEN"
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let handle = thread::spawn(move || {
-        run_daemon_until_shutdown(
+        run_daemon_until_shutdown_for_test(
             daemon_config,
             FixedOutcomeExecutor {
                 outcome: SessionOutcome::Success { exit_code: 0 },
@@ -782,7 +799,7 @@ fn daemon_startup_refuses_to_delete_a_non_socket_socket_path() {
     std::fs::write(config.daemon().socket_path(), original_contents)
         .expect("non-socket placeholder file should be written");
 
-    let error = run_daemon_until_shutdown(
+    let error = run_daemon_until_shutdown_for_test(
         config.clone(),
         FixedOutcomeExecutor {
             outcome: SessionOutcome::Success { exit_code: 0 },
@@ -824,7 +841,7 @@ argv = ["site-builder", "exec"]
     )
     .expect("config should parse");
 
-    let error = run_daemon_until_shutdown(
+    let error = run_daemon_until_shutdown_for_test(
         config,
         FixedOutcomeExecutor {
             outcome: SessionOutcome::Success { exit_code: 0 },

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -109,6 +109,22 @@ source = "AGENTD_GITHUB_TOKEN"
     .expect("config should parse")
 }
 
+fn config_with_forge(forge: &str) -> Config {
+    Config::from_str(&format!(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+forge = "{forge}"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#
+    ))
+    .expect("config should parse")
+}
+
 fn config_with_mounts() -> Config {
     Config::from_str(
         r#"
@@ -162,6 +178,61 @@ argv = ["code-reviewer", "exec"]
 "#,
     )
     .expect("config should parse")
+}
+
+#[test]
+fn dispatch_run_forwards_active_forge_into_session_spec() {
+    let config = config_with_forge("sourcehut");
+    let request = RunRequest {
+        agent: "site-builder".to_string(),
+        repo_url: Some("https://example.com/repo.git".to_string()),
+        work_unit: None,
+        input: None,
+    };
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
+
+    let state = state.lock().expect("recording state should lock");
+    let spec = state
+        .last_spec
+        .as_ref()
+        .expect("executor should receive spec");
+
+    assert_eq!(spec.forge, "sourcehut");
+}
+
+#[test]
+fn dispatch_run_defaults_active_forge_to_github() {
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse");
+    let request = RunRequest {
+        agent: "site-builder".to_string(),
+        repo_url: Some("https://example.com/repo.git".to_string()),
+        work_unit: None,
+        input: None,
+    };
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
+
+    let state = state.lock().expect("recording state should lock");
+    let spec = state
+        .last_spec
+        .as_ref()
+        .expect("executor should receive spec");
+
+    assert_eq!(spec.forge, "github");
 }
 
 #[test]

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -16,6 +16,9 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
+# Optional active forge tag injected as GROUNDWORK_FORGE for Groundwork.
+# Defaults to "github" when omitted.
+#forge = "github"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
 # and for each scheduled run of this agent.
 repo = "https://github.com/pentaxis93/agentd.git"


### PR DESCRIPTION
## Summary

- Adds an optional per-agent `forge` field that defaults to `github`.
- Injects the selected active forge into launched sessions as runner-owned `GROUNDWORK_FORGE`.
- Documents the agentd to Groundwork contract and covers explicit/default forge behavior in tests.

## Changes

- Config parsing now carries `forge` through `Agent` and rejects empty or whitespace-padded values.
- Dispatch forwards the active forge into `agentd-runner::SessionSpec`.
- Runner validation reserves `GROUNDWORK_FORGE`, injects it into `podman create`, and validates direct runner callers provide a non-empty trimmed forge.
- README, architecture docs, example config, and changelog describe the new field and contract symbol.

## GitHub Issue(s)

Closes #141

## Test plan

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p agentd-runner`
- `cargo test -p agentd --test config_parsing --test session_dispatch`
- `cargo test -p agentd-scheduler`

Note: `cargo test -p agentd` is blocked in this container because `podman` is not installed. The failing scheduler daemon test starts full daemon startup, which runs Podman startup reconciliation before binding its socket.
