### PR TITLE
refactor(session-config): rename forge type contract

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ service:
 | Daemon socket and PID file | daemon process; host clients use the socket through the host mount | Configure explicit daemon runtime paths inside the container and mount their parent directory from the host runtime location. |
 | Host Podman socket | daemon process through the Podman client | Mount the host rootless Podman socket to the path named by `CONTAINER_HOST`. |
 | Credential sources | daemon process environment | Inject the environment variables named by agent credentials into the daemon container. |
-| Active forge | agent config | Set one forge tag per session; omitted values default to `github` and are injected as `GROUNDWORK_FORGE`. |
+| Active forge type | agent config | Set one forge type per session; omitted values default to `github` and are injected as `GROUNDWORK_FORGE_TYPE`. |
 | `methodology_dir` and request/artifact schemas | daemon process reads; host Podman resolves direct relabelled methodology source | The path must exist for the daemon and be valid from the host Podman service's filesystem view. |
 | `audit_root` | daemon process creates/chmods; host Podman resolves direct relabelled audit sources; session containers write audit entries | Mount durable host storage at the configured audit root, with the daemon UID aligned to the session writer's mapped host UID or granted equivalent chmod authority. |
 | Agent-declared `mounts.source` | daemon process canonicalizes; host Podman resolves staged bind sources | Mount or expose each source so the daemon and host Podman agree on the source path. |
@@ -69,7 +69,7 @@ property.
 
 ### Terminology
 
-- **Agent**: a named, reusable environment specification in the daemon config — base image, methodology, optional active forge, optional default repo, optional schedule, credentials, and command. What the operator declares.
+- **Agent**: a named, reusable environment specification in the daemon config — base image, methodology, optional active forge type, optional default repo, optional schedule, credentials, and command. What the operator declares.
 - **Session**: a single execution created from an agent plus invocation parameters (repo, work unit, timeout). What the runner manages.
 
 ## 2. Agent Capability Needs
@@ -184,7 +184,7 @@ The runner prepares the execution environment:
 
 1. Creates an ephemeral Podman container from the agent's configured base image. That image must provide a POSIX-compatible shell at `/bin/sh` because the runner's container entrypoint executes through that path.
 2. Sets identity inside the container, including `AGENT_NAME` and a unique container name derived from the agent.
-3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments, and injects the non-secret active forge tag as `GROUNDWORK_FORGE`.
+3. Injects caller-resolved credentials as environment variables for that session only via Podman-managed secrets rather than inline CLI arguments, and injects the non-secret active forge type as `GROUNDWORK_FORGE_TYPE`.
 4. Mounts the configured methodology directory read-only.
 5. Creates an unprivileged unix user whose username is the configured agent name, with home directory `/home/{username}` and UID/GID `1000`, and clones the requested repository into `/home/{username}/repo`. This clone step is a plain in-container `git clone`: the base image must provide `git`, `find`, `groupadd`, `useradd`, and `gosu` in `PATH`, it accepts `https://`, `http://`, `git://`, `ssh://`, and `user@host:path` SSH repository URLs, rejects credential-bearing URLs up front, and can authenticate private HTTPS clones with an invocation-scoped bearer `repo_token`. SSH clone runs as the session user with `HOME=/home/{username}` so OpenSSH reads agent-scoped mounted material under that home, typically `/home/{username}/.ssh`; it does not use `repo_token_source`. The token is injected through a Podman secret, converted into one-shot git configuration for the clone process only, and removed before `runa init` and the agent command start. Base images that lack `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, or `runa`, or that cannot reserve UID/GID `1000` for the session user, are not supported. SSH clone additionally requires an OpenSSH-compatible client in the base image.
 6. Resolves the host audit root, creates it if needed, and probes writability before accepting work. The default for rootless deployments is `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` when `XDG_STATE_HOME` is unset. Operators may override that with `daemon.audit_root`; root-owned system installs should typically point it at `/var/lib/tesserine/audit`. After resolution, the runner allocates a host audit record at `{audit_root}/{agent}/{session_id}/`, writes start metadata to `agentd/session.json`, bind-mounts the `runa/` subtree into the container at `/home/{username}/.agentd/audit/runa`, and bind-mounts `agentd/transcript/` at `/agentd/transcript` before the runtime initializes runa state.
@@ -241,7 +241,7 @@ agentd runs sessions in ephemeral Podman containers so agents remain separated f
 
 From inside the environment, an agent should see:
 - identity-related environment variables
-- `GROUNDWORK_FORGE`, the active forge tag Groundwork reads to resolve forge-specific mechanics
+- `GROUNDWORK_FORGE_TYPE`, the active forge type Groundwork reads to resolve forge-specific mechanics
 - `$HOME` set to `/home/{username}`
 - a read-only methodology mount rooted at `manifest.toml`
 - a read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Runner setup now supports SSH repository clone through agent-scoped mounted
   OpenSSH material, including `ssh://` and `user@host:path` repository URLs.
-- Agent configuration now accepts an optional `forge` field and injects the
-  selected value as `GROUNDWORK_FORGE`, defaulting omitted values to `github`.
+- Agent configuration now accepts an optional `forge_type` field and injects the
+  selected forge type as `GROUNDWORK_FORGE_TYPE`, defaulting omitted values to `github`.
 
 ## [0.1.2] — 2026-05-17
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ explicit override for root-owned installs such as `/var/lib/tesserine/audit/`.
 ## Configuration
 
 An agent is a named environment specification: base image, methodology
-directory, optional active forge, optional additional bind mounts, optional
+directory, optional active forge type, optional additional bind mounts, optional
 default repo, optional cron schedule, credentials, and exact command argv. Define agents in a TOML
 config file — start from
 [`examples/agentd.toml`](examples/agentd.toml):
@@ -73,9 +73,9 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
-# Optional active forge tag injected as GROUNDWORK_FORGE for Groundwork.
+# Optional active forge type injected as GROUNDWORK_FORGE_TYPE for Groundwork.
 # Defaults to "github" when omitted.
-#forge = "github"
+#forge_type = "github"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
 # and for every scheduled run of this agent. HTTPS, HTTP, git://, ssh://, and
 # user@host:path SSH forms are accepted.
@@ -141,8 +141,8 @@ relabelled by Podman from their canonical host source paths. The base image
 must provide `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, `runa`,
 and whatever binaries the declared agent command uses. SSH repository clone
 also requires an OpenSSH-compatible client in the base image. UID/GID `1000`
-must be available for the session user. The optional `forge` value declares one
-active forge for each session and is injected as `GROUNDWORK_FORGE`; when
+must be available for the session user. The optional `forge_type` value declares one
+active forge type for each session and is injected as `GROUNDWORK_FORGE_TYPE`; when
 omitted, agentd injects `github`. When an agent declares `schedule`, it must
 also declare `repo`. Schedules are evaluated in daemon-local time and missed
 fires are not backfilled after downtime. Persistent audit records default to
@@ -325,7 +325,7 @@ the container, the agent sees:
 - A runner-managed read-only invocation-input mount at `/agentd/invocation-input` when manual input is supplied
 - Any operator-declared additional bind mounts, read-only or read-write per agent
 - Credentials injected as environment variables
-- `GROUNDWORK_FORGE` with the configured active forge, defaulting to `github`
+- `GROUNDWORK_FORGE_TYPE` with the configured active forge type, defaulting to `github`
 - `AGENTD_WORK_UNIT` when the invocation includes one
 - A pre-materialized artifact under `.runa/workspace/...` when the invocation includes `--request` or `--artifact-file`
 - `runa init` state followed by `runa run --agent-command -- <argv>` from the repo directory

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -1207,7 +1207,7 @@ fn run_session_injects_empty_environment_values_via_direct_env_args() {
 }
 
 #[test]
-fn run_session_injects_active_forge_as_groundwork_forge_environment() {
+fn run_session_injects_active_forge_type_as_groundwork_forge_type_environment() {
     let _guard = fake_podman_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1217,7 +1217,7 @@ fn run_session_injects_active_forge_as_groundwork_forge_environment() {
     let methodology_dir = fixture.create_methodology_dir("runner-methodology");
     let outcome = fixture.run_with_fake_podman(crate::SessionSpec {
         methodology_dir,
-        forge: "sourcehut".to_string(),
+        forge_type: "sourcehut".to_string(),
         ..test_session_spec()
     });
 
@@ -1227,7 +1227,7 @@ fn run_session_injects_active_forge_as_groundwork_forge_environment() {
     );
 
     let create_args = fixture.create_args();
-    assert!(create_args.contains("--env GROUNDWORK_FORGE=sourcehut"));
+    assert!(create_args.contains("--env GROUNDWORK_FORGE_TYPE=sourcehut"));
 }
 
 #[test]

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -18,7 +18,7 @@ pub(crate) fn test_session_spec() -> SessionSpec {
         base_image: "image".to_string(),
         methodology_dir: PathBuf::from("/tmp/methodology"),
         audit_root: std::env::temp_dir().join("agentd-runner-test-audit-root"),
-        forge: "github".to_string(),
+        forge_type: "github".to_string(),
         mounts: Vec::new(),
         agent_command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 /// Static configuration for a session, derived from an agent.
 ///
-/// Describes the agent identity, container image, methodology, active forge,
+/// Describes the agent identity, container image, methodology, active forge type,
 /// command, and caller-resolved environment variables. Validated by
 /// [`run_session`](crate::run_session) before any resources are allocated.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,9 +39,9 @@ pub struct SessionSpec {
     /// Host-side root where persistent audit records are created. The runner
     /// stores each session under `<audit_root>/<agent>/<session_id>/`.
     pub audit_root: PathBuf,
-    /// Active forge tag exposed to the session as `GROUNDWORK_FORGE` so
+    /// Active forge type exposed to the session as `GROUNDWORK_FORGE_TYPE` so
     /// Groundwork can resolve forge-invariant operations.
-    pub forge: String,
+    pub forge_type: String,
     /// Additional host bind mounts declared by the selected agent.
     pub mounts: Vec<BindMount>,
     /// Command array executed directly from the cloned repository after
@@ -52,7 +52,7 @@ pub struct SessionSpec {
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
     /// Names reserved for runner-owned values such as `AGENT_NAME`,
-    /// `GROUNDWORK_FORGE`, `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`,
+    /// `GROUNDWORK_FORGE_TYPE`, `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`,
     /// `RUNA_TRANSCRIPT_DIR`, and `RUNA_TRANSCRIPT_REDACT_ENV` are rejected
     /// during validation.
     pub environment: Vec<ResolvedEnvironmentVariable>,
@@ -336,9 +336,9 @@ pub enum RunnerError {
     /// The configured audit root path is not absolute. Produced during spec
     /// validation.
     InvalidAuditRoot { path: PathBuf },
-    /// The active forge tag is empty or has surrounding whitespace. Produced
+    /// The active forge type is empty or has surrounding whitespace. Produced
     /// during spec validation.
-    InvalidForge { forge: String },
+    InvalidForgeType { forge_type: String },
     /// The repository URL is not a supported remote form (`https://`,
     /// `http://`, `git://`), embeds credentials, or is paired with
     /// `repo_token` without using `https://`. Produced during invocation
@@ -408,9 +408,9 @@ impl fmt::Display for RunnerError {
             RunnerError::InvalidAuditRoot { path } => {
                 write!(f, "audit_root must be an absolute path: {}", path.display())
             }
-            RunnerError::InvalidForge { forge } => write!(
+            RunnerError::InvalidForgeType { forge_type } => write!(
                 f,
-                "forge must not be empty or contain surrounding whitespace: {forge:?}"
+                "forge type (`forge_type`) must not be empty or contain surrounding whitespace: {forge_type:?}"
             ),
             RunnerError::InvalidRepoUrl { message } => write!(f, "repo_url {message}"),
             RunnerError::InvalidInvocationInput { message } => write!(f, "{message}"),

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 const AGENT_NAME_ENV: &str = "AGENT_NAME";
-const GROUNDWORK_FORGE_ENV: &str = "GROUNDWORK_FORGE";
+const GROUNDWORK_FORGE_TYPE_ENV: &str = "GROUNDWORK_FORGE_TYPE";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
 pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
 pub(crate) const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
@@ -42,9 +42,9 @@ pub(crate) fn validate_spec(spec: &SessionSpec) -> Result<(), RunnerError> {
             path: spec.audit_root.clone(),
         });
     }
-    if spec.forge.trim().is_empty() || spec.forge != spec.forge.trim() {
-        return Err(RunnerError::InvalidForge {
-            forge: spec.forge.clone(),
+    if spec.forge_type.trim().is_empty() || spec.forge_type != spec.forge_type.trim() {
+        return Err(RunnerError::InvalidForgeType {
+            forge_type: spec.forge_type.clone(),
         });
     }
     if spec.agent_command.is_empty() || spec.agent_command.iter().any(|arg| arg.is_empty()) {
@@ -170,7 +170,7 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
 /// Validates an environment variable name against naming rules.
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
-/// runner-managed names such as `AGENT_NAME`, `GROUNDWORK_FORGE`,
+/// runner-managed names such as `AGENT_NAME`, `GROUNDWORK_FORGE_TYPE`,
 /// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
 /// `RUNA_TRANSCRIPT_REDACT_ENV`. Used both by
 /// [`run_session`](crate::run_session) during spec validation and by the
@@ -233,7 +233,7 @@ pub fn validate_repo_url(repo_url: &str) -> Result<(), RunnerError> {
 pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> [(&str, &str); 2] {
     [
         (AGENT_NAME_ENV, &spec.agent_name),
-        (GROUNDWORK_FORGE_ENV, &spec.forge),
+        (GROUNDWORK_FORGE_TYPE_ENV, &spec.forge_type),
     ]
 }
 
@@ -372,7 +372,7 @@ fn is_reserved_environment_name(name: &str) -> bool {
     matches!(
         name,
         AGENT_NAME_ENV
-            | GROUNDWORK_FORGE_ENV
+            | GROUNDWORK_FORGE_TYPE_ENV
             | WORK_UNIT_ENV
             | REPO_TOKEN_ENV
             | TRANSCRIPT_DIR_ENV
@@ -486,7 +486,7 @@ mod tests {
     fn validate_spec_rejects_reserved_environment_names() {
         for reserved_name in [
             "AGENT_NAME",
-            "GROUNDWORK_FORGE",
+            "GROUNDWORK_FORGE_TYPE",
             WORK_UNIT_ENV,
             REPO_TOKEN_ENV,
             "RUNA_TRANSCRIPT_DIR",
@@ -539,26 +539,26 @@ mod tests {
     }
 
     #[test]
-    fn validate_spec_rejects_empty_or_whitespace_padded_forge() {
-        for forge in ["", " ", " sourcehut", "sourcehut "] {
+    fn validate_spec_rejects_empty_or_whitespace_padded_forge_type() {
+        for forge_type in ["", " ", " sourcehut", "sourcehut "] {
             let error = validate_spec(&SessionSpec {
-                forge: forge.to_string(),
+                forge_type: forge_type.to_string(),
                 ..test_session_spec()
             })
-            .expect_err("forge values must be non-empty and trimmed");
+            .expect_err("forge type values must be non-empty and trimmed");
 
             match &error {
-                RunnerError::InvalidForge {
-                    forge: invalid_forge,
+                RunnerError::InvalidForgeType {
+                    forge_type: invalid_forge_type,
                 } => {
-                    assert_eq!(invalid_forge, forge);
+                    assert_eq!(invalid_forge_type, forge_type);
                 }
-                other => panic!("expected InvalidForge, got {other:?}"),
+                other => panic!("expected InvalidForgeType, got {other:?}"),
             }
 
             assert!(
-                error.to_string().contains("forge"),
-                "invalid forge error should explain forge validation: {error}"
+                error.to_string().contains("forge type"),
+                "invalid forge type error should explain forge type validation: {error}"
             );
         }
     }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -135,7 +135,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec![
                 "site-builder".to_string(),
@@ -191,7 +191,7 @@ fn materializes_request_text_input_before_session_command_runs() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -239,7 +239,7 @@ fn materializes_generic_artifact_input_before_session_command_runs() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -290,7 +290,7 @@ fn rejects_request_text_when_methodology_declares_an_unsupported_request_version
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),
@@ -335,7 +335,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -388,7 +388,7 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -433,7 +433,7 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -484,7 +484,7 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -536,7 +536,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -597,7 +597,7 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readonly-mount-run/.claude"),
@@ -667,7 +667,7 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readwrite-mount-run/.runa"),
@@ -741,7 +741,7 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/nested-home-mount-run/.config/claude"),
@@ -793,7 +793,7 @@ fn preserves_session_user_access_to_preexisting_home_content() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -836,7 +836,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -935,7 +935,7 @@ fn persists_session_transcript_under_agentd_audit_dir() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1006,7 +1006,7 @@ fn finalizes_session_after_runtime_restricts_transcript_directory_permissions() 
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1081,7 +1081,7 @@ fn finalizes_session_after_runtime_restricts_events_jsonl_permissions() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1156,7 +1156,7 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1256,7 +1256,7 @@ fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes(
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: audit_root.clone(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/audit-hard-link-run/shared"),
@@ -1335,7 +1335,7 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1403,7 +1403,7 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -1456,7 +1456,7 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 base_image: image,
                 methodology_dir,
                 audit_root: audit_root.clone(),
-                forge: "github".to_string(),
+                forge_type: "github".to_string(),
                 mounts: Vec::new(),
                 agent_command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![
@@ -1515,7 +1515,7 @@ fn clones_ssh_repo_with_agent_scoped_mounted_identity() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: vec![BindMount {
                 source: ssh_dir,
                 target: PathBuf::from("/home/ssh-clone-run/.ssh"),
@@ -1563,7 +1563,7 @@ fn ssh_repo_clone_cannot_use_another_agents_unmounted_identity() {
             base_image: image,
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
-            forge: "github".to_string(),
+            forge_type: "github".to_string(),
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -3,7 +3,7 @@
 //! Bridges operator-facing configuration to daemon dispatch and the runner's
 //! [`SessionSpec`] model. Validation here is stricter than the runner's own
 //! validation — it enforces uniqueness (no duplicate agent or credential
-//! names), non-empty fields, active forge defaulting, and whitespace hygiene
+//! names), non-empty fields, active forge type defaulting, and whitespace hygiene
 //! in addition to the runner's format and reservation rules. Relative daemon
 //! runtime paths and `methodology_dir` are resolved against the configuration
 //! file location when loaded from disk.
@@ -25,12 +25,12 @@ use sha2::{Digest, Sha256};
 
 use crate::runtime_paths::{RuntimePathError, default_daemon_runtime_paths};
 
-const DEFAULT_ACTIVE_FORGE: &str = "github";
+const DEFAULT_FORGE_TYPE: &str = "github";
 
 /// Validated daemon and agent registry parsed from a TOML configuration file.
 ///
 /// Guarantees that daemon runtime paths are present, all agent names are
-/// unique and valid, all required fields are non-empty, active forge defaults
+/// unique and valid, all required fields are non-empty, active forge type defaults
 /// are applied, and all credential names are valid environment variable names.
 /// Relative daemon runtime paths and `methodology_dir` paths are resolved
 /// against the configuration file's parent directory.
@@ -140,12 +140,12 @@ impl Config {
                 }
                 None => None,
             };
-            let forge = match raw_agent.forge {
+            let forge_type = match raw_agent.forge_type {
                 Some(value) => {
-                    validate_lookup_key("forge", &value, Some(raw_agent.name.as_str()), None)?;
+                    validate_lookup_key("forge_type", &value, Some(raw_agent.name.as_str()), None)?;
                     value
                 }
-                None => DEFAULT_ACTIVE_FORGE.to_string(),
+                None => DEFAULT_FORGE_TYPE.to_string(),
             };
 
             if raw_agent.command.argv.is_empty() {
@@ -272,7 +272,7 @@ impl Config {
                 repo,
                 schedule,
                 repo_token_source,
-                forge,
+                forge_type,
                 credentials,
                 agent_command,
             });
@@ -310,7 +310,7 @@ pub struct Agent {
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
-    forge: String,
+    forge_type: String,
     credentials: Vec<CredentialConfig>,
     agent_command: Vec<String>,
 }
@@ -355,10 +355,10 @@ impl Agent {
         self.repo_token_source.as_deref()
     }
 
-    /// Active forge tag injected into each launched session for Groundwork
-    /// forge-specific operation resolution.
-    pub fn forge(&self) -> &str {
-        &self.forge
+    /// Active forge type injected into each launched session for Groundwork
+    /// forge-operation resolution.
+    pub fn forge_type(&self) -> &str {
+        &self.forge_type
     }
 
     /// Declared credentials for this agent. Each credential's name is a
@@ -666,7 +666,7 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::InvalidCredentialName { agent, name } => write!(
                 f,
-                "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, GROUNDWORK_FORGE, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
+                "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, GROUNDWORK_FORGE_TYPE, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
             ),
             ConfigError::EmptyField {
                 field,
@@ -841,7 +841,7 @@ struct RawAgent {
     repo: Option<String>,
     schedule: Option<String>,
     repo_token_source: Option<String>,
-    forge: Option<String>,
+    forge_type: Option<String>,
     #[serde(default)]
     credentials: Vec<RawCredentialConfig>,
 }

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -157,7 +157,7 @@ pub fn dispatch_run(
                 base_image: agent.base_image().to_string(),
                 methodology_dir: agent.methodology_dir().to_path_buf(),
                 audit_root,
-                forge: agent.forge().to_string(),
+                forge_type: agent.forge_type().to_string(),
                 mounts: agent
                     .mounts()
                     .iter()

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -192,7 +192,7 @@ fn parses_example_config_into_static_agent_settings() {
         site_builder.repo_token_source(),
         Some("SITE_BUILDER_REPO_TOKEN")
     );
-    assert_eq!(site_builder.forge(), "github");
+    assert_eq!(site_builder.forge_type(), "github");
     assert_eq!(site_builder.agent_command(), ["site-builder", "exec"]);
     assert_eq!(site_builder.credentials().len(), 1);
     assert_eq!(site_builder.credentials()[0].name(), "GITHUB_TOKEN");
@@ -217,7 +217,7 @@ fn parses_example_config_into_static_agent_settings() {
         code_reviewer.repo_token_source(),
         Some("CODE_REVIEWER_REPO_TOKEN")
     );
-    assert_eq!(code_reviewer.forge(), "github");
+    assert_eq!(code_reviewer.forge_type(), "github");
     assert_eq!(code_reviewer.agent_command(), ["code-reviewer", "exec"]);
     assert_eq!(code_reviewer.credentials().len(), 1);
     assert_eq!(code_reviewer.credentials()[0].name(), "GITHUB_TOKEN");
@@ -829,39 +829,39 @@ argv = ["site-builder", "exec"]
 }
 
 #[test]
-fn parses_agent_forge_as_active_session_forge() {
+fn parses_agent_forge_type_as_active_session_forge_type() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    set_xdg_runtime_dir("agent-forge");
+    set_xdg_runtime_dir("agent-forge-type");
     let config = Config::from_str(
         r#"
 [[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
-forge = "sourcehut"
+forge_type = "sourcehut"
 
 [agents.command]
 argv = ["site-builder", "exec"]
 "#,
     )
-    .expect("config should parse active forge");
+    .expect("config should parse active forge type");
 
     let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(agent.forge(), "sourcehut");
+    assert_eq!(agent.forge_type(), "sourcehut");
     unsafe {
         std::env::remove_var("XDG_RUNTIME_DIR");
     }
 }
 
 #[test]
-fn defaults_agent_forge_to_github_when_omitted() {
+fn defaults_agent_forge_type_to_github_when_omitted() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    set_xdg_runtime_dir("default-agent-forge");
+    set_xdg_runtime_dir("default-agent-forge-type");
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -873,11 +873,11 @@ methodology_dir = "../groundwork"
 argv = ["site-builder", "exec"]
 "#,
     )
-    .expect("config should default active forge");
+    .expect("config should default active forge type");
 
     let agent = config.agent("site-builder").expect("agent should exist");
 
-    assert_eq!(agent.forge(), "github");
+    assert_eq!(agent.forge_type(), "github");
     unsafe {
         std::env::remove_var("XDG_RUNTIME_DIR");
     }
@@ -1375,21 +1375,21 @@ argv = ["site-builder", "exec"]
 }
 
 #[test]
-fn rejects_agent_forge_with_outer_whitespace() {
-    for forge in [" sourcehut", "sourcehut "] {
+fn rejects_agent_forge_type_with_outer_whitespace() {
+    for forge_type in [" sourcehut", "sourcehut "] {
         let error = Config::from_str(&format!(
             r#"
 [[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
-forge = "{forge}"
+forge_type = "{forge_type}"
 
 [agents.command]
 argv = ["site-builder", "exec"]
 "#
         ))
-        .expect_err("whitespace-padded forge values should be rejected");
+        .expect_err("whitespace-padded forge type values should be rejected");
 
         match error {
             ConfigError::FieldHasOuterWhitespace {
@@ -1397,7 +1397,7 @@ argv = ["site-builder", "exec"]
                 agent,
                 credential,
             } => {
-                assert_eq!(field, "forge");
+                assert_eq!(field, "forge_type");
                 assert_eq!(agent.as_deref(), Some("site-builder"));
                 assert_eq!(credential, None);
             }
@@ -1407,20 +1407,20 @@ argv = ["site-builder", "exec"]
 }
 
 #[test]
-fn rejects_empty_agent_forge() {
+fn rejects_empty_agent_forge_type() {
     let error = Config::from_str(
         r#"
 [[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
-forge = ""
+forge_type = ""
 
 [agents.command]
 argv = ["site-builder", "exec"]
 "#,
     )
-    .expect_err("empty forge values should be rejected");
+    .expect_err("empty forge type values should be rejected");
 
     match error {
         ConfigError::EmptyField {
@@ -1428,7 +1428,7 @@ argv = ["site-builder", "exec"]
             agent,
             credential,
         } => {
-            assert_eq!(field, "forge");
+            assert_eq!(field, "forge_type");
             assert_eq!(agent.as_deref(), Some("site-builder"));
             assert_eq!(credential, None);
         }

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -109,14 +109,14 @@ source = "AGENTD_GITHUB_TOKEN"
     .expect("config should parse")
 }
 
-fn config_with_forge(forge: &str) -> Config {
+fn config_with_forge_type(forge_type: &str) -> Config {
     Config::from_str(&format!(
         r#"
 [[agents]]
 name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 methodology_dir = "../groundwork"
-forge = "{forge}"
+forge_type = "{forge_type}"
 
 [agents.command]
 argv = ["site-builder", "exec"]
@@ -181,8 +181,8 @@ argv = ["code-reviewer", "exec"]
 }
 
 #[test]
-fn dispatch_run_forwards_active_forge_into_session_spec() {
-    let config = config_with_forge("sourcehut");
+fn dispatch_run_forwards_active_forge_type_into_session_spec() {
+    let config = config_with_forge_type("sourcehut");
     let request = RunRequest {
         agent: "site-builder".to_string(),
         repo_url: Some("https://example.com/repo.git".to_string()),
@@ -199,11 +199,11 @@ fn dispatch_run_forwards_active_forge_into_session_spec() {
         .as_ref()
         .expect("executor should receive spec");
 
-    assert_eq!(spec.forge, "sourcehut");
+    assert_eq!(spec.forge_type, "sourcehut");
 }
 
 #[test]
-fn dispatch_run_defaults_active_forge_to_github() {
+fn dispatch_run_defaults_active_forge_type_to_github() {
     let config = Config::from_str(
         r#"
 [[agents]]
@@ -232,7 +232,7 @@ argv = ["site-builder", "exec"]
         .as_ref()
         .expect("executor should receive spec");
 
-    assert_eq!(spec.forge, "github");
+    assert_eq!(spec.forge_type, "github");
 }
 
 #[test]

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -16,9 +16,9 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
-# Optional active forge tag injected as GROUNDWORK_FORGE for Groundwork.
+# Optional active forge type injected as GROUNDWORK_FORGE_TYPE for Groundwork.
 # Defaults to "github" when omitted.
-#forge = "github"
+#forge_type = "github"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
 # and for each scheduled run of this agent.
 repo = "https://github.com/pentaxis93/agentd.git"


### PR DESCRIPTION
## Summary

- Renames the agentd producer contract from `forge` / `GROUNDWORK_FORGE` to `forge_type` / `GROUNDWORK_FORGE_TYPE`.
- Keeps omitted values defaulting to `github`, keeps empty/whitespace rejection, and reserves the new runner-managed environment name.
- Updates agentd docs, example config, and behavior coverage for the new producer-side name.

## Changes

- Renames `Agent::forge()` and `SessionSpec.forge` to `forge_type` throughout config parsing, dispatch, runner validation, test support, and session lifecycle tests.
- Changes runner-managed injection and reserved-name validation to `GROUNDWORK_FORGE_TYPE`.
- Updates README.md, ARCHITECTURE.md, examples/agentd.toml, and CHANGELOG.md to describe the agentd-Groundwork contract under the new symbol.

## Landing Coordination

This PR is paired with tesserine/groundwork#360. The two PRs must land together, or no agent sessions should run between merges. A mixed producer/consumer state can silently fall back to `github` because one side would use `GROUNDWORK_FORGE_TYPE` while the other still uses `GROUNDWORK_FORGE`.

## GitHub Issue(s)

Closes #143

Paired with tesserine/groundwork#360.

## Test plan

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- stale-symbol scan for old standalone `GROUNDWORK_FORGE` and old `forge` config/API surface
