### PR TITLE
docs(deployment): remove host-specific example

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -337,9 +337,9 @@ running, agentd opens the mounted `runa/` subtree with mode `0o777` so writes
 through the session user's mapped daemon identity succeed. Any user with host
 shell access can therefore read or write that subtree during the active
 session. On completion, agentd seals directories to `0555` and non-symlink
-entries to `0444`, making finished records world-readable on the host. For
-single-tenant deployments such as babbie, that tradeoff is acceptable; a
-multi-tenant host would need a different permission model before deployment.
+entries to `0444`, making finished records world-readable on the host. That
+tradeoff is acceptable only for single-tenant deployments; a multi-tenant host
+would need a different permission model before deployment.
 
 The startup audit-root probe is intentionally local-filesystem scoped. It
 verifies that the daemon can create, chmod, restore, and remove daemon-owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent configuration now accepts an optional `forge_type` field and injects the
   selected forge type as `GROUNDWORK_FORGE_TYPE`, defaulting omitted values to `github`.
 
+### Changed
+
+- Deployment and architecture documentation no longer names a specific
+  operator host when describing supported single-tenant deployment tradeoffs.
+
 ## [0.1.2] — 2026-05-17
 ### Fixed
 


### PR DESCRIPTION
## Summary

- Removes the remaining named-host example from agentd architecture documentation.
- Keeps the supported deployment guidance generic for operators deploying on their own hosts.

## Changes

- Reworded the single-tenant deployment tradeoff without naming a specific operator host.
- Added a changelog entry for the documentation cleanup.

## GitHub Issue(s)

Refs tesserine/ops#73

## Test plan

- cargo test --workspace
- Org-wide host-term content/path gate
