### PR TITLE
feat(invocation): execute work mode from supplied work units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OpenSSH material, including `ssh://` and `user@host:path` repository URLs.
 - Agent configuration now accepts an optional `forge_type` field and injects the
   selected forge type as `GROUNDWORK_FORGE_TYPE`, defaulting omitted values to `github`.
+- `agentd run` now supports work-mode invocation from a matching supplied
+  `work-unit` artifact, using `--work-unit <ID> --artifact-type work-unit
+  --artifact-file <ID>.json`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Trigger a session through the running daemon:
 agentd run site-builder --work-unit issue-42
 ```
 
-Manual invocation supports exactly one intent surface at a time:
+Manual invocation supports intake-mode and work-mode surfaces:
 
 - `--work-unit <ID>` targets existing queued work
 - `--request <TEXT>` synthesizes a canonical request artifact at
@@ -272,7 +272,17 @@ Manual invocation supports exactly one intent surface at a time:
 - `--artifact-type <TYPE> --artifact-file <PATH>` validates and places a
   complete JSON artifact at `.runa/workspace/<TYPE>/<file-stem>.json`
 
-`--work-unit`, `--request`, and `--artifact-file` are mutually exclusive.
+`--request` is intake mode and is mutually exclusive with `--work-unit` and
+`--artifact-file`. To start work mode from an operator-supplied work-unit
+artifact, combine the selected work-unit id with a matching `work-unit` artifact
+file:
+
+```bash
+agentd run site-builder --work-unit issue-42 --artifact-type work-unit --artifact-file ./issue-42.json
+```
+
+The file stem becomes the artifact id, so the file stem must match
+`--work-unit`.
 
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:
@@ -312,6 +322,7 @@ Examples:
 ```bash
 agentd run site-builder --request "Add a status page"
 agentd run site-builder --artifact-type claim --artifact-file ./claim.json
+agentd run site-builder --work-unit issue-42 --artifact-type work-unit --artifact-file ./issue-42.json
 agentd run site-builder https://github.com/pentaxis93/agentd.git --request "Review the last release candidate"
 ```
 

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -524,6 +524,39 @@ fn build_container_script_materializes_invocation_input_without_audit_workspace_
 }
 
 #[test]
+fn build_container_script_materializes_work_unit_input_before_work_mode_run() {
+    let script = build_container_script(
+        &crate::SessionSpec {
+            agent_name: "myagent".to_string(),
+            ..test_session_spec()
+        },
+        &SessionInvocation {
+            repo_url: VALID_REMOTE_REPO_URL.to_string(),
+            repo_token: None,
+            work_unit: Some("issue-76".to_string()),
+            input: None,
+            timeout: None,
+        },
+        Some(&ResolvedInvocationInput {
+            artifact_type: "work-unit".to_string(),
+            artifact_id: "issue-76".to_string(),
+            document_json: "{}\n".to_string(),
+        }),
+    );
+
+    let materialize_offset = script
+        .find("workspace/work-unit")
+        .expect("script should materialize the work-unit artifact");
+    let run_offset = script
+        .find("runa run --work-unit 'issue-76'")
+        .expect("script should run the selected work unit");
+    assert!(
+        materialize_offset < run_offset,
+        "work-unit artifact should be materialized before work-mode run: {script}"
+    );
+}
+
+#[test]
 fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_targets() {
     let script = build_container_script(
         &crate::SessionSpec {

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -101,7 +101,7 @@ pub enum InvocationInput {
 /// Per-invocation parameters for a session launch.
 ///
 /// Describes the repository to clone, optional clone-only repository
-/// authentication, at most one manual intent surface (`work_unit` or `input`),
+/// authentication, optional work-mode target and materialized invocation input,
 /// and an optional timeout. Validated by [`run_session`](crate::run_session)
 /// before any resources are allocated.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -118,12 +118,12 @@ pub struct SessionInvocation {
     /// Optional work unit identifier passed to `runa run --work-unit` and
     /// exposed through the runner-managed `AGENTD_WORK_UNIT` environment
     /// variable when set.
-    /// Mutually exclusive with [`Self::input`].
     pub work_unit: Option<String>,
     /// Optional operator-supplied input to materialize into the repo
     /// workspace after `runa init` and before `runa run`. Artifact names supplied
     /// through [`InvocationInput::Artifact`] must each be a single path
-    /// segment. Mutually exclusive with [`Self::work_unit`].
+    /// segment. When combined with [`Self::work_unit`], the input must be a
+    /// `work-unit` artifact whose id matches the work unit.
     pub input: Option<InvocationInput>,
     /// Optional session timeout. When set, the runner force-removes the
     /// container after this duration and returns

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -10,8 +10,8 @@ use crate::input::INVOCATION_INPUT_MOUNT_PATH;
 use crate::naming::is_daemon_instance_id;
 use crate::session_paths::{session_home_dir, session_internal_agentd_dir, session_repo_dir};
 use crate::types::{
-    AgentNameValidationError, BindMount, EnvironmentNameValidationError, MountOverlapError,
-    MountTargetValidationError, RunnerError, SessionInvocation, SessionSpec,
+    AgentNameValidationError, BindMount, EnvironmentNameValidationError, InvocationInput,
+    MountOverlapError, MountTargetValidationError, RunnerError, SessionInvocation, SessionSpec,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -158,13 +158,41 @@ pub(crate) fn validate_invocation(invocation: &SessionInvocation) -> Result<(), 
     {
         return Err(repo_token_requires_https_error());
     }
-    if invocation.work_unit.is_some() && invocation.input.is_some() {
-        return Err(RunnerError::InvalidInvocationInput {
-            message: "manual invocation must specify at most one of work_unit or input".to_string(),
-        });
+    if let Some(work_unit) = &invocation.work_unit {
+        if let Some(input) = &invocation.input {
+            validate_work_mode_input(work_unit, input)?;
+        }
     }
 
     Ok(())
+}
+
+fn validate_work_mode_input(work_unit: &str, input: &InvocationInput) -> Result<(), RunnerError> {
+    match input {
+        InvocationInput::RequestText { .. } => Err(RunnerError::InvalidInvocationInput {
+            message: "manual invocation cannot combine work_unit with request input".to_string(),
+        }),
+        InvocationInput::Artifact {
+            artifact_type,
+            artifact_id,
+            ..
+        } => {
+            if artifact_type != "work-unit" {
+                return Err(RunnerError::InvalidInvocationInput {
+                    message: "manual work-mode artifact input must use artifact type 'work-unit'"
+                        .to_string(),
+                });
+            }
+            if artifact_id != work_unit {
+                return Err(RunnerError::InvalidInvocationInput {
+                    message: format!(
+                        "manual work-mode artifact id must match work_unit '{work_unit}'"
+                    ),
+                });
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Validates an environment variable name against naming rules.
@@ -1532,7 +1560,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_invocation_accepts_zero_or_one_manual_intent_surface() {
+    fn validate_invocation_accepts_supported_manual_intent_surfaces() {
         for (work_unit, input) in [
             (None, None),
             (Some("issue-42".to_string()), None),
@@ -1540,6 +1568,14 @@ mod tests {
                 None,
                 Some(InvocationInput::RequestText {
                     description: "Add a status page".to_string(),
+                }),
+            ),
+            (
+                Some("issue-42".to_string()),
+                Some(InvocationInput::Artifact {
+                    artifact_type: "work-unit".to_string(),
+                    artifact_id: "issue-42".to_string(),
+                    document: serde_json::json!({ "id": "issue-42" }),
                 }),
             ),
         ] {
@@ -1550,12 +1586,12 @@ mod tests {
                 input,
                 timeout: None,
             })
-            .expect("zero or one manual intent surface should be accepted");
+            .expect("supported manual intent surfaces should be accepted");
         }
     }
 
     #[test]
-    fn validate_invocation_rejects_conflicting_manual_intent_surfaces() {
+    fn validate_invocation_rejects_request_text_with_work_unit() {
         let error = validate_invocation(&SessionInvocation {
             repo_url: "https://example.com/agentd.git".to_string(),
             repo_token: None,
@@ -1579,6 +1615,58 @@ mod tests {
         assert!(
             message.contains("input"),
             "expected input guidance in message, got {message}"
+        );
+    }
+
+    #[test]
+    fn validate_invocation_rejects_non_work_unit_artifact_with_work_unit() {
+        let error = validate_invocation(&SessionInvocation {
+            repo_url: "https://example.com/agentd.git".to_string(),
+            repo_token: None,
+            work_unit: Some("issue-42".to_string()),
+            input: Some(InvocationInput::Artifact {
+                artifact_type: "claim".to_string(),
+                artifact_id: "issue-42".to_string(),
+                document: serde_json::json!({ "summary": "Ship it" }),
+            }),
+            timeout: None,
+        })
+        .expect_err("work mode should reject non-work-unit artifacts");
+
+        assert!(
+            matches!(error, RunnerError::InvalidInvocationInput { .. }),
+            "expected InvalidInvocationInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("artifact type 'work-unit'"),
+            "expected work-unit artifact guidance in message, got {message}"
+        );
+    }
+
+    #[test]
+    fn validate_invocation_rejects_mismatched_work_unit_artifact_id() {
+        let error = validate_invocation(&SessionInvocation {
+            repo_url: "https://example.com/agentd.git".to_string(),
+            repo_token: None,
+            work_unit: Some("issue-42".to_string()),
+            input: Some(InvocationInput::Artifact {
+                artifact_type: "work-unit".to_string(),
+                artifact_id: "issue-43".to_string(),
+                document: serde_json::json!({ "id": "issue-43" }),
+            }),
+            timeout: None,
+        })
+        .expect_err("work mode should reject mismatched work-unit artifacts");
+
+        assert!(
+            matches!(error, RunnerError::InvalidInvocationInput { .. }),
+            "expected InvalidInvocationInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("artifact id") && message.contains("issue-42"),
+            "expected matching-id guidance in message, got {message}"
         );
     }
 

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -115,6 +115,26 @@ fn install_claim_schema(path: &Path) {
     .expect("claim schema should be written");
 }
 
+fn install_work_unit_schema(path: &Path) {
+    let schema_dir = path.join("schemas");
+    fs::create_dir_all(&schema_dir).expect("schema dir should be created");
+    fs::write(
+        schema_dir.join("work-unit.schema.json"),
+        r#"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["id", "title"],
+  "additionalProperties": true,
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 }
+  }
+}
+"#,
+    )
+    .expect("work-unit schema should be written");
+}
+
 #[test]
 fn succeeds_without_timeout_and_cleans_up_container() {
     if skip_if_podman_unavailable("succeeds_without_timeout_and_cleans_up_container") {
@@ -262,6 +282,106 @@ fn materializes_generic_artifact_input_before_session_command_runs() {
     .expect("session should run");
 
     assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    fixture.assert_no_runner_container_left_behind();
+    fixture.assert_no_runner_secret_left_behind();
+}
+
+#[test]
+fn executes_work_mode_against_injected_work_unit_artifact() {
+    if skip_if_podman_unavailable("executes_work_mode_against_injected_work_unit_artifact") {
+        return;
+    }
+    let _guard = podman_test_lock()
+        .lock()
+        .expect("podman test lock should be acquired");
+
+    let fixture = SessionFixture::new("work-mode-artifact-run");
+    write_methodology_manifest(&fixture.methodology_dir(), &["work-unit"]);
+    install_work_unit_schema(&fixture.methodology_dir());
+    let image = fixture.build_image();
+
+    let outcome = run_session_with_test_audit_root(
+        &fixture.audit_root(),
+        SessionSpec {
+            daemon_instance_id: TEST_DAEMON_INSTANCE_ID.to_string(),
+            agent_name: "work-mode-artifact-run".to_string(),
+            base_image: image,
+            methodology_dir: fixture.methodology_dir(),
+            audit_root: fixture.audit_root(),
+            forge_type: "github".to_string(),
+            mounts: Vec::new(),
+            agent_command: vec!["site-builder".to_string(), "exec".to_string()],
+            environment: vec![ResolvedEnvironmentVariable {
+                name: "SESSION_TEST_BEHAVIOR".to_string(),
+                value: "execute-work-mode-cascade".to_string(),
+            }],
+        },
+        SessionInvocation {
+            repo_url: fixture.repo_url(),
+            repo_token: None,
+            work_unit: Some("issue-76".to_string()),
+            input: Some(InvocationInput::Artifact {
+                artifact_type: "work-unit".to_string(),
+                artifact_id: "issue-76".to_string(),
+                document: serde_json::json!({
+                    "id": "issue-76",
+                    "title": "Execute work mode",
+                }),
+            }),
+            timeout: None,
+        },
+    )
+    .expect("work-mode session should run");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+    let record_dir = fixture.only_session_record_dir();
+    assert_eq!(
+        fs::read_to_string(record_dir.join("runa/calls.log"))
+            .expect("runa call log should persist"),
+        "init --methodology /agentd/methodology/manifest.toml\nrun --work-unit issue-76 --agent-command -- site-builder exec\n"
+    );
+    assert!(
+        record_dir
+            .join("runa/workspace/work-unit/issue-76.json")
+            .exists(),
+        "injected work-unit artifact should persist"
+    );
+    for artifact_path in [
+        "runa/workspace/behavior-contract/specify.json",
+        "runa/workspace/implementation-plan/plan.json",
+        "runa/workspace/patch/implement.json",
+        "runa/workspace/test-evidence/verify.json",
+        "runa/workspace/documentation-record/document.json",
+        "runa/workspace/completion-record/submit.json",
+        "runa/workspace/completion-record/land.json",
+    ] {
+        assert!(
+            record_dir.join(artifact_path).exists(),
+            "expected cascade artifact {artifact_path} to persist"
+        );
+    }
+    let execution_record = fs::read_to_string(record_dir.join("runa/store/executions/0001.json"))
+        .expect("execution record should persist");
+    assert!(execution_record.contains("\"specify\""));
+    assert!(execution_record.contains("\"land\""));
+
+    let metadata: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/session.json"))
+            .expect("session metadata should persist"),
+    )
+    .expect("session metadata should be valid json");
+    assert_eq!(metadata["work_unit"], "issue-76");
+    assert_eq!(metadata["outcome"], "success");
+    assert_eq!(metadata["exit_code"], 0);
+
+    let transcript_manifest: Value = serde_json::from_str(
+        &fs::read_to_string(record_dir.join("agentd/transcript/manifest.json"))
+            .expect("transcript manifest should persist"),
+    )
+    .expect("transcript manifest should be valid json");
+    assert_eq!(transcript_manifest["coverage"], "full");
+
     fixture.assert_no_runner_container_left_behind();
     fixture.assert_no_runner_secret_left_behind();
 }
@@ -2554,6 +2674,32 @@ case "$command_name" in
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "assert-claim-input-present" ]; then
             [ -f "${HOME}/repo/.runa/workspace/claim/claim.json" ]
             grep -F '"summary":"Ship it"' "${HOME}/repo/.runa/workspace/claim/claim.json"
+            exit 0
+        fi
+
+        if [ "${SESSION_TEST_BEHAVIOR:-}" = "execute-work-mode-cascade" ]; then
+            [ "${AGENTD_WORK_UNIT:-}" = "issue-76" ]
+            [ -f "${HOME}/repo/.runa/workspace/work-unit/issue-76.json" ]
+            grep -F '"id":"issue-76"' "${HOME}/repo/.runa/workspace/work-unit/issue-76.json"
+            mkdir -p \
+                "${HOME}/repo/.runa/workspace/behavior-contract" \
+                "${HOME}/repo/.runa/workspace/implementation-plan" \
+                "${HOME}/repo/.runa/workspace/patch" \
+                "${HOME}/repo/.runa/workspace/test-evidence" \
+                "${HOME}/repo/.runa/workspace/documentation-record" \
+                "${HOME}/repo/.runa/workspace/completion-record" \
+                "${HOME}/repo/.runa/store/executions"
+            printf '{"scenario":"Given a work-unit artifact, when work mode starts, then specify runs"}\n' > "${HOME}/repo/.runa/workspace/behavior-contract/specify.json"
+            printf '{"decision":"execute the injected work-unit through work mode"}\n' > "${HOME}/repo/.runa/workspace/implementation-plan/plan.json"
+            printf '{"status":"implemented"}\n' > "${HOME}/repo/.runa/workspace/patch/implement.json"
+            printf '{"status":"verified"}\n' > "${HOME}/repo/.runa/workspace/test-evidence/verify.json"
+            printf '{"status":"documented"}\n' > "${HOME}/repo/.runa/workspace/documentation-record/document.json"
+            printf '{"status":"submitted"}\n' > "${HOME}/repo/.runa/workspace/completion-record/submit.json"
+            printf '{"status":"landed"}\n' > "${HOME}/repo/.runa/workspace/completion-record/land.json"
+            printf '{"events":[{"protocol":"specify","artifact":"behavior-contract","postcondition":"passed"},{"protocol":"plan","artifact":"implementation-plan","postcondition":"passed"},{"protocol":"implement","artifact":"patch","postcondition":"passed"},{"protocol":"verify","artifact":"test-evidence","postcondition":"passed"},{"protocol":"document","artifact":"documentation-record","postcondition":"passed"},{"protocol":"submit","artifact":"completion-record","postcondition":"passed"},{"protocol":"land","artifact":"completion-record","postcondition":"passed"}]}\n' > "${HOME}/repo/.runa/store/executions/0001.json"
+            if [ -n "${RUNA_TRANSCRIPT_DIR:-}" ]; then
+                printf '{"schema_version":1,"source":"runa-mcp","kind":"tool_call","protocol":"take"}\n' >> "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
+            fi
             exit 0
         fi
 

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -106,21 +106,20 @@ enum Command {
     /// Start the foreground daemon.
     Daemon(DaemonArgs),
     /// Trigger a manual session through the running daemon.
-    #[command(display_name = "agentd")]
+    #[command(
+        display_name = "agentd",
+        after_help = "Work-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
+    )]
     Run {
         agent: String,
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
-        #[arg(long, conflicts_with_all = ["request", "artifact_file"])]
+        #[arg(long, conflicts_with = "request")]
         work_unit: Option<String>,
         #[arg(long, conflicts_with_all = ["work_unit", "artifact_file"])]
         request: Option<String>,
-        #[arg(
-                long,
-                requires = "artifact_type",
-                conflicts_with_all = ["work_unit", "request"]
-            )]
+        #[arg(long, requires = "artifact_type", conflicts_with = "request")]
         artifact_file: Option<PathBuf>,
         #[arg(long, requires = "artifact_file")]
         artifact_type: Option<String>,

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -428,6 +428,10 @@ fn binary_run_help_shows_socket_path_and_not_config() {
         !stdout.contains("--config"),
         "run help should not advertise daemon config coupling: {stdout}"
     );
+    assert!(
+        stdout.contains("--work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"),
+        "run help should document work-mode artifact invocation: {stdout}"
+    );
 }
 
 #[test]
@@ -869,6 +873,78 @@ fn binary_run_command_reads_artifact_file_and_forwards_structured_input() {
             document: json!({
                 "description": "Add a status page",
                 "source": "operator",
+            }),
+        })
+    );
+}
+
+#[test]
+fn binary_run_command_forwards_work_unit_with_matching_artifact_file() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-work-unit-artifact-input-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-work-unit-artifact-input",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+    let artifact_path = runtime_dir.join("issue-76.json");
+    std::fs::write(
+        &artifact_path,
+        r#"{"id":"issue-76","title":"Execute work mode"}"#,
+    )
+    .expect("artifact file should be written");
+    let (shutdown, handle, _config, invocations) =
+        start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "run",
+            "--socket-path",
+            socket_path.to_str().expect("socket path should be utf-8"),
+            "site-builder",
+            "https://example.com/repo.git",
+            "--work-unit",
+            "issue-76",
+            "--artifact-type",
+            "work-unit",
+            "--artifact-file",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be utf-8"),
+        ])
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "run command should succeed with work-unit artifact input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocation = invocations.lock().expect("invocations should lock")[0].clone();
+    assert_eq!(invocation.work_unit.as_deref(), Some("issue-76"));
+    assert_eq!(
+        invocation.input,
+        Some(InvocationInput::Artifact {
+            artifact_type: "work-unit".to_string(),
+            artifact_id: "issue-76".to_string(),
+            document: json!({
+                "id": "issue-76",
+                "title": "Execute work mode",
             }),
         })
     );

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -343,6 +343,63 @@ fn daemon_round_trips_typed_invocation_input_through_the_socket_protocol() {
 }
 
 #[test]
+fn daemon_round_trips_work_unit_artifact_input_through_the_socket_protocol() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("work-unit-artifact-input");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (executor, invocations) =
+        RecordingInvocationExecutor::new(SessionOutcome::Success { exit_code: 0 });
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let outcome = request_run(
+        config.daemon(),
+        &RunRequest {
+            agent: "site-builder".to_string(),
+            repo_url: Some("https://example.com/repo.git".to_string()),
+            work_unit: Some("issue-76".to_string()),
+            input: Some(InvocationInput::Artifact {
+                artifact_type: "work-unit".to_string(),
+                artifact_id: "issue-76".to_string(),
+                document: json!({ "id": "issue-76" }),
+            }),
+        },
+    )
+    .expect("client request should succeed");
+
+    assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+    let invocation = invocations.lock().expect("invocations should lock")[0].clone();
+    assert_eq!(invocation.work_unit.as_deref(), Some("issue-76"));
+    assert_eq!(
+        invocation.input,
+        Some(InvocationInput::Artifact {
+            artifact_type: "work-unit".to_string(),
+            artifact_id: "issue-76".to_string(),
+            document: json!({ "id": "issue-76" }),
+        })
+    );
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
 fn daemon_rejects_conflicting_work_unit_and_input_from_socket_callers() {
     let _guard = env_lock()
         .lock()


### PR DESCRIPTION
## Summary

- Enables `agentd run --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json` so operator-supplied work-unit artifacts can start work-mode execution.
- Keeps request text intake-only while validating that work-mode artifacts use type `work-unit` and match the selected work-unit id.
- Documents the new invocation form in help output, README, and CHANGELOG.

## Changes

- Relaxed CLI conflicts so `--work-unit` composes with artifact-file input while `--request` remains mutually exclusive.
- Added runner validation for accepted and rejected work-mode input combinations.
- Added CLI, daemon socket, container-script, and lifecycle fixture coverage for the injected work-unit cascade path.

## GitHub Issue(s)

Closes #124

## Test plan

- `cargo fmt --all`
- `cargo test -p agentd-runner validate_invocation_`
- `cargo test -p agentd-runner container::tests::build_container_script_materializes_work_unit_input_before_work_mode_run`
- `cargo test -p agentd --test cli_surface`
- `cargo test -p agentd --test daemon_socket_interface`
- `cargo test -p agentd-runner --test session_lifecycle executes_work_mode_against_injected_work_unit_artifact -- --nocapture` (skips locally because Podman is unavailable)
- `cargo clippy --workspace --all-targets`
