### PR TITLE
docs: operator runbooks, audit/protocol invariants, references, and quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,24 @@ Every change must follow this sequence: behavioral spec -> test -> implementatio
 ### Coherence on Landing
 Each landing PR must verify documentation and code remain aligned. Confirm README claims still match repository reality. Confirm `ARCHITECTURE.md` still describes the actual architecture. Confirm doc comments match runtime behavior and interfaces. Confirm `AGENTS.md` still reflects required agent workflow and quality gates. If drift is found, fix it in the same PR.
 
+## Build and Test
+
+MSRV is Rust 1.85 (`rust-version` in `Cargo.toml`); the workspace targets
+Linux and non-Linux builds fail intentionally. The full loop:
+
+```sh
+cargo build
+cargo test          # unit + integration; podman interactions use a fake-podman fixture
+cargo clippy --all-targets
+cargo fmt --check
+```
+
+Integration tests live in `crates/agentd/tests/` and per-crate `tests/`;
+they do not require a running Podman service (container interactions go
+through the fake-podman test fixture). Verifying real session execution
+end-to-end requires a rootless-Podman host — follow
+[`docs/quickstart.md`](docs/quickstart.md).
+
 ## Conventions
 - Commit messages must use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`.
 - Branch names must follow `issue-N-brief-description`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS
 
+Principles: [pentaxis93/principles](https://github.com/pentaxis93/principles)
+
 ## Project Identity
 agentd is an autonomous AI agent runtime daemon for running autonomous AI agents on infrastructure you control. It is for builders and operators who need predictable, self-hosted execution of agent workflows without relying on hosted runtimes. The project is being built as a modular Rust workspace so runtime, scheduling, and integration concerns can evolve independently.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Invariant-level documentation next to security-critical code: `audit.rs`
+  gains a module contract (lifecycle, sealing invariants, symlink no-follow,
+  multi-link refusal, atomic metadata publish) with doc comments tying the
+  sealing constants and lifecycle functions to the security model;
+  `protocol.rs` documents the socket message enums and links the outcome
+  vocabulary to its canonical home at commons/EXIT-CODES.md;
+  `resources.rs` and `container.rs` document the secret-lifetime and
+  privilege-drop paths.
+- `docs/socket-protocol.md` — daemon Unix-socket wire reference: framing,
+  connection lifecycle, message shapes, outcome-status table, and the
+  internal/unversioned same-build rationale.
+- `docs/audit-record.md` — audit record format reference: layout,
+  `session.json` (`schema_version: 2`) and transcript `manifest.json`
+  schemas, sealing semantics, and change policy.
+
 - Operator runbooks under `docs/runbooks/`: equip an agent SSH identity,
   provision session secrets, and redeploy the daemon. Generic successors to
   the runbooks retired with `tesserine/ops` (recoverable at ops commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- `docs/environment.md` — environment-variable reference covering the
+  daemon-process, session-injection, and test-only scopes.
+- `AGENTS.md` Build and Test section: MSRV, the cargo loop, and where the
+  integration tests live.
 - `docs/quickstart.md` — end-to-end tutorial from image build through a
   completed session to the sealed audit record, using the canonical
   example-hello integration request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- `RELEASING.md` Tooling Provenance section and a `scripts/release-check`
+  provenance header: the script is agentd-owned, the ceremony convention is
+  canonical in commons, and no repo is the tooling upstream.
+
 - Invariant-level documentation next to security-critical code: `audit.rs`
   gains a module contract (lifecycle, sealing invariants, symlink no-follow,
   multi-link refusal, atomic metadata publish) with doc comments tying the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- `AGENTS.md` carries the canonical principles pointer
+  (`pentaxis93/principles`), matching the runa/groundwork entry-line
+  convention (#148).
 - `docs/environment.md` — environment-variable reference covering the
   daemon-process, session-injection, and test-only scopes.
 - `AGENTS.md` Build and Test section: MSRV, the cargo loop, and where the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- `SessionOutcome` documents commons/EXIT-CODES.md as the canonical home
+  of its outcome vocabulary, with `TimedOut` identified as the one
+  agentd-layer (caller-enforced timeout) addition.
 - `RELEASING.md` Tooling Provenance section and a `scripts/release-check`
   provenance header: the script is agentd-owned, the ceremony convention is
   canonical in commons, and no repo is the tooling upstream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Operator runbooks under `docs/runbooks/`: equip an agent SSH identity,
+  provision session secrets, and redeploy the daemon. Generic successors to
+  the runbooks retired with `tesserine/ops` (recoverable at ops commit
+  `c394550^`); host-specific deployment state remains with the operator's
+  host operations repository.
+
 - Runner setup now supports SSH repository clone through agent-scoped mounted
   OpenSSH material, including `ssh://` and `user@host:path` repository URLs.
 - Agent configuration now accepts an optional `forge_type` field and injects the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   canonical in commons, and no repo is the tooling upstream.
 
 - Invariant-level documentation next to security-critical code: `audit.rs`
-  gains a module contract (lifecycle, sealing invariants, symlink no-follow,
+  gains a module contract (lifecycle, sealing invariants, symlink skipping,
   multi-link refusal, atomic metadata publish) with doc comments tying the
   sealing constants and lifecycle functions to the security model;
   `protocol.rs` documents the socket message enums and links the outcome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- `docs/quickstart.md` — end-to-end tutorial from image build through a
+  completed session to the sealed audit record, using the canonical
+  example-hello integration request.
 - `SessionOutcome` documents commons/EXIT-CODES.md as the canonical home
   of its outcome vocabulary, with `TimedOut` identified as the one
   agentd-layer (caller-enforced timeout) addition.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ schedule evaluation: the next occurrence runs at its next scheduled time.
 
 ## Going Deeper
 
+- **[docs/quickstart.md](docs/quickstart.md)** — end-to-end tutorial: build
+  the image, configure an agent, run the first session, inspect the sealed
+  audit record.
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — session lifecycle phases, container
   isolation model, credential flow, and workspace crate boundaries. How the
   system is built and why.

--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ schedule evaluation: the next occurrence runs at its next scheduled time.
   branch conventions. Read this before contributing.
 - **[examples/agentd.toml](examples/agentd.toml)** — annotated agent
   configuration. Starting point for writing your own.
+- **[docs/runbooks/](docs/runbooks/README.md)** — operator runbooks: equip an
+  agent SSH identity, provision session secrets, redeploy the daemon.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ explicitly so the daemon socket location is also a deliberate host mount.
 
 On SIGINT or SIGTERM, the daemon stops accepting connections and drains
 in-flight sessions; a second signal exits immediately.
-The Unix socket protocol is internal to `agentd` in `v0.1.x`: daemon and CLI must be the same build, and operators must restart the daemon after replacing the binary before using `agentd run` again.
+The Unix socket protocol is internal to `agentd` in `v0.1.x`: daemon and CLI must be the same build, and operators must restart the daemon after replacing the binary before using `agentd run` again. The wire format is documented in [docs/socket-protocol.md](docs/socket-protocol.md).
 
 Trigger a session through the running daemon:
 
@@ -382,6 +382,11 @@ schedule evaluation: the next occurrence runs at its next scheduled time.
   configuration. Starting point for writing your own.
 - **[docs/runbooks/](docs/runbooks/README.md)** — operator runbooks: equip an
   agent SSH identity, provision session secrets, redeploy the daemon.
+- **[docs/audit-record.md](docs/audit-record.md)** — the sealed audit record
+  format: layout, `session.json` and `manifest.json` schemas, sealing
+  semantics. The supported surface for inspecting what a session did.
+- **[docs/socket-protocol.md](docs/socket-protocol.md)** — daemon socket wire
+  format (internal, unversioned in `v0.1.x`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ schedule evaluation: the next occurrence runs at its next scheduled time.
   semantics. The supported surface for inspecting what a session did.
 - **[docs/socket-protocol.md](docs/socket-protocol.md)** — daemon socket wire
   format (internal, unversioned in `v0.1.x`).
+- **[docs/environment.md](docs/environment.md)** — every environment variable
+  the daemon reads or injects, by scope.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,20 @@ Artifacts built from the tag must report that identity:
 This adapts the Tesserine release conventions in commons ADR-0006, ADR-0010,
 and ADR-0011 to agentd's release surface.
 
+## Tooling Provenance
+
+`scripts/release-check` (with its `scripts/verify-release-adoption.sh`
+self-test) is the agentd-owned implementation of the shared release
+ceremony's verification checks; the release cut itself uses `cargo release`
+per ADR-0006. The ceremony convention is canonical in
+[commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md)
+and ADR-0006/0011/0012. The script shares ancestry with the sibling
+implementations in the other release-component repos
+([commons#21](https://github.com/tesserine/commons/issues/21)) but is
+independently owned: no repo is the tooling upstream, and fixes do not
+propagate automatically. Ownership details:
+[base RELEASING.md § Release Tooling Ownership](https://github.com/tesserine/base/blob/main/RELEASING.md#release-tooling-ownership).
+
 ## Pre-Release Gate
 
 A releasable commit is on `main`, up to date with `origin/main`, and has a

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -1,3 +1,42 @@
+//! Session audit records: preparation, transcript finalization, and sealing.
+//!
+//! Every session leaves a persistent record under
+//! `<audit_root>/<agent>/<session_id>/` (layout and format:
+//! `docs/audit-record.md`; security tradeoffs: `ARCHITECTURE.md`
+//! § "Host audit records"). The record moves through exactly one lifecycle:
+//!
+//! 1. [`prepare_session_audit_record`] — create the record tree with
+//!    *active* permissions and publish initial `session.json` metadata.
+//!    Any preparation failure rolls the whole record directory back so a
+//!    half-built record is never observable.
+//! 2. The session runs; runa writes `runa/` state and transcript events
+//!    arrive in `agentd/transcript/` through the session-user identity.
+//! 3. [`finalize_session_transcript`] — render `events.jsonl` into
+//!    `transcript.md` and record a coverage verdict in `manifest.json`.
+//!    A rendering failure is itself recorded (`finalization_failed`) so
+//!    the manifest never silently overstates coverage.
+//! 4. [`finalize_session_audit_record`] — seal the tree read-only and only
+//!    then publish the finalized metadata. A record with a populated
+//!    `outcome` is therefore always a sealed record.
+//!
+//! Sealing is the security boundary between "session may still write" and
+//! "record is evidence". The invariants the sealing path enforces:
+//!
+//! - **Symlinks are never followed.** Inspection uses `symlink_metadata`,
+//!   chmod uses `fchmodat(AT_SYMLINK_NOFOLLOW)`, and symlink entries are
+//!   skipped, so session-written links cannot redirect a daemon-privileged
+//!   chmod outside the record.
+//! - **Multi-linked files are refused, not sealed.** A regular file with
+//!   `nlink > 1` aborts finalization (`preflight_validate_sealable_tree`):
+//!   chmod acts on the inode, so sealing a hardlink would mutate a file
+//!   that also lives outside the record.
+//! - **Metadata is published by atomic replace.** `session.json` is written
+//!   to a temp file, fsynced, then renamed into place (`write_atomic`);
+//!   readers see the old or the new metadata, never a partial write.
+//! - **The daemon seals with its own filesystem authority.** No Podman or
+//!   user-namespace re-entry happens during finalization; the startup
+//!   audit-root probe verified this authority before any dispatch.
+
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
 use serde_json::Value;
@@ -13,10 +52,18 @@ use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
+/// `session.json` schema version; bump on any breaking metadata change and
+/// update `docs/audit-record.md` in the same change.
 const METADATA_SCHEMA_VERSION: u32 = 2;
+/// Directories of an *active* (unsealed) record. World-traversable so the
+/// session-user identity can reach the `runa/` and transcript subtrees.
 const ACTIVE_AUDIT_DIRECTORY_MODE: u32 = 0o755;
+/// Sealed regular files: world-readable, writable by no one. Deliberate
+/// single-tenant tradeoff — see ARCHITECTURE.md § "Host audit records".
 const SEALED_FILE_MODE: u32 = 0o444;
+/// Sealed directories: traversal without write, same tradeoff as files.
 const SEALED_DIRECTORY_MODE: u32 = 0o555;
+/// `manifest.json` schema version for the transcript coverage verdict.
 const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
 const EVENTS_ARTIFACT: &str = "events.jsonl";
 const MANIFEST_ARTIFACT: &str = "manifest.json";
@@ -75,6 +122,12 @@ impl fmt::Display for TranscriptFinalizationFailure {
     }
 }
 
+/// Create the session's audit record tree with active permissions and
+/// publish the initial `session.json` (no `end_timestamp`/`outcome` yet).
+///
+/// On any failure the record directory is removed (`rollback_record_dir_on_error`)
+/// so a half-prepared record is never left for an operator to mistake for a
+/// real session.
 pub(crate) fn prepare_session_audit_record(
     session_id: &str,
     spec: &SessionSpec,
@@ -124,6 +177,15 @@ fn prepare_session_audit_record_at(
     })
 }
 
+/// Seal the record read-only, then publish finalized metadata — in that
+/// order, so a `session.json` carrying an `outcome` is proof the tree was
+/// already sealed.
+///
+/// Ordering within: restore daemon traversal over session-written
+/// directories, refuse the tree if any regular file is multi-linked, seal
+/// everything except the metadata path (which must stay replaceable for the
+/// final atomic write), then atomically publish `session.json` already in
+/// sealed mode.
 pub(crate) fn finalize_session_audit_record(
     record: &SessionAuditRecord,
     completion: SessionAuditCompletion<'_>,
@@ -140,6 +202,12 @@ pub(crate) fn finalize_session_audit_record(
     write_finalized_session_audit_metadata(record, &end_timestamp, outcome, exit_code)
 }
 
+/// Render the transcript artifacts and record a coverage verdict.
+///
+/// Coverage is honest by construction: a failure while producing
+/// `events.jsonl` or `transcript.md` is itself written into
+/// `manifest.json` as `finalization_failed` (with the error), so the
+/// manifest never claims more transcript than the record holds.
 pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result<(), RunnerError> {
     prepare_transcript_tree_for_finalization(&record.transcript_dir)?;
     match finalize_session_transcript_artifacts(record) {
@@ -434,6 +502,9 @@ fn write_fenced_code_block(
     Ok(())
 }
 
+/// Longest backtick run in untrusted transcript content — the rendered
+/// markdown fence must be strictly longer so session output cannot break
+/// out of its code block and forge transcript structure.
 fn max_consecutive_backticks(content: &str) -> usize {
     let mut current = 0;
     let mut max = 0;
@@ -541,6 +612,9 @@ fn ensure_transcript_directory(path: &Path) -> Result<(), RunnerError> {
     Ok(())
 }
 
+/// Re-grant owner access (`u+rwx` dirs, `u+rw` files) over the transcript
+/// tree without following symlinks, so finalization can read
+/// session-written events whatever modes the session left behind.
 fn repair_transcript_path_permissions(path: &Path) -> Result<(), RunnerError> {
     let metadata = fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() {
@@ -560,6 +634,10 @@ fn repair_transcript_path_permissions(path: &Path) -> Result<(), RunnerError> {
     Ok(())
 }
 
+/// chmod that never dereferences a final-component symlink
+/// (`fchmodat(AT_SYMLINK_NOFOLLOW)`): the audit tree contains
+/// session-written content, and following a planted link would let a
+/// session aim the daemon's chmod authority outside the record.
 fn set_owner_permissions_no_follow(path: &Path, mode: u32) -> Result<(), RunnerError> {
     let path = CString::new(path.as_os_str().as_bytes()).map_err(|error| {
         RunnerError::Io(std::io::Error::new(
@@ -586,6 +664,10 @@ fn seal_session_audit_record(record: &SessionAuditRecord) -> Result<(), RunnerEr
     seal_path_recursive(record, &record.record_dir)
 }
 
+/// Restore daemon read+traverse permission over session-written
+/// directories before validation and sealing walk them. The session user
+/// may have dropped directory modes; without this the walk could not even
+/// enumerate the tree it must seal.
 fn prepare_audit_tree_for_traversal(path: &Path) -> Result<(), RunnerError> {
     let metadata = fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
@@ -606,6 +688,13 @@ fn prepare_audit_tree_for_traversal(path: &Path) -> Result<(), RunnerError> {
     Ok(())
 }
 
+/// Refuse to seal a tree containing any multi-linked regular file.
+///
+/// `chmod` acts on the inode: sealing a hardlink planted by the session
+/// would flip permissions on a file that also exists outside the record.
+/// Refusing (rather than skipping) makes the tampering attempt loud — the
+/// session finalizes as an error instead of producing a quietly partial
+/// seal.
 fn preflight_validate_sealable_tree(path: &Path) -> Result<(), RunnerError> {
     let metadata = fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() {
@@ -660,6 +749,10 @@ fn seal_path(path: &Path, is_dir: bool) -> Result<(), RunnerError> {
     Ok(())
 }
 
+/// Paths excluded from sealing: the record root, `session.json`, and its
+/// parent directory. They must remain daemon-writable until the final
+/// atomic metadata publish; the metadata file itself is written directly
+/// in sealed mode.
 fn should_skip_sealing_path(record: &SessionAuditRecord, path: &Path) -> bool {
     path == record.record_dir
         || path == record.metadata_path
@@ -669,6 +762,9 @@ fn should_skip_sealing_path(record: &SessionAuditRecord, path: &Path) -> bool {
             .is_some_and(|metadata_dir| path == metadata_dir)
 }
 
+/// Publish a payload by temp-file write + fsync + rename within the same
+/// directory. Readers observe the previous content or the complete new
+/// content, never a torn write; the temp file is removed on failure.
 fn write_atomic(path: &Path, payload: &[u8], file_mode: Option<u32>) -> Result<(), RunnerError> {
     let temp_path = path.with_extension("json.tmp");
     let parent = path.parent().ok_or_else(|| {

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -22,10 +22,14 @@
 //! Sealing is the security boundary between "session may still write" and
 //! "record is evidence". The invariants the sealing path enforces:
 //!
-//! - **Symlinks are never followed.** Inspection uses `symlink_metadata`,
-//!   chmod uses `fchmodat(AT_SYMLINK_NOFOLLOW)`, and symlink entries are
-//!   skipped, so session-written links cannot redirect a daemon-privileged
-//!   chmod outside the record.
+//! - **Symlink entries are skipped, never sealed.** Every walk inspects
+//!   with `symlink_metadata` and skips symlinks; the sealing chmods are
+//!   plain `fs::set_permissions` calls made only on paths that inspection
+//!   found non-symlink. This check-then-chmod sequence is safe because
+//!   finalization runs after the session container has exited — no live
+//!   writer can swap a path between the check and the chmod. (Transcript
+//!   permission repair additionally uses `fchmodat(AT_SYMLINK_NOFOLLOW)`;
+//!   see `set_owner_permissions_no_follow`.)
 //! - **Multi-linked files are refused, not sealed.** A regular file with
 //!   `nlink > 1` aborts finalization (`preflight_validate_sealable_tree`):
 //!   chmod acts on the inode, so sealing a hardlink would mutate a file

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -52,6 +52,12 @@ pub(crate) fn create_container(
     .map(|_| ())
 }
 
+/// Run the created container attached until exit and classify the result.
+///
+/// Secret lifetime: once the container is observed `running`, the session's
+/// podman secrets are deleted (`wait_for_container_exit`) — the values are
+/// already inside the session environment, so the host-side secret store
+/// holds them only for the startup window.
 pub(crate) fn run_container_to_completion(
     container_name: &str,
     session_id: &str,
@@ -79,6 +85,12 @@ pub(crate) fn run_container_to_completion(
     }
 }
 
+/// [`run_container_to_completion`] with a caller-enforced deadline. On
+/// timeout the container is force-removed and the outcome is
+/// [`SessionOutcome::TimedOut`] — a caller-layer outcome that commons
+/// EXIT-CODES.md deliberately leaves outside the shared exit-code
+/// vocabulary. Cleanup failures degrade to kill + log, never to a hung
+/// session.
 pub(crate) fn run_container_with_timeout(
     container_name: &str,
     session_id: &str,
@@ -140,6 +152,8 @@ pub(crate) fn run_container_with_timeout(
     }
 }
 
+/// Force-remove the session container, ignoring absence so cleanup is
+/// idempotent across retries and crash-recovery paths.
 pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError> {
     run_podman_command(vec![
         "rm".to_string(),
@@ -150,15 +164,18 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
     .map(|_| ())
 }
 
-// Generates the shell script passed as the container entrypoint via
-// `/bin/sh -lc`. The script runs as root (UID 0) to perform privileged setup:
-// creating the agent's unix user, recursively re-owning pre-existing home
-// content while preserving host-backed mount targets, cloning the repository,
-// and transferring repository ownership. It then drops privileges permanently
-// via `gosu`
-// then invokes runa as the unprivileged agent user. `set -eu` at the top
-// ensures any setup failure aborts immediately rather than continuing with a
-// broken workspace.
+/// Generates the shell script passed as the container entrypoint via
+/// `/bin/sh -lc`.
+///
+/// Privilege model: the script starts as root (UID 0) for privileged setup —
+/// creating the agent's unix user, recursively re-owning pre-existing home
+/// content while preserving host-backed mount targets, cloning the
+/// repository, and transferring repository ownership. Every workload step
+/// (clone included) runs through `gosu <agent>`, and the final command is
+/// `exec gosu <agent> …`, so the drop to the unprivileged session user is
+/// permanent — no root process remains to return to. `set -eu` at the top
+/// aborts on any setup failure rather than continuing with a broken
+/// workspace.
 fn build_container_script(
     spec: &SessionSpec,
     invocation: &SessionInvocation,

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -169,13 +169,17 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 ///
 /// Privilege model: the script starts as root (UID 0) for privileged setup —
 /// creating the agent's unix user, recursively re-owning pre-existing home
-/// content while preserving host-backed mount targets, cloning the
-/// repository, and transferring repository ownership. Every workload step
-/// (clone included) runs through `gosu <agent>`, and the final command is
-/// `exec gosu <agent> …`, so the drop to the unprivileged session user is
-/// permanent — no root process remains to return to. `set -eu` at the top
-/// aborts on any setup failure rather than continuing with a broken
-/// workspace.
+/// content while preserving host-backed mount targets, and, for HTTP(S)
+/// repository URLs, running the clone itself as root: the repo token is
+/// captured into a shell variable, `AGENTD_REPO_TOKEN` is unset immediately,
+/// and the value is passed only as a one-shot `http.extraHeader` for that
+/// single `git clone` (`build_clone_command`). SSH clones instead run as the
+/// agent via `gosu` with `HOME` set so OpenSSH reads the mounted identity.
+/// After a root clone, repository ownership is transferred to the agent
+/// user. The final command is `exec gosu <agent> …`, so the drop to the
+/// unprivileged session user is permanent for the agent workload — no root
+/// process remains to return to. `set -eu` at the top aborts on any setup
+/// failure rather than continuing with a broken workspace.
 fn build_container_script(
     spec: &SessionSpec,
     invocation: &SessionInvocation,

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -93,6 +93,14 @@ pub(crate) fn unique_suffix() -> Result<String, RunnerError> {
     unique_suffix_with(|bytes| fill_random_bytes(bytes).map_err(std::io::Error::other))
 }
 
+/// Allocate every host-side resource a session needs — methodology staging
+/// copy, audit and transcript mounts, invocation-input mount, and one
+/// ephemeral podman secret per configured credential — or none of them.
+///
+/// Invariant: no leaked secret outlives a failed allocation. Each failure
+/// path rolls back everything already created (secrets first, then staging)
+/// before returning, and the rollback's own outcome is carried in the
+/// returned [`ResourceAllocationFailure`] so cleanup failures are loud.
 pub(crate) fn prepare_session_resources(
     container_name: &str,
     spec: &SessionSpec,
@@ -223,6 +231,10 @@ pub(crate) fn prepare_session_resources(
     Ok(resources)
 }
 
+/// Best-effort teardown after a late allocation failure: secrets are
+/// removed before the staging directory, every cleanup failure is logged,
+/// and the first cleanup error is preserved alongside the original
+/// allocation error rather than replacing it.
 fn rollback_failed_resource_allocation(
     resources: &SessionResources,
     session_id: &str,
@@ -275,6 +287,9 @@ fn rollback_failed_staging_dir_allocation(
     ResourceAllocationFailure::with_rollback_result(error, rollback_result)
 }
 
+/// Remove the session's ephemeral podman secrets. Secrets hold credential
+/// values for the session's lifetime only; leaving one behind would leak a
+/// live credential into podman's secret store beyond the session boundary.
 pub(crate) fn cleanup_podman_secrets(secret_bindings: &[SecretBinding]) -> Result<(), RunnerError> {
     let secret_names = secret_bindings
         .iter()
@@ -283,6 +298,9 @@ pub(crate) fn cleanup_podman_secrets(secret_bindings: &[SecretBinding]) -> Resul
     cleanup_podman_secret_names(&secret_names)
 }
 
+/// Remove secrets by name, tolerating ones already gone: the existing-name
+/// intersection makes cleanup idempotent, so a retry after partial failure
+/// cannot fail on the already-deleted remainder.
 pub(crate) fn cleanup_podman_secret_names(secret_names: &[String]) -> Result<(), RunnerError> {
     if secret_names.is_empty() {
         return Ok(());

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -132,6 +132,13 @@ pub struct SessionInvocation {
 }
 
 /// Terminal outcome of a completed session.
+///
+/// Labels and exit-code semantics implement the shared session-outcome
+/// vocabulary — canonical: commons/EXIT-CODES.md
+/// (<https://github.com/tesserine/commons/blob/main/EXIT-CODES.md>).
+/// agentd does not redefine them. `TimedOut` is the one agentd-layer
+/// addition: commons scopes caller-enforced timeout outside the shared
+/// vocabulary, and agentd is that caller.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionOutcome {
     /// The container process exited with code 0.

--- a/crates/agentd/src/protocol.rs
+++ b/crates/agentd/src/protocol.rs
@@ -1,26 +1,61 @@
+//! Daemon Unix-socket wire messages.
+//!
+//! Wire format and connection lifecycle are specified in
+//! `docs/socket-protocol.md`: newline-delimited JSON, one request and one
+//! response per connection. The protocol is intentionally internal and
+//! unversioned in `v0.1.x` — daemon and CLI client must be the same build
+//! (see README § Running a Session), which is why these types are
+//! `pub(crate)` and carry no version field.
+
 use agentd_runner::{InvocationInput, SessionOutcome};
 use serde::{Deserialize, Serialize};
 
+/// Client → daemon. Serialized externally as `{"type": "ping"}` or
+/// `{"type": "run", ...}`.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum RequestMessage {
+    /// Liveness probe; the daemon answers [`ResponseMessage::Pong`].
     Ping,
+    /// Trigger one session for a configured agent.
     Run {
+        /// Exact `[[agents]].name` from `agentd.toml`.
         agent: String,
+        /// Clone URL override; `None` uses the agent's configured `repo`.
         repo_url: Option<String>,
+        /// Work-unit identifier for work-mode invocations.
         work_unit: Option<String>,
+        /// Operator-supplied input materialized into the session workspace.
         input: Option<InvocationInput>,
     },
 }
 
+/// Daemon → client. Exactly one is written per accepted request, then the
+/// connection closes.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum ResponseMessage {
+    /// Answer to [`RequestMessage::Ping`].
     Pong,
+    /// The session ran to a terminal outcome (which may be a failure
+    /// outcome — transport success, not work success).
     SessionOutcome { outcome: OutcomeMessage },
+    /// The request was rejected before a session outcome existed:
+    /// malformed JSON, unknown agent, or dispatch failure.
     Error { message: String },
 }
 
+/// Terminal session outcome.
+///
+/// The `status` labels and `exit_code` values for `success` through
+/// `infrastructure_failure` (codes 0–6) and the reserved external codes
+/// (126, 127, 128+N) implement the shared session-outcome vocabulary —
+/// canonical: [commons/EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
+/// Do not redefine their semantics here.
+///
+/// `timed_out` is the one agentd-layer addition: commons defines
+/// caller-enforced timeout as a caller-layer outcome outside the shared
+/// vocabulary, and agentd is that caller.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub(crate) enum OutcomeMessage {

--- a/docs/audit-record.md
+++ b/docs/audit-record.md
@@ -1,0 +1,84 @@
+# Audit Record Format
+
+The persistent, sealed record every agentd session leaves behind. This is
+the supported integration surface for inspecting what a session did.
+Implemented by
+[`crates/agentd-runner/src/audit.rs`](../crates/agentd-runner/src/audit.rs);
+security model and tradeoffs: [ARCHITECTURE.md](../ARCHITECTURE.md)
+§ "Host audit records".
+
+## Location and layout
+
+One record per session at `<audit_root>/<agent>/<session_id>/`:
+
+```
+<audit_root>/<agent>/<session_id>/
+├── runa/                          # preserved .runa/ runtime state (store/, workspace/)
+└── agentd/
+    ├── session.json               # agentd-written session metadata (schema below)
+    └── transcript/
+        ├── events.jsonl           # structured transcript events (one JSON object per line)
+        ├── transcript.md          # human-readable rendering of the event stream
+        └── manifest.json          # transcript schema version + coverage verdict
+```
+
+`audit_root` resolution: `daemon.audit_root` if set, else
+`$XDG_STATE_HOME/tesserine/audit`, else `$HOME/.local/state/tesserine/audit`.
+Session ids are 16 lowercase hex characters.
+
+## Sealing
+
+A record is **active** while its session runs (directories `0755`, the
+`runa/` and transcript subtrees session-writable) and **sealed** once it
+completes: directories `0555`, non-symlink files `0444`. Sealed records are
+world-readable by design — a single-tenant tradeoff documented in
+ARCHITECTURE.md.
+
+Sealing happens **before** the finalized metadata is published, so:
+
+> A `session.json` containing an `outcome` field is proof the record tree
+> was already sealed when that metadata was written.
+
+A record whose `session.json` lacks `end_timestamp`/`outcome` is either a
+live session or an interrupted one (daemon crash, kill); README
+§ Running a Session describes diagnosing incomplete records.
+
+To delete a sealed record: `chmod -R u+w <record_dir> && rm -rf <record_dir>`.
+
+## `session.json` (`schema_version: 2`)
+
+| Field | Type | Presence | Meaning |
+| --- | --- | --- | --- |
+| `schema_version` | integer | always | `2` |
+| `session_id` | string | always | 16-hex session identifier |
+| `agent` | string | always | `[[agents]].name` that ran |
+| `repo_url` | string | always | repository the session cloned |
+| `work_unit` | string | when work-mode | work-unit identifier |
+| `start_timestamp` | string (RFC 3339) | always | written at preparation |
+| `end_timestamp` | string (RFC 3339) | finalized only | written at sealing |
+| `outcome` | string | finalized only | outcome label per [commons/EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md), or `error` when the runner failed before a session outcome existed |
+| `exit_code` | integer | finalized, when applicable | raw exit code, preserved per the commons caller contract |
+
+`session.json` is always published by atomic temp-file-and-rename within
+the record directory: readers see a complete old or new document, never a
+torn write.
+
+## `manifest.json` (`schema_version: 1`)
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schema_version` | integer | `1` |
+| `coverage` | string | `full`, `missing_mcp_events`, `no_events`, or `finalization_failed` |
+| `finalization_error` | string | present only with `finalization_failed` |
+
+Coverage is honest by construction: a failure while rendering the
+transcript is itself recorded as `finalization_failed` with the error, so
+the manifest never overstates what the transcript captured.
+`missing_mcp_events` means runa ran but the agent runtime never launched
+`runa-mcp`, so tool-call events were not observable.
+
+## Change policy
+
+`session.json` and `manifest.json` breaking changes bump the respective
+`schema_version` and this document in the same change. Additive optional
+fields do not.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,46 @@
+# Environment Variable Reference
+
+Every environment variable agentd reads or injects, by scope. Configuration
+that lives in `agentd.toml` is documented in
+[README § Configuration](../README.md#configuration); this reference covers
+only the environment.
+
+## Read by the daemon process
+
+| Variable | Who sets it | Effect | Default |
+| --- | --- | --- | --- |
+| `RUST_LOG` | operator | Log filter; overrides `AGENTD_LOG` when set | — |
+| `AGENTD_LOG` | operator | Log filter when `RUST_LOG` is unset | `info` |
+| `AGENTD_LOG_FORMAT` | operator | `json` or `pretty` log output on stderr | `json` |
+| credential `source` variables (e.g. `AGENTD_GITHUB_TOKEN`) | operator, per `[[agents.credentials]].source` in `agentd.toml` | Value forwarded into the session as the credential's `name`; read at session creation from the daemon's own process environment ([runbook](runbooks/provision-session-secrets.md)) | — (session creation fails if missing) |
+| `repo_token_source` variable | operator, per agent config | HTTPS clone-only token for the agent's repository | — |
+| `XDG_RUNTIME_DIR` | systemd/login session | Default socket directory: `$XDG_RUNTIME_DIR/agentd/agentd.sock` | — |
+| `XDG_STATE_HOME`, `HOME` | login session | Default audit root: `$XDG_STATE_HOME/tesserine/audit`, falling back to `$HOME/.local/state/tesserine/audit` | — |
+| `TMPDIR` | operator / image | Runner staging directory root; the daemon container image sets `/var/lib/agentd/tmp` ([README § Deployment](../README.md#deployment)) | system default |
+| `CONTAINER_HOST` | daemon container image | Points the in-container Podman client at the mounted host socket | set by the image |
+
+## Injected into the session container by agentd
+
+| Variable | Value | Consumed by |
+| --- | --- | --- |
+| `AGENT_NAME` | the agent's configured name | session tooling |
+| `GROUNDWORK_FORGE_TYPE` | `forge_type` from agent config, defaulting to `github` | groundwork forge mechanics |
+| `AGENTD_WORK_UNIT` | the `--work-unit` identifier, when present | session tooling |
+| `AGENTD_REPO_TOKEN` | the resolved repo token, when configured | repository clone/push |
+| `RUNA_TRANSCRIPT_DIR` | the mounted transcript directory | runa / runa-mcp transcript emission |
+| `RUNA_TRANSCRIPT_REDACT_ENV` | names of session env vars whose values must be redacted from transcripts | runa / runa-mcp |
+| credential `name` variables (e.g. `GITHUB_TOKEN`) | value of the corresponding daemon-side `source` variable, delivered via ephemeral podman secret | agent process |
+
+runa additionally injects its own session variables (`RUNA_FORGE_*`,
+`RUNA_ENTRY_TICKET`, `RUNA_MCP_CONFIG`) — those are runa's surface,
+documented in [runa's contracts](https://github.com/tesserine/runa/tree/main/docs),
+not agentd's.
+
+## Test-only
+
+`AGENTD_FAKE_PODMAN_LOG_DIR` and `AGENTD_LARGE_TRANSCRIPT_STREAMING_CHILD`
+are used by the test suites' fake-podman and streaming fixtures; they have
+no production effect.
+
+Adding a variable to either production table requires updating this
+reference in the same change.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -26,7 +26,7 @@ only the environment.
 | `AGENT_NAME` | the agent's configured name | session tooling |
 | `GROUNDWORK_FORGE_TYPE` | `forge_type` from agent config, defaulting to `github` | groundwork forge mechanics |
 | `AGENTD_WORK_UNIT` | the `--work-unit` identifier, when present | session tooling |
-| `AGENTD_REPO_TOKEN` | the resolved repo token, when configured | repository clone/push |
+| `AGENTD_REPO_TOKEN` | the resolved repo token, when configured | the generated clone step only: consumed for the one HTTPS `git clone` and unset before the agent command runs — it cannot authorize pushes. HTTPS pushes need a credential delivered via `[[agents.credentials]]`; SSH pushes use the mounted `.ssh` identity |
 | `RUNA_TRANSCRIPT_DIR` | the mounted transcript directory | runa / runa-mcp transcript emission |
 | `RUNA_TRANSCRIPT_REDACT_ENV` | names of session env vars whose values must be redacted from transcripts | runa / runa-mcp |
 | credential `name` variables (e.g. `GITHUB_TOKEN`) | value of the corresponding daemon-side `source` variable, delivered via ephemeral podman secret | agent process |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,99 @@
+# Quickstart: First Session to Sealed Audit Record
+
+From nothing to one completed agent session against the canonical
+integration fixture, with the audit record to prove it. Each step links the
+reference documentation it abbreviates.
+
+Prerequisites: Linux host with rootless Podman, Rust toolchain, an
+Anthropic API key.
+
+## 1. Build the session image
+
+Sessions run in the [base](https://github.com/tesserine/base) image (runa +
+verified Claude Code):
+
+```sh
+git clone https://github.com/tesserine/base && cd base
+podman build --tag localhost/tesserine/base .
+cd ..
+```
+
+## 2. Get a methodology
+
+Sessions execute a runa methodology; the reference methodology is
+[groundwork](https://github.com/tesserine/groundwork):
+
+```sh
+git clone https://github.com/tesserine/groundwork
+```
+
+## 3. Configure an agent
+
+Write `agentd.toml` (full reference: [README § Configuration](../README.md#configuration),
+annotated example: [examples/agentd.toml](../examples/agentd.toml)):
+
+```toml
+[[agents]]
+name = "site-builder"
+base_image = "localhost/tesserine/base"
+methodology_dir = "./groundwork"
+repo = "https://github.com/tesserine/example-hello"
+
+[agents.command]
+argv = ["claude", "-p", "--dangerously-skip-permissions"]
+
+[[agents.credentials]]
+name = "ANTHROPIC_API_KEY"
+source = "AGENTD_ANTHROPIC_KEY"
+```
+
+## 4. Build agentd and start the daemon
+
+```sh
+git clone https://github.com/tesserine/agentd && cd agentd
+cargo build --release
+export AGENTD_ANTHROPIC_KEY="<your key>"   # the credential source above
+./target/release/agentd daemon --config ../agentd.toml
+```
+
+The daemon probes its audit root at startup and then listens on its Unix
+socket. (Production deployments run the daemon as a Quadlet-managed
+container instead — [README § Deployment](../README.md#deployment).)
+
+## 5. Run the smoke-test session
+
+In a second shell, trigger the canonical integration request
+([example-hello](https://github.com/tesserine/example-hello)):
+
+```sh
+./target/release/agentd run site-builder --request 'add a `greet(name)` function'
+```
+
+The command blocks until the session reaches a terminal outcome and
+reports it. `success` means the work completed; any other label is
+interpreted per
+[commons EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
+
+## 6. Inspect the audit record
+
+Every session leaves a sealed record
+(format: [audit-record.md](audit-record.md)):
+
+```sh
+record=$(ls -dt "${XDG_STATE_HOME:-$HOME/.local/state}/tesserine/audit/site-builder/"* | head -1)
+cat "$record/agentd/session.json"            # outcome, exit code, timestamps
+cat "$record/agentd/transcript/manifest.json" # transcript coverage verdict
+less "$record/agentd/transcript/transcript.md"
+```
+
+Pass criteria: `session.json` shows `"outcome": "success"`, the record
+tree is read-only (sealed), and `manifest.json` coverage is `full` or
+`missing_mcp_events`.
+
+## Where to go next
+
+- Operate it for real: [runbooks](runbooks/README.md) — SSH identities,
+  session secrets, redeploys.
+- Scheduled runs: [README § Scheduled Runs](../README.md#scheduled-runs).
+- What happened inside: [ARCHITECTURE.md](../ARCHITECTURE.md) — the
+  four-phase session lifecycle and isolation model.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,33 @@
+# Operator Runbooks
+
+Generic operator procedures for hosts running agentd. Each runbook is one
+complete use case: an operator with a goal follows the one runbook for that
+goal, start to finish, and ends with a verification step.
+
+This directory owns the **generic** agentd-host procedures
+(canonical per [commons SOURCE-OF-TRUTH.md](https://github.com/tesserine/commons/blob/main/SOURCE-OF-TRUTH.md)).
+Host-specific deployment state — concrete hostnames, deployment manifests,
+convergence scripts, secret-manager choices — belongs to the operator's own
+host operations repository, not here. These runbooks name the points where
+host-specific procedure takes over.
+
+| Runbook | Use case |
+| --- | --- |
+| [equip-agent-ssh-identity.md](equip-agent-ssh-identity.md) | Give an agent an SSH identity so its sessions can clone and push a repository over SSH |
+| [provision-session-secrets.md](provision-session-secrets.md) | Deliver credentials to the daemon so sessions receive their configured secrets |
+| [redeploy-agentd.md](redeploy-agentd.md) | Upgrade or recover a deployed agentd daemon to a chosen release ref |
+
+## History
+
+Predecessor runbooks lived in [`tesserine/ops`](https://github.com/tesserine/ops),
+which is retired. The host-bound originals (babbie-specific paths, the
+Bitwarden secrets loader, the `tesserine-rebuild-babbie` convergence script)
+are recoverable from ops git history at commit `c394550`'s parent:
+
+```sh
+git -C ops show 'c394550^:runbooks/README.md'
+git -C ops show 'c394550^:runbooks/equip-agent-ssh-identity.md'
+git -C ops show 'c394550^:scripts/agentd-secrets-loader'
+```
+
+The runbooks here are their generic successors.

--- a/docs/runbooks/equip-agent-ssh-identity.md
+++ b/docs/runbooks/equip-agent-ssh-identity.md
@@ -1,0 +1,127 @@
+# Equip agent SSH identity
+
+Equip an agentd agent with an SSH identity so the agent's sessions can clone
+and push a private repository over SSH. SSH clones use mounted `.ssh`
+material; they do not use `repo_token_source` (which is HTTPS-only — see
+[provision-session-secrets.md](provision-session-secrets.md)).
+
+## Parameters
+
+- `<agent>` — the exact `[[agents]].name` in `agentd.toml`.
+- `<git-ssh-host>` — the SSH host of the agent's private repository, such as
+  `github.com`.
+- `<private-repo-ssh-url>` — the SSH clone URL used for end-to-end
+  verification.
+- `<identity-root>` — host directory holding per-agent identity directories,
+  owner-only for the daemon user. Convention: a dedicated root such as
+  `/var/lib/tesserine/agent-ssh-identities`.
+
+## Preconditions
+
+- Shell access to the agentd host as the daemon user.
+- The agent exists in `agentd.toml`.
+- You can register an SSH public key with the Git service hosting
+  `<private-repo-ssh-url>`.
+- Changes to `agentd.toml` go through your host's change-review process
+  where one exists.
+
+## Procedure
+
+### 1. Provision the agent's keypair and host-key trust
+
+The identity directory convention for `<agent>`:
+
+- directory: `<identity-root>/<agent>`, mode `0700`, owned by the daemon user
+- private key: `<identity-root>/<agent>/id_ed25519`, mode `0600`
+- public key: `<identity-root>/<agent>/id_ed25519.pub`, mode `0644`
+- known hosts: `<identity-root>/<agent>/known_hosts`, mode `0644`
+
+```bash
+agent=<agent>
+git_ssh_host=<git-ssh-host>
+identity_dir="<identity-root>/$agent"
+
+test ! -e "$identity_dir/id_ed25519"
+test ! -e "$identity_dir/known_hosts"
+install -d -m 0700 "$identity_dir"
+ssh-keygen -t ed25519 -N "" -f "$identity_dir/id_ed25519" -C "$agent@$(hostname)"
+ssh-keyscan -T 10 -t rsa,ecdsa,ed25519 -H "$git_ssh_host" > "$identity_dir/known_hosts"
+test -s "$identity_dir/known_hosts"
+ssh-keygen -lf "$identity_dir/known_hosts"
+chmod 0600 "$identity_dir/id_ed25519"
+chmod 0644 "$identity_dir/id_ed25519.pub" "$identity_dir/known_hosts"
+```
+
+The key is deliberately **passphraseless**: agent sessions have no
+interactive terminal for a passphrase prompt, and the `.ssh` mount is
+read-only, so OpenSSH cannot prompt for host-key trust or write first-use
+`known_hosts` entries during clone or push. The private key never leaves
+the host.
+
+On SELinux-enforcing hosts, the identity directory must carry a container
+file context or the session cannot read the mount. Register a durable
+mapping and apply it:
+
+```bash
+sudo semanage fcontext -a -t container_file_t "<identity-root>(/.*)?"
+sudo restorecon -RFv "<identity-root>"
+```
+
+On hosts without `semanage` (e.g. Fedora CoreOS), append the rule to
+`/etc/selinux/targeted/contexts/files/file_contexts.local` directly, then
+run `restorecon -RFv`.
+
+### 2. Authorize the public key with the Git service
+
+Before trusting the identity, compare the fingerprints printed by
+`ssh-keygen -lf` against the Git provider's published SSH host-key
+fingerprints. Then register `id_ed25519.pub` with the service for
+`<private-repo-ssh-url>` — as a repository deploy key (write-enabled if the
+agent pushes) or on a machine account scoped to that repository.
+
+### 3. Mount the identity into the agent's session
+
+Add a read-only mount of **only the owning agent's directory** to that
+agent's configuration in `agentd.toml`, through review:
+
+```toml
+[[agents.mounts]]
+source = "<identity-root>/<agent>"
+target = "/home/<agent>/.ssh"
+read_only = true
+```
+
+Never mount the shared identity root, and never mount another agent's
+directory. Sessions run with `HOME=/home/<agent>`, so OpenSSH reads the
+mounted material from the session user's home.
+
+### 4. Restart the daemon on the reviewed configuration
+
+Apply the reviewed `agentd.toml` to the live host and restart the daemon —
+via your host's deployment procedure, or
+[redeploy-agentd.md](redeploy-agentd.md) when the change ships together
+with a release-ref change.
+
+## Verification
+
+Run the agent against its configured private repository:
+
+```sh
+agentd run <agent> <private-repo-ssh-url>
+```
+
+The run succeeds past repository clone using the mounted identity.
+
+## Failure modes
+
+- **SSH permission failure at clone** — the public key is not registered
+  with the Git service, or is registered without access to this repository.
+- **Host-key prompt or `known_hosts` failure** — `known_hosts` is missing,
+  empty, or does not cover `<git-ssh-host>`; regenerate it with
+  `ssh-keyscan` and re-verify fingerprints.
+- **Permission denied reading the mount on SELinux hosts** — the
+  `container_file_t` mapping was not applied; rerun `restorecon -RFv`.
+- **Identity lost after host reprovisioning** — immutable-OS hosts wipe
+  host state; recreate or restore the identity directory, and if a new
+  keypair is generated, replace the registered public key before running
+  the agent.

--- a/docs/runbooks/provision-session-secrets.md
+++ b/docs/runbooks/provision-session-secrets.md
@@ -1,0 +1,117 @@
+# Provision session secrets
+
+Deliver credentials to the agentd daemon so agent sessions receive their
+configured secrets. agentd reads each configured credential from the
+**daemon's own process environment** and forwards it into the session as an
+ephemeral Podman secret; the operator's job is getting the right variables
+into that environment without persisting secret values anywhere
+world-readable.
+
+How a session receives credentials (reference:
+[README § Configuration](../../README.md#configuration)):
+
+- `[[agents.credentials]]` — each entry names a session-visible variable
+  (`name`) and the daemon-environment variable it is read from (`source`).
+- `repo_token_source` — daemon-environment variable holding an HTTPS
+  clone-only token. SSH clones use mounted `.ssh` material instead
+  ([equip-agent-ssh-identity.md](equip-agent-ssh-identity.md)) and need no
+  token.
+
+## Parameters
+
+- `<env-file>` — host path of the rendered environment file, owner-only for
+  the daemon user. Convention: `/var/lib/tesserine/config/credentials.env`.
+- The set of `source` variable names declared in `agentd.toml`.
+
+## Preconditions
+
+- Shell access to the agentd host as the daemon user.
+- A secret store the host can query non-interactively (a secrets-manager
+  CLI with a machine token, or systemd-creds material). Which store is a
+  host decision; this runbook is store-agnostic.
+
+## Procedure
+
+### 1. Render the environment file from your secret store
+
+Produce `<env-file>` containing one `KEY=value` line per `source` variable.
+Render it atomically and owner-only, and never echo values:
+
+```bash
+umask 077
+tmp="$(mktemp "$(dirname <env-file>)/.credentials.XXXXXX")"
+# Query your secret store here, writing KEY=value lines to "$tmp".
+# Do not log, echo, or command-line-pass the values; do not run under set -x.
+mv "$tmp" <env-file>
+```
+
+Rules the renderer must follow, whatever the store:
+
+- The file is created `0600` before any secret byte is written (the `umask`
+  + `mktemp` pattern above).
+- Values are written exactly — decode any store-side JSON string escapes.
+- A failed render leaves the previous file intact (atomic `mv`).
+- Machine tokens for the store live in their own owner-only file, never in
+  the rendered output and never in shell history.
+
+### 2. Point the daemon at the environment file
+
+For a Quadlet/systemd-managed daemon container, reference the file from the
+unit so every daemon start carries the variables:
+
+```ini
+[Container]
+EnvironmentFile=<env-file>
+```
+
+For a directly-run daemon, export the variables into its process
+environment from the same file before start. Either way, re-render then
+restart the daemon to pick up rotated values:
+
+```bash
+systemctl --user restart agentd.service
+```
+
+### 3. Rotate
+
+Rotation is re-running this runbook: update the value in the secret store,
+re-render `<env-file>`, restart the daemon. Sessions started after the
+restart use the new value; running sessions keep the secret they were
+started with until they end.
+
+## Verification
+
+Without printing any secret value:
+
+```bash
+stat -c '%a %U' <env-file>          # expect: 600 <daemon-user>
+cut -d= -f1 <env-file> | sort       # expect: exactly the configured source names
+```
+
+Then start a session for an agent whose work requires the credential
+(`agentd run <agent>`) and confirm it proceeds past the step that consumes
+it — e.g. HTTPS clone for `repo_token_source`.
+
+## Failure modes
+
+- **Daemon starts but sessions lack a credential** — the `source` variable
+  was absent from the daemon's environment at start; agentd reads sources
+  at session creation from its own process environment, so fix the env file
+  or unit reference and restart.
+- **Stale value after rotation** — the daemon was not restarted after
+  re-rendering; restart it.
+- **Secret value in logs or history** — treat as exposure: rotate the value
+  at the store, then re-render. Audit the renderer for `set -x`, `echo`, or
+  command-line passing.
+
+## History
+
+The retired `tesserine/ops` repository carried a worked, tested
+implementation of step 1 against Bitwarden Secrets Manager
+(`agentd-secrets-loader`, 479 lines, with config-file/env-var precedence,
+timeouts, JSON unescaping, and atomic replace). It is recoverable for
+reference:
+
+```sh
+git -C ops show 'c394550^:scripts/agentd-secrets-loader'
+```

--- a/docs/runbooks/redeploy-agentd.md
+++ b/docs/runbooks/redeploy-agentd.md
@@ -1,0 +1,89 @@
+# Redeploy agentd
+
+Upgrade or recover a deployed agentd daemon to a chosen release ref. This is
+the generic procedure; a host operations repository that automates it (image
+build, artifact install, convergence, verification in one script) supersedes
+the manual steps on that host.
+
+The deployment shape itself — Quadlet-run daemon container, mounted Podman
+socket, path-visibility requirements — is reference material in
+[README § Deployment](../../README.md#deployment). This runbook is the
+ordered operator procedure over it.
+
+## Parameters
+
+- `<ref>` — immutable agentd release ref: a `vX.Y.Z[-rc.N]` tag or full
+  commit SHA. Never a branch name
+  ([commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md)).
+
+## Preconditions
+
+- Shell access to the agentd host as the daemon user.
+- The reviewed deployment artifacts (`agentd.toml`, the Quadlet `.container`
+  unit) are at the state you intend to converge to.
+- No session you are unwilling to interrupt is running — check the daemon
+  journal (`journalctl --user -u agentd.service`) or `podman ps` for live
+  session containers.
+
+## Procedure
+
+### 1. Build the image at the pinned ref
+
+```bash
+podman build \
+  --build-arg AGENTD_REF=<ref> \
+  --tag localhost/agentd:<ref> .
+```
+
+### 2. Verify the built image before touching live state
+
+```bash
+podman inspect localhost/agentd:<ref> | jq '.[0].Config.Labels'
+podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:<ref> --version
+```
+
+The labels and self-reported version must name `<ref>`. A mismatch is a
+build-input defect — stop before any live mutation.
+
+### 3. Install artifacts and promote
+
+Install the reviewed `agentd.toml` and Quadlet unit to their host
+locations, update the unit's image reference to `localhost/agentd:<ref>`,
+and install the matching host-side `agentd` CLI client if the host uses one
+(the client and daemon should be the same build).
+
+### 4. Restart and reload
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart agentd.service
+```
+
+## Verification
+
+```bash
+systemctl --user is-active agentd.service
+podman ps --format '{{.Image}}' | grep agentd     # running image names <ref>
+agentd --version                                   # host CLI matches, if installed
+```
+
+Then run a session against the canonical integration fixture and confirm a
+sealed audit record appears:
+
+```sh
+agentd run <agent> https://github.com/tesserine/example-hello --request 'add a `greet(name)` function'
+```
+
+## Failure modes
+
+- **Daemon fails startup probe** — the probe verifies create/chmod/restore/
+  remove under `audit_root`; check that the audit mount and runtime paths
+  are reachable from inside the daemon container (README § Deployment, path
+  visibility).
+- **Sessions fail after upgrade with mount errors** — `agentd.toml` mount
+  sources must exist on the host and be visible to host Podman at the same
+  absolute paths; a host reprovision may have wiped them (see
+  [equip-agent-ssh-identity.md](equip-agent-ssh-identity.md) failure modes).
+- **Rollback** — repeat this runbook with the previous known-good `<ref>`;
+  refs are immutable, so the prior image either still exists locally or
+  rebuilds reproducibly.

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -1,0 +1,96 @@
+# Daemon Socket Protocol
+
+Wire protocol between the agentd daemon and its CLI client over the Unix
+socket at `daemon.socket_path`. Implemented by
+[`crates/agentd/src/protocol.rs`](../crates/agentd/src/protocol.rs) (message
+types) and `crates/agentd/src/daemon.rs` (framing and dispatch).
+
+**Stability: internal and unversioned in `v0.1.x`.** Daemon and client must
+be the same build; messages carry no version field. After replacing the
+binary, restart the daemon before using `agentd run` again. Do not build
+external integrations against this protocol — the supported integration
+surfaces are the CLI and the audit record
+([audit-record.md](audit-record.md)).
+
+## Framing and connection lifecycle
+
+- Transport: `SOCK_STREAM` Unix domain socket.
+- Framing: newline-delimited JSON — one request line, one response line.
+- Lifecycle: connect → write one request + `\n` → read one response line →
+  connection closes. One session trigger per connection; the response is
+  not written until the session reaches a terminal outcome, so `run`
+  connections stay open for the session's duration.
+- An empty connection (EOF before a line) is ignored. A malformed request
+  line gets an `error` response.
+
+## Requests
+
+`{"type": "ping"}` — liveness probe.
+
+`{"type": "run", ...}` — trigger one session:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `agent` | string | Exact `[[agents]].name` in `agentd.toml` |
+| `repo_url` | string \| null | Clone URL; `null` uses the agent's configured `repo` |
+| `work_unit` | string \| null | Work-unit identifier for work-mode invocations |
+| `input` | object \| null | Operator-supplied session input, see below |
+
+`input` is one of (externally tagged):
+
+```json
+{"RequestText": {"description": "add a `greet(name)` function"}}
+```
+
+```json
+{"Artifact": {"artifact_type": "work-unit", "artifact_id": "issue-42", "document": { "...": "..." }}}
+```
+
+`RequestText` is synthesized into a canonical request artifact
+([commons REQUEST.md](https://github.com/tesserine/commons/blob/main/REQUEST.md));
+`Artifact` is materialized verbatim after validation.
+
+## Responses
+
+`{"type": "pong"}` — answer to `ping`.
+
+`{"type": "error", "message": "..."}` — the request was rejected before a
+session outcome existed (malformed request, unknown agent, dispatch
+failure).
+
+`{"type": "session_outcome", "outcome": {"status": "...", ...}}` — the
+session ran to a terminal outcome. A `session_outcome` response means the
+transport and dispatch succeeded; the work may still have failed — read
+`status`.
+
+## Outcome statuses
+
+`status` values and exit codes implement the shared session-outcome
+vocabulary — canonical:
+[commons/EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
+The raw exit code is always preserved alongside the label, per the commons
+caller contract.
+
+| `status` | Fields | Commons code |
+| --- | --- | --- |
+| `success` | `exit_code` | 0 |
+| `generic_failure` | `exit_code` | 1 (and unrecognized non-zero codes) |
+| `usage_error` | `exit_code` | 2 |
+| `blocked` | `exit_code` | 3 |
+| `nothing_ready` | `exit_code` | 4 |
+| `work_failed` | `exit_code` | 5 |
+| `infrastructure_failure` | `exit_code` | 6 |
+| `command_not_executable` | `exit_code` | 126 (reserved external) |
+| `command_not_found` | `exit_code` | 127 (reserved external) |
+| `terminated_by_signal` | `exit_code`, `signal` | 128+N (reserved external) |
+| `timed_out` | — | agentd-layer addition: commons scopes caller-enforced timeout outside the shared vocabulary, and agentd is that caller |
+
+## Examples
+
+```sh
+printf '{"type":"ping"}\n' | socat - UNIX-CONNECT:"$XDG_RUNTIME_DIR/agentd/agentd.sock"
+```
+
+```json
+{"type":"run","agent":"site-builder","repo_url":"https://github.com/tesserine/example-hello","work_unit":null,"input":{"RequestText":{"description":"add a `greet(name)` function"}}}
+```

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# agentd-owned implementation of the Tesserine release ceremony.
+# Convention canonical: commons RELEASE.md + ADR-0006/0011/0012
+# (https://github.com/tesserine/commons). This script verifies agentd's own
+# release surface. Sibling implementations in agentd, base, commons, runa,
+# and groundwork share ancestry (commons#21) but are independently owned:
+# no repo is the tooling upstream and fixes do not propagate automatically.
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 


### PR DESCRIPTION
Part of the ecosystem-wide documentation coherence pass (refs tesserine/commons#5).

## What this does

- **docs/runbooks/** — generic successors to the runbooks orphaned by the ops retirement (ops `c394550`): equip-agent-ssh-identity, provision-session-secrets, redeploy-agentd. Host-specific procedure stays with the operator's host repo; the originals are breadcrumbed in ops history.
- **audit.rs invariants at the code** — module contract for the sealing security boundary (symlink skipping, multi-link refusal, seal-before-metadata ordering, atomic publish), doc comments on constants and lifecycle/hardening functions. Previously 1,921 lines with zero doc comments.
- **docs/socket-protocol.md** + `protocol.rs` enum docs — wire format, framing, lifecycle, outcome-status table, same-build rationale.
- **docs/audit-record.md** — record layout, `session.json` (schema_version 2) and transcript manifest schemas, sealing semantics.
- **docs/environment.md** — every env var read or injected, by scope.
- **docs/quickstart.md** — end-to-end: image build → first session → sealed audit record.
- `SessionOutcome`/`OutcomeMessage` back-reference commons/EXIT-CODES.md as canonical (`timed_out` named as the one agentd-layer addition).
- AGENTS.md: build/test quickstart (MSRV 1.85) and the canonical principles pointer (closes #148).
- RELEASING.md tooling-provenance section; release-check provenance header.

## Verification

- `cargo test`: 410 passed, 0 failed. `./scripts/verify-release-adoption.sh` passes.
- All new doc links resolve; quickstart commands verified against the actual CLI surface (no invented subcommands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)