### PR TITLE
docs(readme): position agentd as production-grade autonomous agent operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- README hero rewritten for the ecosystem README pass: positions agentd as
+  the daemon for running autonomous agents like production workloads, with
+  the isolation, credential-lifetime, and sealed-evidence guarantees stated
+  with their proof links. All contract-bearing statements (same-build socket
+  policy, socket resolution, audit root) preserved verbatim.
+
 - Deployment and architecture documentation no longer names a specific
   operator host when describing supported single-tenant deployment tradeoffs.
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,36 @@
 # agentd
 
-Autonomous AI agent runtime daemon. agentd runs agent sessions in ephemeral
-Podman containers on infrastructure you control. Each session gets an isolated
-execution environment — its own identity, credentials, a fresh repository
-clone, and read-only methodology context — supervised from setup through
-teardown. agentd prepares and supervises these environments; model inference and
-MCP transport belong to the agent runtime inside the container.
+**Run autonomous agents like production workloads — isolated, credentialed,
+and evidence-leaving.**
+
+agentd is the daemon that makes "an agent ran unattended on my hardware"
+something you can defend. Each session gets an ephemeral rootless Podman
+container with its own unprivileged identity, a fresh repository clone, and
+read-only methodology context; privileged setup ends in a permanent `gosu`
+drop. Credentials are minimized by construction — session secrets are
+delivered as ephemeral podman secrets and removed from the host-side store
+the moment the container is running, and an HTTPS repo token is consumed by
+the clone step and unset before the agent process ever starts.
+
+And when the session ends, it leaves **evidence**: a sealed audit record —
+directories read-only, metadata published by atomic replace, symlink and
+hardlink tampering refused loudly — whose
+[format is a documented contract](docs/audit-record.md). A record with an
+outcome is proof the tree was already sealed when that outcome was written.
+That is the property the rest of the
+[Tesserine](https://github.com/tesserine) stack's trust story rests on
+(ecosystem map:
+[commons SOURCE-OF-TRUTH.md](https://github.com/tesserine/commons/blob/main/SOURCE-OF-TRUTH.md)).
+
+The operator declares *what* through agent configuration — which image, which
+credentials, which methodology. agentd owns *how* — container lifecycle,
+privilege management, resource cleanup. Model inference and MCP transport
+belong to the agent runtime inside the container; agentd deliberately does
+neither.
 
 The project targets Linux hosts. Non-Linux builds fail intentionally because
 the runner depends on Linux runtime primitives including rootless Podman,
 systemd user services, and SELinux-aware filesystem handling.
-
-## Why
-
-Running autonomous agents requires infrastructure: isolated environments,
-credential injection, workspace setup, identity management. Operators building
-this ad-hoc re-solve the same problems for each agent and each deployment.
-
-agentd is the self-hosted runtime layer. The operator declares *what* through
-agent configuration — which image, which credentials, which methodology.
-agentd owns *how* — container lifecycle, privilege management, resource cleanup.
-The agent gets an isolated, ephemeral workspace with exactly what it needs and
-nothing more.
 
 ## Status
 


### PR DESCRIPTION
Part of the README excellence pass (refs tesserine/commons#5): rewrite the nine front doors — org profile + eight repo READMEs — as one cohesive narrative in a grounded-visionary voice, every claim traceable to a contract, architecture doc, test, or runnable example.

Hero absorbs the old Why section: isolation, credential-lifetime minimization (secret release at container-running, clone-token unset — both code-verified claims), and the sealed-evidence story. All four test-enforced README phrases preserved verbatim; workspace_contract suite passes (24/24).

Verification for the whole pass: SOURCE-OF-TRUTH reachable from all nine pages; no page asserts the exploratory concept draft as fact; agentd's test-enforced phrases and groundwork's forbidden-phrase gates verified; example-hello's canonical-request contract intact; all relative links resolve; suites green (agentd 24/24 workspace_contract, runa 14/14 workspace_contract, groundwork 299+36, gazette 11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)