### PR TITLE
docs(readme): pin deployment examples to the released v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deployment and architecture documentation no longer names a specific
   operator host when describing supported single-tenant deployment tradeoffs.
 
+### Fixed
+
+- README deployment examples reference the released `v0.1.2` tag (they
+  were pinned to `v0.1.2-rc.1`).
+
 ## [0.1.2] — 2026-05-17
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -171,14 +171,14 @@ Repository release operations are described in [`RELEASING.md`](RELEASING.md).
 
 ```bash
 podman build \
-  --build-arg AGENTD_REF=v0.1.2-rc.1 \
-  --tag localhost/agentd:v0.1.2-rc.1 .
+  --build-arg AGENTD_REF=v0.1.2 \
+  --tag localhost/agentd:v0.1.2 .
 ```
 
 Confirm the deployed image metadata with:
 
 ```bash
-podman inspect localhost/agentd:v0.1.2-rc.1 | jq '.[0].Config.Labels'
+podman inspect localhost/agentd:v0.1.2 | jq '.[0].Config.Labels'
 ```
 
 The image's default command starts the daemon and reads
@@ -244,7 +244,7 @@ deployments.
 Confirm the image contents with:
 
 ```bash
-podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:v0.1.2-rc.1 --version
+podman run --rm --entrypoint /usr/local/bin/agentd localhost/agentd:v0.1.2 --version
 ```
 
 ## Running a Session


### PR DESCRIPTION
The README's copy-pasteable deployment examples (image build, `podman inspect`, `--version` smoke check) pinned `v0.1.2-rc.1`. The stable `v0.1.2` tag exists and `Cargo.toml` carries `version = "0.1.2"`, so a first-time visitor following the examples would build from a release candidate instead of the release.

Four occurrences updated; no other content touched.

Part of the public front-door communication pass: tesserine/.github#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)