### PR TITLE
fix(runner): defer additional bind-mount source existence to the host boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,11 +54,15 @@ service:
 | Runner staging directory | daemon process writes; host Podman resolves staged bind sources | The path named by `TMPDIR` must exist at the same absolute path for the daemon container and host Podman. The image default requires host `/var/lib/agentd/tmp` mounted to container `/var/lib/agentd/tmp`, or a changed `TMPDIR` exposed identically on both sides. |
 
 The path split follows directly from the current runner implementation. The
-daemon process validates and canonicalizes methodology, audit, additional
-mount, invocation-input, and staging paths, then sends bind-mount source
+daemon process validates and canonicalizes methodology, audit,
+invocation-input, and staging paths, then sends bind-mount source
 strings to the host Podman service. Runner-owned relabelled sources are passed
 as direct canonical host paths so Podman's SELinux relabel operation applies to
 the real source tree; operator-declared mounts continue to use staged aliases.
+Operator-declared additional-mount sources are not canonicalized in the daemon
+namespace: the alias points at the source as declared, and existence is
+resolved by the host Podman that performs the mount, so a host source absent
+from the daemon container's own filesystem view is still accepted.
 Runner-owned relabelled sources containing both `,` and `:` are rejected
 because neither Podman's comma-delimited `--mount` form nor its colon-delimited
 `--volume` fallback can encode that path unambiguously.
@@ -254,9 +258,11 @@ From inside the environment, an agent should see:
 Additional bind mounts are declared in agent configuration as `source`,
 `target`, and `read_only`. agentd validates absolute container targets plus a
 per-agent disjointness invariant: target paths must be unique and no target
-may be a path-component prefix of another. It then stages canonical host
-sources through runner-managed symlinks before calling Podman so additional
-mounts stay separate from runner-owned relabel handling. Subscription auth is
+may be a path-component prefix of another. It then stages operator-declared
+host sources through runner-managed symlinks before calling Podman so additional
+mounts stay separate from runner-owned relabel handling; the host Podman
+resolves each aliased source at mount time, so a source that exists on the host
+but not in the daemon container's own namespace is accepted. Subscription auth is
 the first read-only consumer of this mechanism; persistent audit storage in
 `#76` builds on the same path with read-write mounts. Additional mounts are not
 relabelled; on SELinux-enabled hosts, operators must pre-label those host paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Operator-declared additional bind-mount sources are no longer canonicalized
+  in the daemon's own filesystem namespace. On a containerized-daemon
+  deployment that namespace holds only the daemon's own mounts, so a host
+  source declared in `[[agents.mounts]]` but absent from the daemon container
+  was rejected with `mount source path does not exist` even though the host
+  Podman that performs the bind mount resolves it. Additional-mount sources are
+  now staged as aliases pointing at the source as declared, with existence
+  deferred to the host boundary that owns the mount; daemon-internal mounts
+  (methodology, audit, transcript, invocation-input) still canonicalize
+  unchanged (#158).
 - README deployment examples reference the released `v0.1.2` tag (they
   were pinned to `v0.1.2-rc.1`).
 

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -431,8 +431,14 @@ fn create_prepared_bind_mount(
     read_only: bool,
     relabel_shared: bool,
 ) -> Result<PreparedBindMount, RunnerError> {
-    let canonical_source = canonical_mount_source(source)?;
-    create_path_symlink(&canonical_source, &staged_source)?;
+    // Operator-declared additional-mount sources are resolved by the host
+    // Podman that performs the bind mount, not by the daemon's own filesystem
+    // namespace. Canonicalizing here would stat the source against the daemon
+    // container's mounts and reject host paths the host Podman resolves fine on
+    // a containerized-daemon deployment, so the staged alias points at the
+    // source as declared — validated absolute upstream — and existence is
+    // deferred to the host boundary that owns the mount.
+    create_path_symlink(source, &staged_source)?;
     Ok(PreparedBindMount {
         source: staged_source,
         target,
@@ -1018,28 +1024,37 @@ mod tests {
     }
 
     #[test]
-    fn prepare_session_resources_rejects_missing_additional_mount_sources() {
+    fn prepare_session_resources_accepts_additional_mount_sources_absent_from_daemon_namespace() {
+        // On a containerized-daemon deployment the operator-declared mount
+        // source lives on the host but not in the daemon container's own
+        // filesystem namespace. A path absent from this process's namespace
+        // stands in for that case: the daemon must accept it and defer
+        // existence to the host Podman that performs the bind mount, staging
+        // the source as a symlink alias resolved on the host at mount time.
         let _guard = fake_podman_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let fixture = FakePodmanFixture::new();
         let methodology_dir = fixture.create_methodology_dir("runner-methodology");
-        let missing_mount_source = std::env::temp_dir().join(format!(
-            "agentd-runner-missing-mount-{}-{}",
+        let host_only_mount_source = std::env::temp_dir().join(format!(
+            "agentd-runner-host-only-mount-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("system time should be after the unix epoch")
                 .as_nanos()
         ));
-        let session_id = format!("session-missing-mount-{}", std::process::id());
+        // Deliberately not created: absent from the daemon's own namespace.
+        let session_id = format!("session-host-only-mount-{}", std::process::id());
+        let audit_record = test_audit_record(&session_id);
+        let audit_record_dir = audit_record.record_dir.clone();
 
-        let result = prepare_session_resources(
+        let resources = prepare_session_resources(
             "agentd-agent-session",
             &crate::SessionSpec {
                 methodology_dir,
                 mounts: vec![BindMount {
-                    source: missing_mount_source.clone(),
+                    source: host_only_mount_source.clone(),
                     target: PathBuf::from("/mnt/readonly"),
                     read_only: true,
                 }],
@@ -1053,19 +1068,26 @@ mod tests {
                 timeout: None,
             },
             &session_id,
-            test_audit_record(&session_id),
+            audit_record,
             None,
+        )
+        .expect("additional mount sources resolvable only on the host must be accepted");
+
+        assert_eq!(resources.additional_mounts.len(), 1);
+        let mount = &resources.additional_mounts[0];
+        assert_eq!(mount.target, PathBuf::from("/mnt/readonly"));
+        assert!(mount.read_only);
+        assert!(!mount.relabel_shared);
+        let alias_target = fs::read_link(&mount.source)
+            .expect("staged additional mount source should be a symlink alias");
+        assert_eq!(
+            alias_target, host_only_mount_source,
+            "the alias must point at the operator-declared source; the host Podman resolves it"
         );
 
-        match result
-            .expect_err("missing mount sources should be rejected")
-            .allocation_error
-        {
-            RunnerError::MissingMountSource { path } => {
-                assert_eq!(path, missing_mount_source);
-            }
-            other => panic!("expected MissingMountSource, got {other:?}"),
-        }
+        fs::remove_dir_all(&resources.methodology_staging_dir)
+            .expect("temporary staging dir should be removed");
+        fs::remove_dir_all(&audit_record_dir).expect("temporary audit record should be removed");
     }
 
     #[test]


### PR DESCRIPTION
Closes #158.

Operator-declared additional bind-mount sources were canonicalized in the daemon's own filesystem namespace (`canonical_mount_source` → `source.canonicalize()`) before being staged as symlink aliases. On a containerized-daemon deployment that namespace holds only the daemon's own mounts, so a host source declared in `[[agents.mounts]]` but absent from the daemon container was rejected with `MissingMountSource` — even though the host Podman that performs the bind mount resolves it fine.

**Fix:** `create_prepared_bind_mount` (the additional-mount path) now stages the alias pointing at the source **as declared** (validated absolute upstream), dropping the daemon-namespace `canonicalize()`. The alias is resolved by the host Podman at mount time, so existence belongs to the host boundary that owns the mount. Daemon-internal mounts (methodology, audit, transcript, invocation-input) go through `create_direct_prepared_bind_mount` and still canonicalize unchanged.

**Acceptance (issue AC1–AC4):**
- Rewrote `prepare_session_resources_..._absent_from_daemon_namespace` (formerly `..._rejects_missing_additional_mount_sources`): asserts a source absent from the process namespace — the same `canonicalize()` `NotFound` path a containerized daemon hits on a host-only source — is **accepted**, and the staged alias is a symlink whose target is the declared source. Fails without the fix, passes with it.
- `ARCHITECTURE.md` updated: additional-mount sources are staged aliases resolved by the host boundary; no longer states the daemon canonicalizes additional-mount paths.
- `CHANGELOG.md` Fixed entry added.

**Verification:** `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace` all clean. `agentd-runner` suite green except pre-existing environment-gated failures (permission-based cleanup-failure injection that a root test bypasses; XDG-runtime-dir probes) — proven byte-identical on pristine `dd565a72`. The Podman integration mount tests are deployment-gated and stage host-present sources, so the non-gated unit proxy above is the defect's fail-without/pass-with test.

Scope is the narrow canonicalization fix; the host-native-daemon deployment question (issue's *Pattern*) is out of scope.
