### PR TITLE
feat(cli): stream execution transcript progress

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,9 +165,12 @@ default-repo resolution happen daemon-side after the socket request is
 received, so client and daemon responsibility boundaries stay clean.
 While a manual `agentd wish` or `agentd run` request is in flight, the daemon
 may send progress frames over that same client connection before the terminal
-session outcome. The CLI renders those frames according to the operator's
-selected progress level, so the launching terminal can observe the session
-without knowing container names, daemon log layout, or audit-record paths.
+session outcome. The runner tails the active transcript event stream it already
+owns under `agentd/transcript/events.jsonl`, and the daemon forwards those
+events to the launching client while the session executes. The CLI renders
+those frames according to the operator's selected progress level, so the
+launching terminal can observe the session without knowing container names,
+daemon log layout, or audit-record paths.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,6 +163,11 @@ and operators must either fix the XDG runtime environment or provide explicit
 paths. There is no implicit `/tmp` or `/run` fallback. Agent lookup and
 default-repo resolution happen daemon-side after the socket request is
 received, so client and daemon responsibility boundaries stay clean.
+While a manual `agentd wish` or `agentd run` request is in flight, the daemon
+may send progress frames over that same client connection before the terminal
+session outcome. The CLI renders those frames according to the operator's
+selected progress level, so the launching terminal can observe the session
+without knowing container names, daemon log layout, or audit-record paths.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agentd wish` starts an intent-seeded session through an evocative
   operator prompt, collecting the statement and optional target before reusing
   the existing canonical intent intake.
+- `agentd wish` and `agentd run` now stream live session progress in the
+  invoking terminal, with `--progress summary` as the default and
+  `--progress full` for all fields currently carried by progress frames.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the existing canonical intent intake.
 - `agentd wish` and `agentd run` now stream live session progress in the
   invoking terminal, with `--progress summary` as the default and
-  `--progress full` for all fields currently carried by progress frames.
+  `--progress full` for raw transcript event detail while the session executes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ agentd run site-builder --work-unit issue-42 --artifact-type work-unit --artifac
 The file stem becomes the artifact id, so the file stem must match
 `--work-unit`.
 
+`agentd wish` and `agentd run` stream live session progress to the invoking
+terminal while the daemon runs the session. The default `--progress summary`
+prints concise lifecycle output before the terminal `session <status>` line;
+`--progress full` includes every field currently carried by the progress
+stream.
+
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:
 

--- a/README.md
+++ b/README.md
@@ -314,9 +314,8 @@ The file stem becomes the artifact id, so the file stem must match
 
 `agentd wish` and `agentd run` stream live session progress to the invoking
 terminal while the daemon runs the session. The default `--progress summary`
-prints concise lifecycle output before the terminal `session <status>` line;
-`--progress full` includes every field currently carried by the progress
-stream.
+prints concise transcript event names before the terminal `session <status>`
+line; `--progress full` includes the session id and raw transcript event line.
 
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -337,10 +337,10 @@ fn observe_transcript_events(
         }
     };
 
-    let mut line = String::new();
+    let mut pending_line = String::new();
     loop {
-        line.clear();
-        match reader.read_line(&mut line) {
+        let mut chunk = String::new();
+        match reader.read_line(&mut chunk) {
             Ok(0) => {
                 if stop.load(Ordering::Acquire) {
                     return;
@@ -348,8 +348,14 @@ fn observe_transcript_events(
                 thread::sleep(TRANSCRIPT_POLL_INTERVAL);
             }
             Ok(_) => {
-                let line = line.trim_end_matches(['\r', '\n']).to_string();
-                if !line.trim().is_empty() {
+                let line_complete = chunk.ends_with('\n');
+                pending_line.push_str(&chunk);
+                if line_complete {
+                    let line = pending_line.trim_end_matches(['\r', '\n']).to_string();
+                    pending_line.clear();
+                    if line.trim().is_empty() {
+                        continue;
+                    }
                     progress.observe(SessionProgressEvent::TranscriptEvent {
                         session_id: session_id.to_string(),
                         line,
@@ -503,9 +509,11 @@ mod tests {
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
 
     #[test]
-    fn transcript_observer_reports_events_written_while_session_is_running() {
+    fn transcript_observer_waits_for_newline_before_reporting_live_event() {
         let transcript_dir = unique_temp_dir("agentd-live-transcript-observer");
         fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
+        let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+        fs::write(&events_path, "").expect("transcript events should be created");
         let stop = AtomicBool::new(false);
         let (tx, rx) = mpsc::channel();
         thread::scope(|scope| {
@@ -523,18 +531,30 @@ mod tests {
                 );
             });
 
-            let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
-            fs::write(
-                &events_path,
-                r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
-            )
-            .expect("transcript event should be written");
-            fs::OpenOptions::new()
+            let mut events = fs::OpenOptions::new()
                 .append(true)
                 .open(&events_path)
-                .expect("transcript events should reopen")
+                .expect("transcript events should reopen");
+            events
+                .write_all(
+                    br#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
+                )
+                .expect("partial transcript event should be written");
+            events
+                .flush()
+                .expect("partial transcript event should flush");
+
+            assert!(
+                rx.recv_timeout(Duration::from_millis(250)).is_err(),
+                "observer must not report a transcript event before its newline is written"
+            );
+
+            events
                 .write_all(b"\n")
                 .expect("transcript event newline should be written");
+            events
+                .flush()
+                .expect("complete transcript event should flush");
 
             assert_eq!(
                 rx.recv_timeout(Duration::from_secs(2))

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -65,6 +65,7 @@ use validation::{validate_invocation, validate_spec};
 
 const TRANSCRIPT_EVENTS_FILE: &str = "events.jsonl";
 const TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const MAX_LIVE_TRANSCRIPT_LINE_BYTES: usize = 32 * 1024;
 
 /// Executes a single session from validation through teardown.
 ///
@@ -337,30 +338,65 @@ fn observe_transcript_events(
         }
     };
 
-    let mut pending_line = String::new();
+    let mut pending_line = Vec::new();
+    let mut dropping_oversized_line = false;
     loop {
-        let mut chunk = String::new();
-        match reader.read_line(&mut chunk) {
-            Ok(0) => {
+        let consumed = match reader.fill_buf() {
+            Ok([]) => {
                 if stop.load(Ordering::Acquire) {
                     return;
                 }
                 thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+                continue;
             }
-            Ok(_) => {
-                let line_complete = chunk.ends_with('\n');
-                pending_line.push_str(&chunk);
-                if line_complete {
-                    let line = pending_line.trim_end_matches(['\r', '\n']).to_string();
-                    pending_line.clear();
-                    if line.trim().is_empty() {
+            Ok(buffer) => {
+                let mut consumed = 0;
+                while consumed < buffer.len() {
+                    let remaining = &buffer[consumed..];
+                    let segment_len = remaining
+                        .iter()
+                        .position(|byte| *byte == b'\n')
+                        .map_or(remaining.len(), |newline| newline + 1);
+                    let segment = &remaining[..segment_len];
+                    let line_complete = segment.ends_with(b"\n");
+
+                    if dropping_oversized_line {
+                        if line_complete {
+                            dropping_oversized_line = false;
+                        }
+                        consumed += segment_len;
                         continue;
                     }
-                    progress.observe(SessionProgressEvent::TranscriptEvent {
-                        session_id: session_id.to_string(),
-                        line,
-                    });
+
+                    if pending_line.len().saturating_add(segment.len())
+                        > MAX_LIVE_TRANSCRIPT_LINE_BYTES
+                    {
+                        pending_line.clear();
+                        dropping_oversized_line = !line_complete;
+                        tracing::debug!(
+                            event = "runner.transcript_progress_oversized_record_dropped",
+                            session_id = session_id,
+                            max_bytes = MAX_LIVE_TRANSCRIPT_LINE_BYTES,
+                            "dropped oversized live transcript progress record"
+                        );
+                        consumed += segment_len;
+                        continue;
+                    }
+
+                    pending_line.extend_from_slice(segment);
+                    consumed += segment_len;
+
+                    if line_complete {
+                        if let Some(line) = live_transcript_line_from_bytes(&pending_line) {
+                            progress.observe(SessionProgressEvent::TranscriptEvent {
+                                session_id: session_id.to_string(),
+                                line,
+                            });
+                        }
+                        pending_line.clear();
+                    }
                 }
+                consumed
             }
             Err(error) => {
                 tracing::warn!(
@@ -372,8 +408,26 @@ fn observe_transcript_events(
                 );
                 return;
             }
-        }
+        };
+
+        reader.consume(consumed);
     }
+}
+
+fn live_transcript_line_from_bytes(bytes: &[u8]) -> Option<String> {
+    let line = String::from_utf8_lossy(trim_line_end_bytes(bytes)).into_owned();
+    if line.trim().is_empty() {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn trim_line_end_bytes(mut bytes: &[u8]) -> &[u8] {
+    while matches!(bytes.last(), Some(b'\r' | b'\n')) {
+        bytes = &bytes[..bytes.len() - 1];
+    }
+    bytes
 }
 
 fn open_live_transcript_events(path: &Path) -> Result<File, io::Error> {
@@ -563,6 +617,73 @@ mod tests {
                     session_id: "session-123".to_string(),
                     line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#.to_string(),
                 }
+            );
+
+            stop.store(true, Ordering::Release);
+            handle.join().expect("observer should not panic");
+        });
+        fs::remove_dir_all(transcript_dir).expect("transcript dir should be removed");
+    }
+
+    #[test]
+    fn transcript_observer_drops_oversized_records_whole_and_resumes_after_newline() {
+        let transcript_dir = unique_temp_dir("agentd-live-transcript-observer-oversized");
+        fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
+        let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+        fs::write(&events_path, "").expect("transcript events should be created");
+        let stop = AtomicBool::new(false);
+        let (tx, rx) = mpsc::channel();
+        thread::scope(|scope| {
+            let observer = |event| {
+                tx.send(event).expect("progress event should send");
+            };
+            let observer_transcript_dir = &transcript_dir;
+            let observer_stop = &stop;
+            let handle = scope.spawn(move || {
+                observe_transcript_events(
+                    observer_transcript_dir,
+                    "session-123",
+                    &observer,
+                    observer_stop,
+                );
+            });
+
+            let mut events = fs::OpenOptions::new()
+                .append(true)
+                .open(&events_path)
+                .expect("transcript events should reopen");
+            events
+                .write_all(&vec![b'x'; MAX_LIVE_TRANSCRIPT_LINE_BYTES + 1])
+                .expect("oversized unterminated transcript event should be written");
+            events
+                .flush()
+                .expect("oversized transcript event should flush");
+
+            assert!(
+                rx.recv_timeout(Duration::from_millis(250)).is_err(),
+                "observer must not report an oversized unterminated transcript record"
+            );
+
+            events
+                .write_all(
+                    br#"
+{"schema_version":1,"source":"runa","kind":"agent_input","content":"after oversized"}
+"#,
+                )
+                .expect("oversized terminator and valid event should be written");
+            events.flush().expect("valid transcript event should flush");
+
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(2))
+                    .expect("observer should report the valid event after oversized drop"),
+                SessionProgressEvent::TranscriptEvent {
+                    session_id: "session-123".to_string(),
+                    line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"after oversized"}"#.to_string(),
+                }
+            );
+            assert!(
+                rx.recv_timeout(Duration::from_millis(250)).is_err(),
+                "oversized record should be dropped whole, not emitted as a fragment"
             );
 
             stop.store(true, Ordering::Release);

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -29,8 +29,9 @@ pub(crate) mod test_support;
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
     AgentNameValidationError, BindMount, EnvironmentNameValidationError, InvocationInput,
-    MountOverlapError, MountTargetValidationError, ResolvedEnvironmentVariable, RunnerError,
-    SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    MountOverlapError, MountTargetValidationError, NoopSessionProgressObserver,
+    ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
+    SessionProgressEvent, SessionProgressObserver, SessionSpec, StartupReconciliationReport,
 };
 pub use validation::{
     validate_agent_name, validate_environment_name, validate_mount_overlap, validate_mount_target,
@@ -49,10 +50,21 @@ use lifecycle::{
 };
 use naming::format_container_name;
 use resources::{
-    ResourceAllocationFailure, SessionResources, cleanup_methodology_staging_dir,
+    ResourceAllocationFailure, SecretBinding, SessionResources, cleanup_methodology_staging_dir,
     cleanup_podman_secrets, prepare_session_resources, unique_suffix,
 };
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
 use validation::{validate_invocation, validate_spec};
+
+const TRANSCRIPT_EVENTS_FILE: &str = "events.jsonl";
+const TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Executes a single session from validation through teardown.
 ///
@@ -69,6 +81,16 @@ use validation::{validate_invocation, validate_spec};
 pub fn run_session(
     spec: SessionSpec,
     invocation: SessionInvocation,
+) -> Result<SessionOutcome, RunnerError> {
+    run_session_with_progress(spec, invocation, &NoopSessionProgressObserver)
+}
+
+/// Executes a single session and reports best-effort transcript progress while
+/// the session process is running.
+pub fn run_session_with_progress(
+    spec: SessionSpec,
+    invocation: SessionInvocation,
+    progress: &dyn SessionProgressObserver,
 ) -> Result<SessionOutcome, RunnerError> {
     validate_spec(&spec)?;
     validate_invocation(&invocation)?;
@@ -188,17 +210,13 @@ pub fn run_session(
     }
 
     let secret_bindings = resources.all_secret_bindings();
-    let start_result = match invocation.timeout {
-        Some(timeout) => run_container_with_timeout(
-            &resources.container_name,
-            &session_id,
-            &secret_bindings,
-            timeout,
-        ),
-        None => {
-            run_container_to_completion(&resources.container_name, &session_id, &secret_bindings)
-        }
-    };
+    let start_result = run_container_with_transcript_progress(
+        &resources,
+        &session_id,
+        &secret_bindings,
+        invocation.timeout,
+        progress,
+    );
 
     match &start_result {
         Ok(outcome) => log_session_outcome(&session_id, &resources.container_name, outcome),
@@ -247,6 +265,142 @@ pub fn run_session(
     }
 }
 
+fn run_container_with_transcript_progress(
+    resources: &SessionResources,
+    session_id: &str,
+    secret_bindings: &[SecretBinding],
+    timeout: Option<Duration>,
+    progress: &dyn SessionProgressObserver,
+) -> Result<SessionOutcome, RunnerError> {
+    let stop = Arc::new(AtomicBool::new(false));
+    thread::scope(|scope| {
+        let observer_stop = Arc::clone(&stop);
+        let observer = scope.spawn(move || {
+            observe_transcript_events(
+                &resources.audit_record.transcript_dir,
+                session_id,
+                progress,
+                &observer_stop,
+            );
+        });
+
+        let result = match timeout {
+            Some(timeout) => run_container_with_timeout(
+                &resources.container_name,
+                session_id,
+                secret_bindings,
+                timeout,
+            ),
+            None => {
+                run_container_to_completion(&resources.container_name, session_id, secret_bindings)
+            }
+        };
+        stop.store(true, Ordering::Release);
+        if observer.join().is_err() {
+            tracing::warn!(
+                event = "runner.transcript_progress_observer_panicked",
+                session_id = session_id,
+                container_name = %resources.container_name,
+                "transcript progress observer panicked"
+            );
+        }
+        result
+    })
+}
+
+fn observe_transcript_events(
+    transcript_dir: &Path,
+    session_id: &str,
+    progress: &dyn SessionProgressObserver,
+    stop: &AtomicBool,
+) {
+    let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+    let mut reader = loop {
+        match open_live_transcript_events(&events_path) {
+            Ok(file) => break BufReader::new(file),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if stop.load(Ordering::Acquire) {
+                    return;
+                }
+                thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "runner.transcript_progress_unavailable",
+                    session_id = session_id,
+                    path = %events_path.display(),
+                    error = %error,
+                    "live transcript progress unavailable"
+                );
+                return;
+            }
+        }
+    };
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                if stop.load(Ordering::Acquire) {
+                    return;
+                }
+                thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+            }
+            Ok(_) => {
+                let line = line.trim_end_matches(['\r', '\n']).to_string();
+                if !line.trim().is_empty() {
+                    progress.observe(SessionProgressEvent::TranscriptEvent {
+                        session_id: session_id.to_string(),
+                        line,
+                    });
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "runner.transcript_progress_read_failed",
+                    session_id = session_id,
+                    path = %events_path.display(),
+                    error = %error,
+                    "failed to read live transcript progress"
+                );
+                return;
+            }
+        }
+    }
+}
+
+fn open_live_transcript_events(path: &Path) -> Result<File, io::Error> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_file() {
+        return Err(io::Error::other(format!(
+            "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
+        )));
+    }
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| match error.raw_os_error() {
+            Some(libc::ELOOP) => io::Error::other(format!(
+                "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
+            )),
+            _ => error,
+        })?;
+    let open_metadata = file.metadata()?;
+    if !open_metadata.is_file()
+        || open_metadata.dev() != metadata.dev()
+        || open_metadata.ino() != metadata.ino()
+    {
+        return Err(io::Error::other(format!(
+            "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
+        )));
+    }
+
+    Ok(file)
+}
+
 fn cleanup_session_resources(resources: &SessionResources) -> Result<(), RunnerError> {
     let container_result = container::cleanup_container(&resources.container_name);
     let secret_bindings = resources.all_secret_bindings();
@@ -292,8 +446,11 @@ mod tests {
     };
     use serde_json::Value;
     use std::fs;
+    use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
     use std::thread;
     use std::time::{Duration, Instant};
 
@@ -344,6 +501,55 @@ mod tests {
     }
 
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
+
+    #[test]
+    fn transcript_observer_reports_events_written_while_session_is_running() {
+        let transcript_dir = unique_temp_dir("agentd-live-transcript-observer");
+        fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
+        let stop = AtomicBool::new(false);
+        let (tx, rx) = mpsc::channel();
+        thread::scope(|scope| {
+            let observer = |event| {
+                tx.send(event).expect("progress event should send");
+            };
+            let observer_transcript_dir = &transcript_dir;
+            let observer_stop = &stop;
+            let handle = scope.spawn(move || {
+                observe_transcript_events(
+                    observer_transcript_dir,
+                    "session-123",
+                    &observer,
+                    observer_stop,
+                );
+            });
+
+            let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+            fs::write(
+                &events_path,
+                r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
+            )
+            .expect("transcript event should be written");
+            fs::OpenOptions::new()
+                .append(true)
+                .open(&events_path)
+                .expect("transcript events should reopen")
+                .write_all(b"\n")
+                .expect("transcript event newline should be written");
+
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(2))
+                    .expect("observer should report a live transcript event"),
+                SessionProgressEvent::TranscriptEvent {
+                    session_id: "session-123".to_string(),
+                    line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#.to_string(),
+                }
+            );
+
+            stop.store(true, Ordering::Release);
+            handle.join().expect("observer should not panic");
+        });
+        fs::remove_dir_all(transcript_dir).expect("transcript dir should be removed");
+    }
 
     fn reconcile_startup_resources_for_tests() -> Result<StartupReconciliationReport, RunnerError> {
         reconcile_startup_resources(TEST_DAEMON_INSTANCE_ID)

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -135,6 +135,35 @@ pub struct SessionInvocation {
     pub timeout: Option<Duration>,
 }
 
+/// Non-terminal progress observed while a session is executing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionProgressEvent {
+    /// One complete line from `agentd/transcript/events.jsonl`.
+    TranscriptEvent { session_id: String, line: String },
+}
+
+/// Receives best-effort execution progress while a session is running.
+pub trait SessionProgressObserver: Send + Sync {
+    fn observe(&self, event: SessionProgressEvent);
+}
+
+impl<F> SessionProgressObserver for F
+where
+    F: Fn(SessionProgressEvent) + Send + Sync,
+{
+    fn observe(&self, event: SessionProgressEvent) {
+        self(event);
+    }
+}
+
+/// Progress observer used by callers that only need the terminal outcome.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopSessionProgressObserver;
+
+impl SessionProgressObserver for NoopSessionProgressObserver {
+    fn observe(&self, _event: SessionProgressEvent) {}
+}
+
 /// Terminal outcome of a completed session.
 ///
 /// Labels and exit-code semantics implement the shared session-outcome

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -5,14 +5,15 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
 use agentd_runner::{
-    RunnerError, SessionOutcome, StartupReconciliationReport, reconcile_startup_resources,
+    RunnerError, SessionOutcome, SessionProgressEvent, StartupReconciliationReport,
+    reconcile_startup_resources,
 };
 
 use crate::audit_root::prepare_audit_root;
@@ -515,9 +516,31 @@ fn render_progress<W: Write>(
                 if input_present { "present" } else { "absent" }
             )?;
         }
+        (ProgressMessage::TranscriptEvent { line, .. }, LiveObservationLevel::Summary) => {
+            writeln!(
+                writer,
+                "session event: {}",
+                summarize_transcript_event(&line)
+            )?;
+        }
+        (ProgressMessage::TranscriptEvent { session_id, line }, LiveObservationLevel::Full) => {
+            writeln!(writer, "session event: session_id={session_id} {line}")?;
+        }
     }
     writer.flush()?;
     Ok(())
+}
+
+fn summarize_transcript_event(line: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|event| {
+            event
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unparsed_event".to_string())
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -565,12 +588,36 @@ fn handle_connection_inner(
             work_unit,
             input,
         } => {
-            let progress = ResponseMessage::Progress {
+            let stream = Mutex::new(&mut stream);
+            let dispatch_progress = ResponseMessage::Progress {
                 progress: ProgressMessage::DispatchStarted {
                     agent: agent.clone(),
                     work_unit: work_unit.clone(),
                     input_present: input.is_some(),
                 },
+            };
+            let write_progress = |event: SessionProgressEvent| {
+                let SessionProgressEvent::TranscriptEvent { session_id, line } = event;
+                let progress = ResponseMessage::Progress {
+                    progress: ProgressMessage::TranscriptEvent { session_id, line },
+                };
+                match stream.lock() {
+                    Ok(mut stream) => {
+                        if let Err(error) = write_response(&mut stream, &progress) {
+                            tracing::warn!(
+                                event = "agentd.manual_run_progress_failed",
+                                error = %error,
+                                "failed to write manual run progress"
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            event = "agentd.manual_run_progress_lock_poisoned",
+                            "failed to lock manual run progress stream"
+                        );
+                    }
+                }
             };
             match dispatch_run_after_preflight(
                 config,
@@ -581,15 +628,24 @@ fn handle_connection_inner(
                     input,
                 },
                 executor,
-                || {
-                    if let Err(error) = write_response(&mut stream, &progress) {
+                || match stream.lock() {
+                    Ok(mut stream) => {
+                        if let Err(error) = write_response(&mut stream, &dispatch_progress) {
+                            tracing::warn!(
+                                event = "agentd.manual_run_progress_failed",
+                                error = %error,
+                                "failed to write manual run progress"
+                            );
+                        }
+                    }
+                    Err(_) => {
                         tracing::warn!(
-                            event = "agentd.manual_run_progress_failed",
-                            error = %error,
-                            "failed to write manual run progress"
+                            event = "agentd.manual_run_progress_lock_poisoned",
+                            "failed to lock manual run progress stream"
                         );
                     }
                 },
+                &write_progress,
             ) {
                 Ok(outcome) => {
                     log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
@@ -845,7 +901,8 @@ mod tests {
     use crate::config::Config;
     use crate::dispatch::SessionExecutor;
     use agentd_runner::{
-        RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+        RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
+        StartupReconciliationReport,
     };
     use std::fs;
     use std::io;
@@ -888,6 +945,7 @@ mod tests {
             &self,
             _spec: SessionSpec,
             _invocation: SessionInvocation,
+            _progress: &dyn SessionProgressObserver,
         ) -> Result<SessionOutcome, RunnerError> {
             Ok(SessionOutcome::Success { exit_code: 0 })
         }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -1,12 +1,14 @@
+use std::collections::VecDeque;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, TryLockError};
+use std::sync::{Arc, Condvar, Mutex, TryLockError};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -28,7 +30,8 @@ const RUNTIME_DIR_MODE: u32 = 0o700;
 const SOCKET_MODE: u32 = 0o600;
 const SHUTDOWN_MESSAGE: &str = "agentd is shutting down";
 const MAX_PROGRESS_FRAME_BYTES: usize = 128 * 1024;
-const TERMINAL_RESPONSE_RESERVE_BYTES: usize = 16 * 1024;
+const PROGRESS_QUEUE_CAPACITY: usize = 64;
+const PROGRESS_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Startup or runtime failures for the foreground daemon loop.
 #[derive(Debug)]
@@ -625,100 +628,74 @@ fn handle_connection_inner(
             work_unit,
             input,
         } => {
-            let stream = Mutex::new(&mut stream);
-            let dispatch_progress = ResponseMessage::Progress {
-                progress: ProgressMessage::DispatchStarted {
-                    agent: agent.clone(),
-                    work_unit: work_unit.clone(),
-                    input_present: input.is_some(),
-                },
+            return handle_run_connection(
+                stream, config, executor, agent, repo_url, work_unit, input,
+            );
+        }
+    };
+
+    write_response(&mut stream, &response)
+}
+
+fn handle_run_connection(
+    stream: UnixStream,
+    config: &Config,
+    executor: &impl SessionExecutor,
+    agent: String,
+    repo_url: Option<String>,
+    work_unit: Option<String>,
+    input: Option<agentd_runner::InvocationInput>,
+) -> Result<(), io::Error> {
+    let writer = ProgressWriter::spawn(stream)?;
+    let response = {
+        let dispatch_progress = ResponseMessage::Progress {
+            progress: ProgressMessage::DispatchStarted {
+                agent: agent.clone(),
+                work_unit: work_unit.clone(),
+                input_present: input.is_some(),
+            },
+        };
+        let write_progress = |event: SessionProgressEvent| {
+            let SessionProgressEvent::TranscriptEvent { session_id, line } = event;
+            let progress = ResponseMessage::Progress {
+                progress: ProgressMessage::TranscriptEvent { session_id, line },
             };
-            let write_progress = |event: SessionProgressEvent| {
-                let SessionProgressEvent::TranscriptEvent { session_id, line } = event;
-                let progress = ResponseMessage::Progress {
-                    progress: ProgressMessage::TranscriptEvent { session_id, line },
-                };
-                match stream.try_lock() {
-                    Ok(mut stream) => {
-                        if let Err(error) = try_write_progress_response(&mut stream, &progress) {
-                            tracing::warn!(
-                                event = "agentd.manual_run_progress_failed",
-                                error = %error,
-                                "failed to write manual run progress"
-                            );
-                        }
-                    }
-                    Err(TryLockError::WouldBlock) => {
-                        tracing::debug!(
-                            event = "agentd.manual_run_progress_dropped",
-                            "dropped manual run progress while another response was in flight"
-                        );
-                    }
-                    Err(TryLockError::Poisoned(_)) => {
-                        tracing::warn!(
-                            event = "agentd.manual_run_progress_lock_poisoned",
-                            "failed to lock manual run progress stream"
-                        );
-                    }
+            writer.enqueue_progress(progress);
+        };
+        match dispatch_run_after_preflight(
+            config,
+            &RunRequest {
+                agent: agent.clone(),
+                repo_url,
+                work_unit: work_unit.clone(),
+                input,
+            },
+            executor,
+            || {
+                writer.enqueue_dispatch_progress(dispatch_progress);
+            },
+            &write_progress,
+        ) {
+            Ok(outcome) => {
+                log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
+                ResponseMessage::SessionOutcome {
+                    outcome: outcome.into(),
                 }
-            };
-            match dispatch_run_after_preflight(
-                config,
-                &RunRequest {
-                    agent: agent.clone(),
-                    repo_url,
-                    work_unit: work_unit.clone(),
-                    input,
-                },
-                executor,
-                || match stream.try_lock() {
-                    Ok(mut stream) => {
-                        if let Err(error) =
-                            try_write_progress_response(&mut stream, &dispatch_progress)
-                        {
-                            tracing::warn!(
-                                event = "agentd.manual_run_progress_failed",
-                                error = %error,
-                                "failed to write manual run progress"
-                            );
-                        }
-                    }
-                    Err(TryLockError::WouldBlock) => {
-                        tracing::debug!(
-                            event = "agentd.manual_run_progress_dropped",
-                            "dropped manual run progress while another response was in flight"
-                        );
-                    }
-                    Err(TryLockError::Poisoned(_)) => {
-                        tracing::warn!(
-                            event = "agentd.manual_run_progress_lock_poisoned",
-                            "failed to lock manual run progress stream"
-                        );
-                    }
-                },
-                &write_progress,
-            ) {
-                Ok(outcome) => {
-                    log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
-                    ResponseMessage::SessionOutcome {
-                        outcome: outcome.into(),
-                    }
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        event = "agentd.manual_run_rejected",
-                        error = %error,
-                        "run request rejected"
-                    );
-                    ResponseMessage::Error {
-                        message: dispatch_error_message(&error),
-                    }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_rejected",
+                    error = %error,
+                    "run request rejected"
+                );
+                ResponseMessage::Error {
+                    message: dispatch_error_message(&error),
                 }
             }
         }
     };
 
-    write_response(&mut stream, &response)
+    writer.finish(response)
 }
 
 fn write_response(stream: &mut UnixStream, response: &ResponseMessage) -> Result<(), io::Error> {
@@ -741,119 +718,267 @@ fn write_response_part(stream: &mut UnixStream, bytes: &[u8]) -> Result<(), io::
     }
 }
 
-fn try_write_progress_response(
-    stream: &mut UnixStream,
-    response: &ResponseMessage,
-) -> Result<(), io::Error> {
+fn serialize_response_frame(response: &ResponseMessage) -> Result<Vec<u8>, io::Error> {
     let mut payload = serde_json::to_vec(response)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     payload.push(b'\n');
-    if payload.len() > MAX_PROGRESS_FRAME_BYTES {
-        tracing::debug!(
-            event = "agentd.manual_run_progress_dropped",
-            frame_bytes = payload.len(),
-            max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
-            "dropped oversized manual run progress frame"
-        );
-        return Ok(());
+    Ok(payload)
+}
+
+#[derive(Clone)]
+struct ProgressWriter {
+    shared: Arc<ProgressWriterShared>,
+}
+
+struct ProgressWriterShared {
+    state: Mutex<ProgressWriterState>,
+    available: Condvar,
+}
+
+struct ProgressWriterState {
+    progress: VecDeque<QueuedProgressFrame>,
+    terminal: Option<Vec<u8>>,
+    closed: bool,
+}
+
+struct QueuedProgressFrame {
+    bytes: Vec<u8>,
+    deliver_before_terminal: bool,
+}
+
+enum ProgressWriterFrame {
+    Progress(Vec<u8>),
+    Terminal(Vec<u8>),
+}
+
+impl ProgressWriter {
+    fn spawn(stream: UnixStream) -> Result<Self, io::Error> {
+        stream.set_write_timeout(Some(PROGRESS_WRITE_TIMEOUT))?;
+        let shared = Arc::new(ProgressWriterShared {
+            state: Mutex::new(ProgressWriterState {
+                progress: VecDeque::new(),
+                terminal: None,
+                closed: false,
+            }),
+            available: Condvar::new(),
+        });
+        let writer_shared = Arc::clone(&shared);
+        thread::spawn(move || {
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                run_progress_writer(stream, writer_shared);
+            }));
+            if result.is_err() {
+                tracing::error!(
+                    event = "agentd.manual_run_progress_writer_panicked",
+                    "manual run progress writer panicked"
+                );
+            }
+        });
+
+        Ok(Self { shared })
     }
 
-    if !progress_frame_has_reserved_capacity(stream, payload.len())? {
-        tracing::debug!(
-            event = "agentd.manual_run_progress_dropped",
-            frame_bytes = payload.len(),
-            terminal_reserve_bytes = TERMINAL_RESPONSE_RESERVE_BYTES,
-            "dropped manual run progress frame because the client connection is backpressured"
-        );
-        return Ok(());
+    fn enqueue_progress(&self, response: ResponseMessage) {
+        self.enqueue_progress_frame(response, false);
     }
 
-    stream.set_nonblocking(true)?;
-    let write_result = write_progress_frame_nonblocking(stream, &payload);
-    let restore_result = stream.set_nonblocking(false);
-
-    match (write_result, restore_result) {
-        (Ok(()), Ok(())) => Ok(()),
-        (Err(error), Ok(())) if peer_disconnected_during_response(&error) => Ok(()),
-        (Err(error), Ok(())) if progress_response_would_block(&error) => Ok(()),
-        (Err(error), Ok(())) => Err(error),
-        (Ok(()), Err(error)) => Err(error),
-        (Err(write_error), Err(restore_error)) => {
-            tracing::warn!(
-                event = "agentd.manual_run_progress_blocking_restore_failed",
-                error = %restore_error,
-                "failed to restore blocking mode after manual run progress write"
+    fn enqueue_dispatch_progress(&self, response: ResponseMessage) {
+        let frame = match serialize_response_frame(&response) {
+            Ok(frame) => frame,
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_serialization_failed",
+                    error = %error,
+                    "failed to serialize manual run dispatch progress"
+                );
+                return;
+            }
+        };
+        if frame.len() > MAX_PROGRESS_FRAME_BYTES {
+            tracing::debug!(
+                event = "agentd.manual_run_progress_dropped",
+                frame_bytes = frame.len(),
+                max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+                "dropped oversized manual run dispatch progress frame"
             );
-            Err(write_error)
+            return;
+        }
+
+        let mut state = self
+            .shared
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.closed || state.terminal.is_some() {
+            tracing::debug!(
+                event = "agentd.manual_run_progress_dropped",
+                "dropped manual run dispatch progress after terminal response was queued"
+            );
+            return;
+        }
+
+        state.progress.push_back(QueuedProgressFrame {
+            bytes: frame,
+            deliver_before_terminal: true,
+        });
+        self.shared.available.notify_one();
+    }
+
+    fn enqueue_progress_frame(&self, response: ResponseMessage, deliver_before_terminal: bool) {
+        let frame = match serialize_response_frame(&response) {
+            Ok(frame) => frame,
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_serialization_failed",
+                    error = %error,
+                    "failed to serialize manual run progress"
+                );
+                return;
+            }
+        };
+
+        if frame.len() > MAX_PROGRESS_FRAME_BYTES {
+            tracing::debug!(
+                event = "agentd.manual_run_progress_dropped",
+                frame_bytes = frame.len(),
+                max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+                "dropped oversized manual run progress frame"
+            );
+            return;
+        }
+
+        match self.shared.state.try_lock() {
+            Ok(mut state) => {
+                if state.closed || state.terminal.is_some() {
+                    tracing::debug!(
+                        event = "agentd.manual_run_progress_dropped",
+                        "dropped manual run progress after terminal response was queued"
+                    );
+                    return;
+                }
+
+                if state.progress.len() >= PROGRESS_QUEUE_CAPACITY {
+                    tracing::debug!(
+                        event = "agentd.manual_run_progress_dropped",
+                        queue_capacity = PROGRESS_QUEUE_CAPACITY,
+                        "dropped manual run progress because the bounded queue is full"
+                    );
+                    return;
+                }
+
+                state.progress.push_back(QueuedProgressFrame {
+                    bytes: frame,
+                    deliver_before_terminal,
+                });
+                self.shared.available.notify_one();
+            }
+            Err(TryLockError::WouldBlock) => {
+                tracing::debug!(
+                    event = "agentd.manual_run_progress_dropped",
+                    "dropped manual run progress while the writer queue was busy"
+                );
+            }
+            Err(TryLockError::Poisoned(_)) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_queue_poisoned",
+                    "failed to lock manual run progress writer queue"
+                );
+            }
+        }
+    }
+
+    fn finish(&self, response: ResponseMessage) -> Result<(), io::Error> {
+        let terminal = serialize_response_frame(&response)?;
+        let mut state = self
+            .shared
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.progress.retain(|frame| frame.deliver_before_terminal);
+        state.terminal = Some(terminal);
+        self.shared.available.notify_one();
+        Ok(())
+    }
+}
+
+fn run_progress_writer(mut stream: UnixStream, shared: Arc<ProgressWriterShared>) {
+    while let Some(frame) = next_progress_writer_frame(&shared) {
+        let is_terminal = matches!(frame, ProgressWriterFrame::Terminal(_));
+        let bytes = match frame {
+            ProgressWriterFrame::Progress(bytes) | ProgressWriterFrame::Terminal(bytes) => bytes,
+        };
+
+        match stream.write_all(&bytes) {
+            Ok(()) if is_terminal => return,
+            Ok(()) => {}
+            Err(error) if peer_disconnected_during_response(&error) => return,
+            Err(error) if progress_writer_timed_out(&error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_writer_timed_out",
+                    error = %error,
+                    timeout_ms = PROGRESS_WRITE_TIMEOUT.as_millis(),
+                    "manual run progress writer timed out and closed the client connection"
+                );
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_writer_failed",
+                    error = %error,
+                    "manual run progress writer closed the client connection after a write failure"
+                );
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+                return;
+            }
         }
     }
 }
 
-fn write_progress_frame_nonblocking(
-    stream: &mut UnixStream,
-    bytes: &[u8],
-) -> Result<(), io::Error> {
-    match stream.write(bytes) {
-        Ok(written) if written == bytes.len() => Ok(()),
-        Ok(0) => Err(io::Error::new(
-            io::ErrorKind::WriteZero,
-            "failed to write progress response",
-        )),
-        Ok(written) => Err(io::Error::new(
-            io::ErrorKind::WouldBlock,
-            format!(
-                "partial progress frame write accepted {written} of {}",
-                bytes.len()
-            ),
-        )),
-        Err(error) if peer_disconnected_during_response(&error) => Ok(()),
-        Err(error) => Err(error),
+fn next_progress_writer_frame(shared: &ProgressWriterShared) -> Option<ProgressWriterFrame> {
+    let mut state = shared
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    loop {
+        if let Some(terminal) = state.terminal.take() {
+            if state
+                .progress
+                .front()
+                .is_some_and(|frame| frame.deliver_before_terminal)
+            {
+                let progress = state
+                    .progress
+                    .pop_front()
+                    .expect("front progress frame should exist");
+                state.terminal = Some(terminal);
+                return Some(ProgressWriterFrame::Progress(progress.bytes));
+            }
+            state.progress.clear();
+            state.closed = true;
+            return Some(ProgressWriterFrame::Terminal(terminal));
+        }
+
+        if let Some(progress) = state.progress.pop_front() {
+            return Some(ProgressWriterFrame::Progress(progress.bytes));
+        }
+
+        if state.closed {
+            return None;
+        }
+
+        state = shared
+            .available
+            .wait(state)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
     }
 }
 
-fn progress_frame_has_reserved_capacity(
-    stream: &UnixStream,
-    frame_bytes: usize,
-) -> Result<bool, io::Error> {
-    let send_buffer_bytes = socket_send_buffer_bytes(stream)?;
-    let queued_bytes = socket_queued_output_bytes(stream)?;
-    Ok(queued_bytes.saturating_add(frame_bytes)
-        <= send_buffer_bytes.saturating_sub(TERMINAL_RESPONSE_RESERVE_BYTES))
-}
-
-fn socket_send_buffer_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
-    let mut size = 0_i32;
-    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
-    let result = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_SNDBUF,
-            &mut size as *mut i32 as *mut libc::c_void,
-            &mut size_len,
-        )
-    };
-    if result == 0 {
-        usize::try_from(size)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "SO_SNDBUF was negative"))
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-fn socket_queued_output_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
-    let mut queued = 0_i32;
-    let result = unsafe { libc::ioctl(stream.as_raw_fd(), libc::TIOCOUTQ, &mut queued) };
-    if result == 0 {
-        usize::try_from(queued)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "TIOCOUTQ was negative"))
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-fn progress_response_would_block(error: &io::Error) -> bool {
-    matches!(error.kind(), io::ErrorKind::WouldBlock)
+fn progress_writer_timed_out(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+    )
 }
 
 fn peer_disconnected_during_response(error: &io::Error) -> bool {

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -17,9 +17,10 @@ use agentd_runner::{
 
 use crate::audit_root::prepare_audit_root;
 use crate::config::{Config, ConfigError};
-use crate::protocol::{RequestMessage, ResponseMessage};
+use crate::dispatch::dispatch_run_after_preflight;
+use crate::protocol::{ProgressMessage, RequestMessage, ResponseMessage};
 use crate::scheduler::{join_scheduler_thread, spawn_scheduler_thread};
-use crate::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
+use crate::{DispatchError, RunRequest, SessionExecutor};
 
 const ACCEPT_TIMEOUT: Duration = Duration::from_millis(100);
 const RUNTIME_DIR_MODE: u32 = 0o700;
@@ -81,6 +82,15 @@ pub enum ClientError {
     Io(io::Error),
     Protocol(serde_json::Error),
     Server { message: String },
+}
+
+/// Client-side rendering level for live session observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveObservationLevel {
+    /// Print concise lifecycle markers while waiting for the terminal outcome.
+    Summary,
+    /// Print lifecycle markers with every field carried by the progress frame.
+    Full,
 }
 
 impl fmt::Display for ClientError {
@@ -341,19 +351,41 @@ pub fn request_run(
     socket_path: impl AsRef<Path>,
     request: &RunRequest,
 ) -> Result<SessionOutcome, ClientError> {
+    request_run_inner::<io::Sink>(socket_path.as_ref(), request, None)
+}
+
+/// Trigger a run and render daemon progress messages while waiting.
+pub fn request_run_with_live_observation<W: Write>(
+    socket_path: impl AsRef<Path>,
+    request: &RunRequest,
+    level: LiveObservationLevel,
+    writer: &mut W,
+) -> Result<SessionOutcome, ClientError> {
+    request_run_inner(socket_path.as_ref(), request, Some((level, writer)))
+}
+
+fn request_run_inner<W: Write>(
+    socket_path: &Path,
+    request: &RunRequest,
+    observer: Option<(LiveObservationLevel, &mut W)>,
+) -> Result<SessionOutcome, ClientError> {
     match send_request(
-        socket_path.as_ref(),
+        socket_path,
         &RequestMessage::Run {
             agent: request.agent.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
             input: request.input.clone(),
         },
+        observer,
     )? {
         ResponseMessage::SessionOutcome { outcome } => Ok(outcome.into()),
         ResponseMessage::Error { message } => Err(ClientError::Server { message }),
         ResponseMessage::Pong => Err(ClientError::Server {
             message: "unexpected pong from daemon".to_string(),
+        }),
+        ResponseMessage::Progress { .. } => Err(ClientError::Server {
+            message: "daemon closed the connection before reporting a terminal outcome".to_string(),
         }),
     }
 }
@@ -373,14 +405,15 @@ pub(crate) fn request_run_without_waiting(
     )
 }
 
-fn send_request(
+fn send_request<W: Write>(
     socket_path: &Path,
     request: &RequestMessage,
+    observer: Option<(LiveObservationLevel, &mut W)>,
 ) -> Result<ResponseMessage, ClientError> {
     let mut stream = connect_to_daemon(socket_path)?;
     write_request(&mut stream, request)?;
 
-    read_response(stream)
+    read_terminal_response(stream, observer)
 }
 
 fn send_request_without_response(
@@ -416,17 +449,75 @@ fn write_request(stream: &mut UnixStream, request: &RequestMessage) -> Result<()
     Ok(())
 }
 
-fn read_response(stream: UnixStream) -> Result<ResponseMessage, ClientError> {
+fn read_terminal_response<W: Write>(
+    stream: UnixStream,
+    mut observer: Option<(LiveObservationLevel, &mut W)>,
+) -> Result<ResponseMessage, ClientError> {
     let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    let bytes_read = reader.read_line(&mut line)?;
-    if bytes_read == 0 {
-        return Err(ClientError::Server {
-            message: "daemon closed the connection without a response".to_string(),
-        });
-    }
+    let mut saw_message = false;
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line)?;
+        if bytes_read == 0 {
+            let message = if saw_message {
+                "daemon closed the connection before reporting a terminal outcome"
+            } else {
+                "daemon closed the connection without a response"
+            };
+            return Err(ClientError::Server {
+                message: message.to_string(),
+            });
+        }
+        saw_message = true;
 
-    Ok(serde_json::from_str(&line)?)
+        let response = serde_json::from_str(&line)?;
+        match response {
+            ResponseMessage::Progress { progress } => {
+                if let Some((level, writer)) = observer.as_mut() {
+                    render_progress(progress, *level, &mut **writer)?;
+                }
+            }
+            terminal => return Ok(terminal),
+        }
+    }
+}
+
+fn render_progress<W: Write>(
+    progress: ProgressMessage,
+    level: LiveObservationLevel,
+    writer: &mut W,
+) -> Result<(), ClientError> {
+    match (progress, level) {
+        (
+            ProgressMessage::DispatchStarted {
+                agent, work_unit, ..
+            },
+            LiveObservationLevel::Summary,
+        ) => {
+            if let Some(work_unit) = work_unit {
+                writeln!(writer, "session running: {agent} ({work_unit})")?;
+            } else {
+                writeln!(writer, "session running: {agent}")?;
+            }
+        }
+        (
+            ProgressMessage::DispatchStarted {
+                agent,
+                work_unit,
+                input_present,
+            },
+            LiveObservationLevel::Full,
+        ) => {
+            writeln!(
+                writer,
+                "session running: agent={agent} work_unit={} input={}",
+                work_unit.as_deref().unwrap_or("-"),
+                if input_present { "present" } else { "absent" }
+            )?;
+        }
+    }
+    writer.flush()?;
+    Ok(())
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -473,33 +564,51 @@ fn handle_connection_inner(
             repo_url,
             work_unit,
             input,
-        } => match dispatch_run(
-            config,
-            &RunRequest {
-                agent: agent.clone(),
-                repo_url,
-                work_unit: work_unit.clone(),
-                input,
-            },
-            executor,
-        ) {
-            Ok(outcome) => {
-                log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
-                ResponseMessage::SessionOutcome {
-                    outcome: outcome.into(),
+        } => {
+            let progress = ResponseMessage::Progress {
+                progress: ProgressMessage::DispatchStarted {
+                    agent: agent.clone(),
+                    work_unit: work_unit.clone(),
+                    input_present: input.is_some(),
+                },
+            };
+            match dispatch_run_after_preflight(
+                config,
+                &RunRequest {
+                    agent: agent.clone(),
+                    repo_url,
+                    work_unit: work_unit.clone(),
+                    input,
+                },
+                executor,
+                || {
+                    if let Err(error) = write_response(&mut stream, &progress) {
+                        tracing::warn!(
+                            event = "agentd.manual_run_progress_failed",
+                            error = %error,
+                            "failed to write manual run progress"
+                        );
+                    }
+                },
+            ) {
+                Ok(outcome) => {
+                    log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
+                    ResponseMessage::SessionOutcome {
+                        outcome: outcome.into(),
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        event = "agentd.manual_run_rejected",
+                        error = %error,
+                        "run request rejected"
+                    );
+                    ResponseMessage::Error {
+                        message: dispatch_error_message(&error),
+                    }
                 }
             }
-            Err(error) => {
-                tracing::warn!(
-                    event = "agentd.manual_run_rejected",
-                    error = %error,
-                    "run request rejected"
-                );
-                ResponseMessage::Error {
-                    message: dispatch_error_message(&error),
-                }
-            }
-        },
+        }
     };
 
     write_response(&mut stream, &response)

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -538,9 +538,14 @@ fn summarize_transcript_event(line: &str) -> String {
             event
                 .get("kind")
                 .and_then(serde_json::Value::as_str)
-                .map(str::to_string)
+                .filter(|kind| !kind.is_empty())
+                .map(escape_transcript_event_kind)
         })
         .unwrap_or_else(|| "unparsed_event".to_string())
+}
+
+fn escape_transcript_event_kind(kind: &str) -> String {
+    kind.chars().flat_map(char::escape_default).collect()
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -895,11 +900,12 @@ fn read_pid(pid_file: &Path) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DaemonError, ResponseMessage, reap_finished_handlers,
+        DaemonError, LiveObservationLevel, ResponseMessage, reap_finished_handlers,
         run_daemon_until_shutdown_with_reconciler, write_response,
     };
     use crate::config::Config;
     use crate::dispatch::SessionExecutor;
+    use crate::protocol::ProgressMessage;
     use agentd_runner::{
         RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
         StartupReconciliationReport,
@@ -1065,6 +1071,28 @@ source = "AGENTD_GITHUB_TOKEN"
         assert!(
             result.is_ok(),
             "closed peer during response write should be treated as normal completion"
+        );
+    }
+
+    #[test]
+    fn summary_progress_escapes_untrusted_transcript_event_kind_controls() {
+        let mut output = Vec::new();
+
+        super::render_progress(
+            ProgressMessage::TranscriptEvent {
+                session_id: "fake-session-1".to_string(),
+                line: "{\"kind\":\"agent_input\\nspoof\\u001b[2J\"}".to_string(),
+            },
+            LiveObservationLevel::Summary,
+            &mut output,
+        )
+        .expect("summary progress should render");
+
+        let output = String::from_utf8(output).expect("summary progress should be utf8");
+        assert_eq!(output, "session event: agent_input\\nspoof\\u{1b}[2J\n");
+        assert!(
+            !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
+            "summary output should not contain embedded terminal controls: {output:?}"
         );
     }
 

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -27,6 +27,8 @@ const ACCEPT_TIMEOUT: Duration = Duration::from_millis(100);
 const RUNTIME_DIR_MODE: u32 = 0o700;
 const SOCKET_MODE: u32 = 0o600;
 const SHUTDOWN_MESSAGE: &str = "agentd is shutting down";
+const MAX_PROGRESS_FRAME_BYTES: usize = 128 * 1024;
+const TERMINAL_RESPONSE_RESERVE_BYTES: usize = 16 * 1024;
 
 /// Startup or runtime failures for the foreground daemon loop.
 #[derive(Debug)]
@@ -488,6 +490,19 @@ fn render_progress<W: Write>(
     level: LiveObservationLevel,
     writer: &mut W,
 ) -> Result<(), ClientError> {
+    writeln!(
+        writer,
+        "{}",
+        render_operator_progress_line(&progress, level)
+    )?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn render_operator_progress_line(
+    progress: &ProgressMessage,
+    level: LiveObservationLevel,
+) -> String {
     match (progress, level) {
         (
             ProgressMessage::DispatchStarted {
@@ -496,9 +511,13 @@ fn render_progress<W: Write>(
             LiveObservationLevel::Summary,
         ) => {
             if let Some(work_unit) = work_unit {
-                writeln!(writer, "session running: {agent} ({work_unit})")?;
+                format!(
+                    "session running: {} ({})",
+                    OperatorField(agent),
+                    OperatorField(work_unit)
+                )
             } else {
-                writeln!(writer, "session running: {agent}")?;
+                format!("session running: {}", OperatorField(agent))
             }
         }
         (
@@ -508,31 +527,44 @@ fn render_progress<W: Write>(
                 input_present,
             },
             LiveObservationLevel::Full,
-        ) => {
-            writeln!(
-                writer,
-                "session running: agent={agent} work_unit={} input={}",
-                work_unit.as_deref().unwrap_or("-"),
-                if input_present { "present" } else { "absent" }
-            )?;
-        }
+        ) => format!(
+            "session running: agent={} work_unit={} input={}",
+            OperatorField(agent),
+            work_unit
+                .as_deref()
+                .map(OperatorField)
+                .unwrap_or(OperatorField("-")),
+            if *input_present { "present" } else { "absent" }
+        ),
         (ProgressMessage::TranscriptEvent { line, .. }, LiveObservationLevel::Summary) => {
-            writeln!(
-                writer,
-                "session event: {}",
-                summarize_transcript_event(&line)
-            )?;
+            let summary = summarize_transcript_event(line);
+            format!("session event: {}", OperatorField(&summary))
         }
         (ProgressMessage::TranscriptEvent { session_id, line }, LiveObservationLevel::Full) => {
-            writeln!(
-                writer,
-                "session event: session_id={session_id} {}",
-                escape_control_chars(&line)
-            )?;
+            format!(
+                "session event: session_id={} {}",
+                OperatorField(session_id),
+                OperatorField(line)
+            )
         }
     }
-    writer.flush()?;
-    Ok(())
+}
+
+struct OperatorField<'a>(&'a str);
+
+impl fmt::Display for OperatorField<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for character in self.0.chars() {
+            if character.is_control() {
+                for escaped in character.escape_default() {
+                    write!(f, "{escaped}")?;
+                }
+            } else {
+                write!(f, "{character}")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 fn summarize_transcript_event(line: &str) -> String {
@@ -543,25 +575,9 @@ fn summarize_transcript_event(line: &str) -> String {
                 .get("kind")
                 .and_then(serde_json::Value::as_str)
                 .filter(|kind| !kind.is_empty())
-                .map(escape_transcript_event_kind)
+                .map(str::to_string)
         })
         .unwrap_or_else(|| "unparsed_event".to_string())
-}
-
-fn escape_transcript_event_kind(kind: &str) -> String {
-    kind.chars().flat_map(char::escape_default).collect()
-}
-
-fn escape_control_chars(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for character in value.chars() {
-        if character.is_control() {
-            escaped.extend(character.escape_default());
-        } else {
-            escaped.push(character);
-        }
-    }
-    escaped
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -732,18 +748,34 @@ fn try_write_progress_response(
     let mut payload = serde_json::to_vec(response)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     payload.push(b'\n');
+    if payload.len() > MAX_PROGRESS_FRAME_BYTES {
+        tracing::debug!(
+            event = "agentd.manual_run_progress_dropped",
+            frame_bytes = payload.len(),
+            max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+            "dropped oversized manual run progress frame"
+        );
+        return Ok(());
+    }
+
+    if !progress_frame_has_reserved_capacity(stream, payload.len())? {
+        tracing::debug!(
+            event = "agentd.manual_run_progress_dropped",
+            frame_bytes = payload.len(),
+            terminal_reserve_bytes = TERMINAL_RESPONSE_RESERVE_BYTES,
+            "dropped manual run progress frame because the client connection is backpressured"
+        );
+        return Ok(());
+    }
 
     stream.set_nonblocking(true)?;
-    let write_result = write_response_nonblocking(stream, &payload);
+    let write_result = write_progress_frame_nonblocking(stream, &payload);
     let restore_result = stream.set_nonblocking(false);
 
     match (write_result, restore_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(error), Ok(())) if peer_disconnected_during_response(&error) => Ok(()),
-        (Err(error), Ok(())) if progress_response_would_block(&error) => {
-            let _ = stream.shutdown(std::net::Shutdown::Both);
-            Ok(())
-        }
+        (Err(error), Ok(())) if progress_response_would_block(&error) => Ok(()),
         (Err(error), Ok(())) => Err(error),
         (Ok(()), Err(error)) => Err(error),
         (Err(write_error), Err(restore_error)) => {
@@ -757,25 +789,66 @@ fn try_write_progress_response(
     }
 }
 
-fn write_response_nonblocking(stream: &mut UnixStream, mut bytes: &[u8]) -> Result<(), io::Error> {
-    while !bytes.is_empty() {
-        match stream.write(bytes) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "failed to write progress response",
-                ));
-            }
-            Ok(written) => bytes = &bytes[written..],
-            Err(error) if peer_disconnected_during_response(&error) => return Ok(()),
-            Err(error) => return Err(error),
-        }
-    }
-
-    match stream.flush() {
-        Ok(()) => Ok(()),
+fn write_progress_frame_nonblocking(
+    stream: &mut UnixStream,
+    bytes: &[u8],
+) -> Result<(), io::Error> {
+    match stream.write(bytes) {
+        Ok(written) if written == bytes.len() => Ok(()),
+        Ok(0) => Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "failed to write progress response",
+        )),
+        Ok(written) => Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            format!(
+                "partial progress frame write accepted {written} of {}",
+                bytes.len()
+            ),
+        )),
         Err(error) if peer_disconnected_during_response(&error) => Ok(()),
         Err(error) => Err(error),
+    }
+}
+
+fn progress_frame_has_reserved_capacity(
+    stream: &UnixStream,
+    frame_bytes: usize,
+) -> Result<bool, io::Error> {
+    let send_buffer_bytes = socket_send_buffer_bytes(stream)?;
+    let queued_bytes = socket_queued_output_bytes(stream)?;
+    Ok(queued_bytes.saturating_add(frame_bytes)
+        <= send_buffer_bytes.saturating_sub(TERMINAL_RESPONSE_RESERVE_BYTES))
+}
+
+fn socket_send_buffer_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
+    let mut size = 0_i32;
+    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &mut size as *mut i32 as *mut libc::c_void,
+            &mut size_len,
+        )
+    };
+    if result == 0 {
+        usize::try_from(size)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "SO_SNDBUF was negative"))
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn socket_queued_output_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
+    let mut queued = 0_i32;
+    let result = unsafe { libc::ioctl(stream.as_raw_fd(), libc::TIOCOUTQ, &mut queued) };
+    if result == 0 {
+        usize::try_from(queued)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "TIOCOUTQ was negative"))
+    } else {
+        Err(io::Error::last_os_error())
     }
 }
 
@@ -1190,7 +1263,7 @@ source = "AGENTD_GITHUB_TOKEN"
 
         super::render_progress(
             ProgressMessage::TranscriptEvent {
-                session_id: "fake-session-1".to_string(),
+                session_id: "fake-session-1\rspoof".to_string(),
                 line: "{\"kind\":\"agent_input\"}\nspoof\u{1b}[2J".to_string(),
             },
             LiveObservationLevel::Full,
@@ -1201,12 +1274,41 @@ source = "AGENTD_GITHUB_TOKEN"
         let output = String::from_utf8(output).expect("full progress should be utf8");
         assert_eq!(
             output,
-            "session event: session_id=fake-session-1 {\"kind\":\"agent_input\"}\\nspoof\\u{1b}[2J\n"
+            "session event: session_id=fake-session-1\\rspoof {\"kind\":\"agent_input\"}\\nspoof\\u{1b}[2J\n"
         );
         assert!(
             !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
             "full output should not contain embedded terminal controls: {output:?}"
         );
+    }
+
+    #[test]
+    fn dispatch_progress_escapes_untrusted_request_fields_at_every_level() {
+        for level in [LiveObservationLevel::Summary, LiveObservationLevel::Full] {
+            let mut output = Vec::new();
+
+            super::render_progress(
+                ProgressMessage::DispatchStarted {
+                    agent: "site-builder\nspoof\u{1b}[2J".to_string(),
+                    work_unit: Some("issue-122\rrewrite".to_string()),
+                    input_present: true,
+                },
+                level,
+                &mut output,
+            )
+            .expect("dispatch progress should render");
+
+            let output = String::from_utf8(output).expect("dispatch progress should be utf8");
+            assert!(
+                output.contains("site-builder\\nspoof\\u{1b}[2J")
+                    && output.contains("issue-122\\rrewrite"),
+                "dispatch output should escape request fields: {output:?}"
+            );
+            assert!(
+                !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
+                "dispatch output should not contain embedded terminal controls: {output:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, TryLockError};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -524,7 +524,11 @@ fn render_progress<W: Write>(
             )?;
         }
         (ProgressMessage::TranscriptEvent { session_id, line }, LiveObservationLevel::Full) => {
-            writeln!(writer, "session event: session_id={session_id} {line}")?;
+            writeln!(
+                writer,
+                "session event: session_id={session_id} {}",
+                escape_control_chars(&line)
+            )?;
         }
     }
     writer.flush()?;
@@ -546,6 +550,18 @@ fn summarize_transcript_event(line: &str) -> String {
 
 fn escape_transcript_event_kind(kind: &str) -> String {
     kind.chars().flat_map(char::escape_default).collect()
+}
+
+fn escape_control_chars(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else {
+            escaped.push(character);
+        }
+    }
+    escaped
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -606,9 +622,9 @@ fn handle_connection_inner(
                 let progress = ResponseMessage::Progress {
                     progress: ProgressMessage::TranscriptEvent { session_id, line },
                 };
-                match stream.lock() {
+                match stream.try_lock() {
                     Ok(mut stream) => {
-                        if let Err(error) = write_response(&mut stream, &progress) {
+                        if let Err(error) = try_write_progress_response(&mut stream, &progress) {
                             tracing::warn!(
                                 event = "agentd.manual_run_progress_failed",
                                 error = %error,
@@ -616,7 +632,13 @@ fn handle_connection_inner(
                             );
                         }
                     }
-                    Err(_) => {
+                    Err(TryLockError::WouldBlock) => {
+                        tracing::debug!(
+                            event = "agentd.manual_run_progress_dropped",
+                            "dropped manual run progress while another response was in flight"
+                        );
+                    }
+                    Err(TryLockError::Poisoned(_)) => {
                         tracing::warn!(
                             event = "agentd.manual_run_progress_lock_poisoned",
                             "failed to lock manual run progress stream"
@@ -633,9 +655,11 @@ fn handle_connection_inner(
                     input,
                 },
                 executor,
-                || match stream.lock() {
+                || match stream.try_lock() {
                     Ok(mut stream) => {
-                        if let Err(error) = write_response(&mut stream, &dispatch_progress) {
+                        if let Err(error) =
+                            try_write_progress_response(&mut stream, &dispatch_progress)
+                        {
                             tracing::warn!(
                                 event = "agentd.manual_run_progress_failed",
                                 error = %error,
@@ -643,7 +667,13 @@ fn handle_connection_inner(
                             );
                         }
                     }
-                    Err(_) => {
+                    Err(TryLockError::WouldBlock) => {
+                        tracing::debug!(
+                            event = "agentd.manual_run_progress_dropped",
+                            "dropped manual run progress while another response was in flight"
+                        );
+                    }
+                    Err(TryLockError::Poisoned(_)) => {
                         tracing::warn!(
                             event = "agentd.manual_run_progress_lock_poisoned",
                             "failed to lock manual run progress stream"
@@ -693,6 +723,64 @@ fn write_response_part(stream: &mut UnixStream, bytes: &[u8]) -> Result<(), io::
         Err(error) if peer_disconnected_during_response(&error) => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+fn try_write_progress_response(
+    stream: &mut UnixStream,
+    response: &ResponseMessage,
+) -> Result<(), io::Error> {
+    let mut payload = serde_json::to_vec(response)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    payload.push(b'\n');
+
+    stream.set_nonblocking(true)?;
+    let write_result = write_response_nonblocking(stream, &payload);
+    let restore_result = stream.set_nonblocking(false);
+
+    match (write_result, restore_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) if peer_disconnected_during_response(&error) => Ok(()),
+        (Err(error), Ok(())) if progress_response_would_block(&error) => {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+            Ok(())
+        }
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(write_error), Err(restore_error)) => {
+            tracing::warn!(
+                event = "agentd.manual_run_progress_blocking_restore_failed",
+                error = %restore_error,
+                "failed to restore blocking mode after manual run progress write"
+            );
+            Err(write_error)
+        }
+    }
+}
+
+fn write_response_nonblocking(stream: &mut UnixStream, mut bytes: &[u8]) -> Result<(), io::Error> {
+    while !bytes.is_empty() {
+        match stream.write(bytes) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write progress response",
+                ));
+            }
+            Ok(written) => bytes = &bytes[written..],
+            Err(error) if peer_disconnected_during_response(&error) => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+
+    match stream.flush() {
+        Ok(()) => Ok(()),
+        Err(error) if peer_disconnected_during_response(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn progress_response_would_block(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::WouldBlock)
 }
 
 fn peer_disconnected_during_response(error: &io::Error) -> bool {
@@ -1093,6 +1181,31 @@ source = "AGENTD_GITHUB_TOKEN"
         assert!(
             !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
             "summary output should not contain embedded terminal controls: {output:?}"
+        );
+    }
+
+    #[test]
+    fn full_progress_escapes_untrusted_raw_transcript_line_controls() {
+        let mut output = Vec::new();
+
+        super::render_progress(
+            ProgressMessage::TranscriptEvent {
+                session_id: "fake-session-1".to_string(),
+                line: "{\"kind\":\"agent_input\"}\nspoof\u{1b}[2J".to_string(),
+            },
+            LiveObservationLevel::Full,
+            &mut output,
+        )
+        .expect("full progress should render");
+
+        let output = String::from_utf8(output).expect("full progress should be utf8");
+        assert_eq!(
+            output,
+            "session event: session_id=fake-session-1 {\"kind\":\"agent_input\"}\\nspoof\\u{1b}[2J\n"
+        );
+        assert!(
+            !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
+            "full output should not contain embedded terminal controls: {output:?}"
         );
     }
 

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use agentd_runner::{
-    InvocationInput, ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
-    SessionSpec, run_session,
+    InvocationInput, NoopSessionProgressObserver, ResolvedEnvironmentVariable, RunnerError,
+    SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
+    run_session_with_progress,
 };
 
 use crate::audit_root::prepare_audit_root;
@@ -87,6 +88,7 @@ pub trait SessionExecutor {
         &self,
         spec: SessionSpec,
         invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError>;
 }
 
@@ -99,8 +101,9 @@ impl SessionExecutor for RunnerSessionExecutor {
         &self,
         spec: SessionSpec,
         invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
-        run_session(spec, invocation)
+        run_session_with_progress(spec, invocation, progress)
     }
 }
 
@@ -110,7 +113,13 @@ pub fn dispatch_run(
     request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
-    dispatch_run_after_preflight(config, request, executor, || {})
+    dispatch_run_after_preflight(
+        config,
+        request,
+        executor,
+        || {},
+        &NoopSessionProgressObserver,
+    )
 }
 
 /// Resolve a named agent plus run request into a runner session, notify once
@@ -120,6 +129,7 @@ pub fn dispatch_run_after_preflight(
     request: &RunRequest,
     executor: &impl SessionExecutor,
     after_preflight: impl FnOnce(),
+    progress: &dyn SessionProgressObserver,
 ) -> Result<SessionOutcome, DispatchError> {
     let agent = config
         .agent(&request.agent)
@@ -186,6 +196,7 @@ pub fn dispatch_run_after_preflight(
                 input: request.input.clone(),
                 timeout: None,
             },
+            progress,
         )
         .map_err(DispatchError::from)
 }

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -110,6 +110,17 @@ pub fn dispatch_run(
     request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
+    dispatch_run_after_preflight(config, request, executor, || {})
+}
+
+/// Resolve a named agent plus run request into a runner session, notify once
+/// preflight has passed, and run it.
+pub fn dispatch_run_after_preflight(
+    config: &Config,
+    request: &RunRequest,
+    executor: &impl SessionExecutor,
+    after_preflight: impl FnOnce(),
+) -> Result<SessionOutcome, DispatchError> {
     let agent = config
         .agent(&request.agent)
         .ok_or_else(|| DispatchError::UnknownAgent {
@@ -148,6 +159,8 @@ pub fn dispatch_run(
         .repo_token_source()
         .and_then(|source| std::env::var(source).ok())
         .filter(|value| !value.is_empty());
+
+    after_preflight();
 
     executor
         .run_session(

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -13,7 +13,10 @@ mod protocol;
 pub mod runtime_paths;
 mod scheduler;
 
-pub use daemon::{ClientError, DaemonError, request_run, run_daemon_until_shutdown};
+pub use daemon::{
+    ClientError, DaemonError, LiveObservationLevel, request_run, request_run_with_live_observation,
+    run_daemon_until_shutdown,
+};
 pub use dispatch::{
     DispatchError, RunRequest, RunnerSessionExecutor, SessionExecutor, dispatch_run,
 };

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -143,7 +143,7 @@ enum Command {
     /// Trigger a manual session through the running daemon.
     #[command(
         display_name = "agentd",
-        after_help = "Live observation:\n  agentd run streams concise session progress by default. Use --progress full for every available progress field.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
+        after_help = "Live observation:\n  agentd run streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
     )]
     Run {
         agent: String,
@@ -164,7 +164,7 @@ enum Command {
     /// Greet the operator, elicit intent, and seed a session.
     #[command(
         display_name = "agentd",
-        after_help = "Live observation:\n  agentd wish streams concise session progress by default. Use --progress full for every available progress field.\n\nPrompts:\n  Speak your wish.\n  What do you wish the agent to do?\n  What is this wish aimed at? Leave blank for prose only."
+        after_help = "Live observation:\n  agentd wish streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nPrompts:\n  Speak your wish.\n  What do you wish the agent to do?\n  What is this wish aimed at? Leave blank for prose only."
     )]
     Wish {
         agent: String,

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -7,17 +7,44 @@ use std::{io::BufRead, io::Write};
 
 use agentd::config::Config;
 use agentd::{
-    RunRequest, RunnerSessionExecutor, configure_tracing, request_run, resolve_client_socket_path,
-    run_daemon_until_shutdown,
+    LiveObservationLevel, RunRequest, RunnerSessionExecutor, configure_tracing,
+    request_run_with_live_observation, resolve_client_socket_path, run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 
 const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
 const WISH_GREETING: &str = "Speak your wish.";
 const WISH_STATEMENT_PROMPT: &str = "What do you wish the agent to do?";
 const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank for prose only.";
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ProgressLevel {
+    /// Print concise live session lifecycle messages.
+    Summary,
+    /// Print live session lifecycle messages with all available fields.
+    Full,
+}
+
+impl From<ProgressLevel> for LiveObservationLevel {
+    fn from(level: ProgressLevel) -> Self {
+        match level {
+            ProgressLevel::Summary => Self::Summary,
+            ProgressLevel::Full => Self::Full,
+        }
+    }
+}
+
+struct RunClientArgs {
+    agent: String,
+    repo: Option<String>,
+    progress: ProgressLevel,
+    work_unit: Option<String>,
+    intent: Option<String>,
+    artifact_file: Option<PathBuf>,
+    artifact_type: Option<String>,
+}
 
 #[derive(Debug)]
 enum RunCommandError {
@@ -116,13 +143,15 @@ enum Command {
     /// Trigger a manual session through the running daemon.
     #[command(
         display_name = "agentd",
-        after_help = "Work-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
+        after_help = "Live observation:\n  agentd run streams concise session progress by default. Use --progress full for every available progress field.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
     )]
     Run {
         agent: String,
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
+        progress: ProgressLevel,
         #[arg(long, conflicts_with = "intent")]
         work_unit: Option<String>,
         #[arg(long, conflicts_with_all = ["work_unit", "artifact_file"])]
@@ -135,13 +164,15 @@ enum Command {
     /// Greet the operator, elicit intent, and seed a session.
     #[command(
         display_name = "agentd",
-        after_help = "Prompts:\n  Speak your wish.\n  What do you wish the agent to do?\n  What is this wish aimed at? Leave blank for prose only."
+        after_help = "Live observation:\n  agentd wish streams concise session progress by default. Use --progress full for every available progress field.\n\nPrompts:\n  Speak your wish.\n  What do you wish the agent to do?\n  What is this wish aimed at? Leave blank for prose only."
     )]
     Wish {
         agent: String,
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
+        progress: ProgressLevel,
     },
 }
 
@@ -175,6 +206,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             agent,
             repo,
             socket_path,
+            progress,
             work_unit,
             intent,
             artifact_file,
@@ -188,18 +220,22 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             run_client(
                 socket_path.as_deref(),
-                agent,
-                repo,
-                work_unit,
-                intent,
-                artifact_file,
-                artifact_type,
+                RunClientArgs {
+                    agent,
+                    repo,
+                    progress,
+                    work_unit,
+                    intent,
+                    artifact_file,
+                    artifact_type,
+                },
             )
         }
         Some(Command::Wish {
             agent,
             repo,
             socket_path,
+            progress,
         }) => {
             if cli.config.is_some() {
                 return Err(Box::new(std::io::Error::new(
@@ -207,7 +243,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     "--config is only supported for daemon mode, not `agentd wish`",
                 )));
             }
-            run_wish_client(socket_path.as_deref(), agent, repo)
+            run_wish_client(socket_path.as_deref(), agent, repo, progress)
         }
     }
 }
@@ -246,21 +282,24 @@ fn register_termination_handlers(shutdown: Arc<AtomicBool>) -> Result<(), std::i
 
 fn run_client(
     explicit_socket_path: Option<&std::path::Path>,
-    agent: String,
-    repo: Option<String>,
-    work_unit: Option<String>,
-    intent: Option<String>,
-    artifact_file: Option<PathBuf>,
-    artifact_type: Option<String>,
+    args: RunClientArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let input = resolve_invocation_input(intent, artifact_file, artifact_type)?;
-    run_client_with_input(explicit_socket_path, agent, repo, work_unit, input)
+    let input = resolve_invocation_input(args.intent, args.artifact_file, args.artifact_type)?;
+    run_client_with_input(
+        explicit_socket_path,
+        args.agent,
+        args.repo,
+        args.progress,
+        args.work_unit,
+        input,
+    )
 }
 
 fn run_wish_client(
     explicit_socket_path: Option<&std::path::Path>,
     agent: String,
     repo: Option<String>,
+    progress: ProgressLevel,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout();
@@ -270,6 +309,7 @@ fn run_wish_client(
         explicit_socket_path,
         agent,
         repo,
+        progress,
         None,
         Some(InvocationInput::IntentText { statement, target }),
     )
@@ -279,11 +319,13 @@ fn run_client_with_input(
     explicit_socket_path: Option<&std::path::Path>,
     agent: String,
     repo: Option<String>,
+    progress: ProgressLevel,
     work_unit: Option<String>,
     input: Option<InvocationInput>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let socket_path = resolve_client_socket_path(explicit_socket_path)?;
-    let outcome = request_run(
+    let mut stdout = std::io::stdout();
+    let outcome = request_run_with_live_observation(
         &socket_path,
         &RunRequest {
             agent,
@@ -291,6 +333,8 @@ fn run_client_with_input(
             work_unit,
             input,
         },
+        progress.into(),
+        &mut stdout,
     )?;
 
     if outcome.is_cli_success() {

--- a/crates/agentd/src/protocol.rs
+++ b/crates/agentd/src/protocol.rs
@@ -1,8 +1,8 @@
 //! Daemon Unix-socket wire messages.
 //!
 //! Wire format and connection lifecycle are specified in
-//! `docs/socket-protocol.md`: newline-delimited JSON, one request and one
-//! response per connection. The protocol is intentionally internal and
+//! `docs/socket-protocol.md`: newline-delimited JSON, one request followed by
+//! one or more response lines. The protocol is intentionally internal and
 //! unversioned in `v0.1.x` — daemon and CLI client must be the same build
 //! (see README § Running a Session), which is why these types are
 //! `pub(crate)` and carry no version field.
@@ -57,6 +57,8 @@ pub(crate) enum ProgressMessage {
         work_unit: Option<String>,
         input_present: bool,
     },
+    /// One event line emitted by the running session's transcript stream.
+    TranscriptEvent { session_id: String, line: String },
 }
 
 /// Terminal session outcome.

--- a/crates/agentd/src/protocol.rs
+++ b/crates/agentd/src/protocol.rs
@@ -30,19 +30,33 @@ pub(crate) enum RequestMessage {
     },
 }
 
-/// Daemon → client. Exactly one is written per accepted request, then the
-/// connection closes.
+/// Daemon → client. A run request may emit zero or more progress messages
+/// before its terminal outcome or error message, then the connection closes.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum ResponseMessage {
     /// Answer to [`RequestMessage::Ping`].
     Pong,
+    /// Human-observable progress for a running session.
+    Progress { progress: ProgressMessage },
     /// The session ran to a terminal outcome (which may be a failure
     /// outcome — transport success, not work success).
     SessionOutcome { outcome: OutcomeMessage },
     /// The request was rejected before a session outcome existed:
     /// malformed JSON, unknown agent, or dispatch failure.
     Error { message: String },
+}
+
+/// Non-terminal session progress.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+pub(crate) enum ProgressMessage {
+    /// The daemon accepted the request and is dispatching it to the runner.
+    DispatchStarted {
+        agent: String,
+        work_unit: Option<String>,
+        input_present: bool,
+    },
 }
 
 /// Terminal session outcome.

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -107,7 +107,8 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use agentd_runner::{
-        RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+        RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
+        StartupReconciliationReport,
     };
 
     use crate::SessionExecutor;
@@ -135,6 +136,7 @@ mod tests {
             &self,
             _spec: SessionSpec,
             invocation: SessionInvocation,
+            _progress: &dyn SessionProgressObserver,
         ) -> Result<SessionOutcome, RunnerError> {
             self.invocations
                 .lock()

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -12,8 +12,8 @@ use agentd::SessionExecutor;
 use agentd::config::Config;
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
 use agentd_runner::{
-    InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
-    StartupReconciliationReport,
+    InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver,
+    SessionSpec, StartupReconciliationReport,
 };
 use serde_json::json;
 
@@ -35,6 +35,7 @@ impl SessionExecutor for FixedOutcomeExecutor {
         &self,
         _spec: SessionSpec,
         _invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         Ok(self.outcome.clone())
     }
@@ -64,6 +65,7 @@ impl SessionExecutor for RecordingInvocationExecutor {
         &self,
         _spec: SessionSpec,
         invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         self.invocations
             .lock()

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -425,6 +425,12 @@ fn binary_run_help_shows_socket_path_and_not_config() {
         "run help should advertise socket override: {stdout}"
     );
     assert!(
+        stdout.contains("--progress <PROGRESS>")
+            && stdout.contains("summary")
+            && stdout.contains("full"),
+        "run help should document live progress verbosity: {stdout}"
+    );
+    assert!(
         !stdout.contains("--config"),
         "run help should not advertise daemon config coupling: {stdout}"
     );
@@ -471,6 +477,12 @@ fn binary_wish_help_shows_evocative_intent_prompting_surface() {
     assert!(
         stdout.contains("--socket-path"),
         "wish help should advertise socket override: {stdout}"
+    );
+    assert!(
+        stdout.contains("--progress <PROGRESS>")
+            && stdout.contains("summary")
+            && stdout.contains("full"),
+        "wish help should document live progress verbosity: {stdout}"
     );
     assert!(
         stdout.contains("What do you wish the agent to do?"),
@@ -1295,11 +1307,10 @@ fn binary_run_command_exits_non_zero_and_reports_failed_sessions_on_stderr() {
         !output.status.success(),
         "run command should fail when the daemon reports a failed session"
     );
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be valid UTF-8")
-            .is_empty(),
-        "failed run should not print a success-style stdout message"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session running: site-builder\n",
+        "failed run should print only live progress on stdout"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
@@ -1350,11 +1361,10 @@ fn binary_run_command_exits_non_zero_and_reports_timed_out_sessions_on_stderr() 
         !output.status.success(),
         "run command should fail when the daemon reports a timed-out session"
     );
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be valid UTF-8")
-            .is_empty(),
-        "timed-out run should not print a success-style stdout message"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session running: site-builder\n",
+        "timed-out run should print only live progress on stdout"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
@@ -1411,11 +1421,10 @@ fn binary_run_command_exits_non_zero_and_reports_signal_terminated_sessions_on_s
         !output.status.success(),
         "run command should fail when the daemon reports a signal-terminated session"
     );
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be valid UTF-8")
-            .is_empty(),
-        "signal-terminated run should not print a success-style stdout message"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session running: site-builder\n",
+        "signal-terminated run should print only live progress on stdout"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
@@ -1470,7 +1479,7 @@ fn binary_run_command_exits_zero_and_reports_blocked_sessions_on_stdout() {
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session blocked\n"
+        "session running: site-builder\nsession blocked\n"
     );
     assert!(
         String::from_utf8(output.stderr)
@@ -1525,7 +1534,7 @@ fn binary_run_command_exits_zero_and_reports_nothing_ready_sessions_on_stdout() 
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session nothing_ready\n"
+        "session running: site-builder\nsession nothing_ready\n"
     );
     assert!(
         String::from_utf8(output.stderr)
@@ -1592,7 +1601,7 @@ argv = ["site-builder", "exec"]
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session success\n"
+        "session running: site-builder\nsession success\n"
     );
     assert_eq!(
         invocations.lock().expect("invocations should lock")[0].repo_url,

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -14,7 +14,8 @@ use agentd::{
 };
 use agentd_runner::InvocationInput;
 use agentd_runner::{
-    RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    RunnerError, SessionInvocation, SessionOutcome, SessionProgressEvent, SessionProgressObserver,
+    SessionSpec, StartupReconciliationReport,
 };
 use serde_json::json;
 
@@ -51,6 +52,7 @@ impl SessionExecutor for FixedOutcomeExecutor {
         &self,
         _spec: SessionSpec,
         _invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         Ok(self.outcome.clone())
     }
@@ -80,6 +82,7 @@ impl SessionExecutor for RecordingInvocationExecutor {
         &self,
         _spec: SessionSpec,
         invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         self.invocations
             .lock()
@@ -94,6 +97,7 @@ struct BlockingFirstRunExecutor {
     state: Arc<BlockingFirstRunState>,
     first_outcome: SessionOutcome,
     later_outcome: SessionOutcome,
+    first_progress_line: Option<String>,
 }
 
 struct BlockingFirstRunState {
@@ -112,7 +116,13 @@ impl BlockingFirstRunExecutor {
             }),
             first_outcome,
             later_outcome,
+            first_progress_line: None,
         }
+    }
+
+    fn with_first_progress_line(mut self, line: &str) -> Self {
+        self.first_progress_line = Some(line.to_string());
+        self
     }
 
     fn wait_for_first_run_to_start(&self) {
@@ -138,6 +148,7 @@ impl SessionExecutor for BlockingFirstRunExecutor {
         &self,
         _spec: SessionSpec,
         _invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         let call_index = self.state.calls.fetch_add(1, Ordering::AcqRel);
         if call_index == 0 {
@@ -148,6 +159,13 @@ impl SessionExecutor for BlockingFirstRunExecutor {
             *started = true;
             started_cvar.notify_all();
             drop(started);
+
+            if let Some(line) = &self.first_progress_line {
+                progress.observe(SessionProgressEvent::TranscriptEvent {
+                    session_id: "fake-session-1".to_string(),
+                    line: line.clone(),
+                });
+            }
 
             let (released_lock, released_cvar) = &self.state.first_released;
             let released = released_lock
@@ -282,7 +300,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
 }
 
 #[test]
-fn client_receives_live_progress_before_session_outcome() {
+fn client_receives_execution_progress_while_session_is_still_running() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -297,6 +315,9 @@ fn client_receives_live_progress_before_session_outcome() {
     let executor = BlockingFirstRunExecutor::new(
         SessionOutcome::Success { exit_code: 0 },
         SessionOutcome::Success { exit_code: 0 },
+    )
+    .with_first_progress_line(
+        r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working step"}"#,
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
@@ -321,27 +342,111 @@ fn client_receives_live_progress_before_session_outcome() {
         )
     });
 
+    executor.wait_for_first_run_to_start();
     let mut progress = String::new();
     let deadline = Instant::now() + Duration::from_secs(1);
-    while !progress.ends_with('\n') {
+    while !progress.contains("session event: agent_input") {
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
             !remaining.is_zero(),
-            "live progress should reach the client before the session completes"
+            "execution progress should reach the client before the session completes"
         );
         progress.push_str(
             &progress_rx
                 .recv_timeout(remaining)
-                .expect("live progress should reach the client before the session completes"),
+                .expect("execution progress should reach the client before the session completes"),
         );
     }
     assert!(
-        progress.contains("session running: site-builder (issue-122)"),
+        progress.contains("session event: agent_input"),
         "unexpected progress output: {progress}"
     );
     assert!(
         !client_request.is_finished(),
         "client should still be waiting for the terminal outcome after progress arrives"
+    );
+
+    executor.release_first_run();
+    assert_eq!(
+        client_request
+            .join()
+            .expect("client request thread should join")
+            .expect("client request should succeed"),
+        SessionOutcome::Success { exit_code: 0 }
+    );
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn client_full_progress_includes_raw_execution_event_detail() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("full-live-progress");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let executor = BlockingFirstRunExecutor::new(
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::Success { exit_code: 0 },
+    )
+    .with_first_progress_line(
+        r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working step"}"#,
+    );
+    let daemon_executor = executor.clone();
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let (progress_tx, progress_rx) = mpsc::channel();
+    let client_config = config.clone();
+    let client_request = thread::spawn(move || {
+        let mut writer = ChannelWriter { tx: progress_tx };
+        request_run_with_live_observation(
+            client_config.daemon(),
+            &RunRequest {
+                agent: "site-builder".to_string(),
+                repo_url: Some("https://example.com/repo.git".to_string()),
+                work_unit: Some("issue-122".to_string()),
+                input: None,
+            },
+            LiveObservationLevel::Full,
+            &mut writer,
+        )
+    });
+
+    executor.wait_for_first_run_to_start();
+    let mut progress = String::new();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !progress.contains(r#""content":"working step""#) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "full execution progress should reach the client before the session completes"
+        );
+        progress.push_str(
+            &progress_rx
+                .recv_timeout(remaining)
+                .expect("full execution progress should reach the client before completion"),
+        );
+    }
+    assert!(progress.contains("session_id=fake-session-1"), "{progress}");
+    assert!(
+        !client_request.is_finished(),
+        "client should still be waiting for the terminal outcome after full progress arrives"
     );
 
     executor.release_first_run();

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -9,13 +9,32 @@ use std::time::{Duration, Instant};
 use agentd::config::{Config, ConfigError};
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
 use agentd::{
-    ClientError, DaemonError, RunRequest, RunnerSessionExecutor, SessionExecutor, request_run,
+    ClientError, DaemonError, LiveObservationLevel, RunRequest, RunnerSessionExecutor,
+    SessionExecutor, request_run, request_run_with_live_observation,
 };
 use agentd_runner::InvocationInput;
 use agentd_runner::{
     RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
 use serde_json::json;
+
+struct ChannelWriter {
+    tx: mpsc::Sender<String>,
+}
+
+impl std::io::Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let text = String::from_utf8_lossy(buf).to_string();
+        self.tx
+            .send(text)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "receiver closed"))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -251,6 +270,88 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     .expect("client request should succeed");
 
     assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 23 });
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn client_receives_live_progress_before_session_outcome() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("live-progress");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let executor = BlockingFirstRunExecutor::new(
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::Success { exit_code: 0 },
+    );
+    let daemon_executor = executor.clone();
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let (progress_tx, progress_rx) = mpsc::channel();
+    let client_config = config.clone();
+    let client_request = thread::spawn(move || {
+        let mut writer = ChannelWriter { tx: progress_tx };
+        request_run_with_live_observation(
+            client_config.daemon(),
+            &RunRequest {
+                agent: "site-builder".to_string(),
+                repo_url: Some("https://example.com/repo.git".to_string()),
+                work_unit: Some("issue-122".to_string()),
+                input: None,
+            },
+            LiveObservationLevel::Summary,
+            &mut writer,
+        )
+    });
+
+    let mut progress = String::new();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !progress.ends_with('\n') {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "live progress should reach the client before the session completes"
+        );
+        progress.push_str(
+            &progress_rx
+                .recv_timeout(remaining)
+                .expect("live progress should reach the client before the session completes"),
+        );
+    }
+    assert!(
+        progress.contains("session running: site-builder (issue-122)"),
+        "unexpected progress output: {progress}"
+    );
+    assert!(
+        !client_request.is_finished(),
+        "client should still be waiting for the terminal outcome after progress arrives"
+    );
+
+    executor.release_first_run();
+    assert_eq!(
+        client_request
+            .join()
+            .expect("client request thread should join")
+            .expect("client request should succeed"),
+        SessionOutcome::Success { exit_code: 0 }
+    );
 
     shutdown.store(true, Ordering::Release);
     handle

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -1,5 +1,4 @@
-use std::io::{BufRead, Write};
-use std::os::fd::AsRawFd;
+use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
@@ -126,13 +125,9 @@ impl BurstProgressExecutor {
             progress_events: SATURATING_PROGRESS_EVENTS,
             progress_line: format!(
                 r#"{{"schema_version":1,"source":"runa","kind":"agent_input","content":"{}"}}"#,
-                "x".repeat(8 * 1024)
+                "x".repeat(16 * 1024)
             ),
         }
-    }
-
-    fn total_progress_bytes(&self) -> usize {
-        self.progress_events * self.progress_line.len()
     }
 }
 
@@ -303,22 +298,6 @@ fn run_daemon_until_shutdown_for_test(
     run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
         Ok(StartupReconciliationReport::default())
     })
-}
-
-fn socket_send_buffer_size(stream: &UnixStream) -> usize {
-    let mut size = 0_i32;
-    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
-    let result = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_SNDBUF,
-            &mut size as *mut i32 as *mut libc::c_void,
-            &mut size_len,
-        )
-    };
-    assert_eq!(result, 0, "SO_SNDBUF should be readable");
-    usize::try_from(size).expect("SO_SNDBUF should be non-negative")
 }
 
 #[test]
@@ -535,21 +514,20 @@ fn client_full_progress_includes_raw_execution_event_detail() {
 }
 
 #[test]
-fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown() {
+fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcome() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
     }
-    let runtime_dir = unique_runtime_dir("non-reading-progress-client");
+    let runtime_dir = unique_runtime_dir("slow-reading-progress-client");
     let config = config_in_runtime_dir(&runtime_dir);
     let shutdown = Arc::new(AtomicBool::new(false));
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let (completed_tx, completed_rx) = mpsc::channel();
     let executor = BurstProgressExecutor::new(completed_tx);
-    let offered_progress_bytes = executor.total_progress_bytes();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
     });
@@ -557,11 +535,6 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
 
     let mut client =
         Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
-    let send_buffer_size = socket_send_buffer_size(client.as_ref().expect("client should exist"));
-    assert!(
-        offered_progress_bytes > send_buffer_size * 16,
-        "test must offer enough progress to saturate the socket send buffer: offered={offered_progress_bytes} SO_SNDBUF={send_buffer_size}"
-    );
     writeln!(
         client.as_mut().expect("client should exist"),
         "{}",
@@ -575,6 +548,8 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     )
     .expect("client request should write");
 
+    thread::sleep(Duration::from_millis(50));
+
     if completed_rx.recv_timeout(Duration::from_secs(5)).is_err() {
         drop(client.take());
         shutdown.store(true, Ordering::Release);
@@ -585,7 +560,7 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
         unsafe {
             std::env::remove_var("AGENTD_GITHUB_TOKEN");
         }
-        panic!("progress forwarding should not stall session cleanup for a non-reading client");
+        panic!("progress forwarding should not stall session cleanup for a slow-reading client");
     }
 
     shutdown.store(true, Ordering::Release);
@@ -609,30 +584,40 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
             unsafe {
                 std::env::remove_var("AGENTD_GITHUB_TOKEN");
             }
-            panic!("daemon shutdown should not wait for a non-reading progress client");
+            panic!("daemon shutdown should not wait for a slow-reading progress client");
         }
     };
 
     joiner.join().expect("join helper should join");
     join_result.expect("daemon should exit cleanly");
 
-    let client = client.take().expect("client should still be connected");
+    let mut client = client.take().expect("client should still be connected");
     client
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("client read timeout should be set");
-    let mut reader = std::io::BufReader::new(client);
-    let mut lines = Vec::new();
+    let mut response = Vec::new();
+    let mut buffer = [0_u8; 8192];
     loop {
-        let mut line = String::new();
-        let bytes_read = reader
-            .read_line(&mut line)
-            .expect("daemon stream should remain valid JSONL until EOF");
-        if bytes_read == 0 {
-            break;
+        match client.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(bytes_read) => {
+                response.extend_from_slice(&buffer[..bytes_read]);
+                thread::sleep(Duration::from_millis(1));
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                panic!("slow-reading client timed out before daemon closed the response stream")
+            }
+            Err(error) => panic!("slow-reading client failed to read daemon response: {error}"),
         }
-        lines.push(line);
     }
 
+    let response = String::from_utf8(response).expect("daemon response should be utf8 JSONL");
+    let lines: Vec<&str> = response.lines().collect();
     assert!(
         !lines.is_empty(),
         "daemon should write at least the terminal response"
@@ -650,11 +635,12 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     }
     assert!(
         saw_terminal_outcome,
-        "terminal outcome must survive saturated progress writes: {lines:?}"
+        "terminal outcome must survive slow-reader progress backpressure; parsed {} lines with {progress_frames} progress frames",
+        lines.len()
     );
     assert!(
         progress_frames < SATURATING_PROGRESS_EVENTS,
-        "saturated non-reading client should force progress drops, got all {progress_frames} frames"
+        "slow-reading client should force progress drops, got all {progress_frames} frames"
     );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -1,10 +1,12 @@
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
+use std::{io::Write, sync::mpsc::Sender};
 
 use agentd::config::{Config, ConfigError};
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
@@ -104,6 +106,46 @@ struct BlockingFirstRunState {
     calls: AtomicUsize,
     first_started: (Mutex<bool>, Condvar),
     first_released: (Mutex<bool>, Condvar),
+}
+
+#[derive(Clone)]
+struct BurstProgressExecutor {
+    completed: Sender<()>,
+    progress_events: usize,
+    progress_line: String,
+}
+
+impl BurstProgressExecutor {
+    fn new(completed: Sender<()>) -> Self {
+        Self {
+            completed,
+            progress_events: 32,
+            progress_line: format!(
+                r#"{{"schema_version":1,"source":"runa","kind":"agent_input","content":"{}"}}"#,
+                "x".repeat(256 * 1024)
+            ),
+        }
+    }
+}
+
+impl SessionExecutor for BurstProgressExecutor {
+    fn run_session(
+        &self,
+        _spec: SessionSpec,
+        _invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
+    ) -> Result<SessionOutcome, RunnerError> {
+        for index in 0..self.progress_events {
+            progress.observe(SessionProgressEvent::TranscriptEvent {
+                session_id: format!("fake-session-{index}"),
+                line: self.progress_line.clone(),
+            });
+        }
+        self.completed
+            .send(())
+            .expect("completion signal should send");
+        Ok(SessionOutcome::Success { exit_code: 0 })
+    }
 }
 
 impl BlockingFirstRunExecutor {
@@ -463,6 +505,87 @@ fn client_full_progress_includes_raw_execution_event_detail() {
         .join()
         .expect("daemon thread should join")
         .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("non-reading-progress-client");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (completed_tx, completed_rx) = mpsc::channel();
+    let executor = BurstProgressExecutor::new(completed_tx);
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let mut client =
+        Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
+    writeln!(
+        client.as_mut().expect("client should exist"),
+        "{}",
+        json!({
+            "type": "run",
+            "agent": "site-builder",
+            "repo_url": "https://example.com/repo.git",
+            "work_unit": "issue-122",
+            "input": null
+        })
+    )
+    .expect("client request should write");
+
+    if completed_rx.recv_timeout(Duration::from_secs(1)).is_err() {
+        drop(client.take());
+        shutdown.store(true, Ordering::Release);
+        handle
+            .join()
+            .expect("daemon thread should join after client disconnect")
+            .expect("daemon should exit cleanly after client disconnect");
+        unsafe {
+            std::env::remove_var("AGENTD_GITHUB_TOKEN");
+        }
+        panic!("progress forwarding should not stall session cleanup for a non-reading client");
+    }
+
+    shutdown.store(true, Ordering::Release);
+    let (join_tx, join_rx) = mpsc::channel();
+    let joiner = thread::spawn(move || {
+        let result = handle.join().expect("daemon thread should not panic");
+        join_tx
+            .send(result)
+            .expect("daemon join result should send");
+    });
+
+    let join_result = match join_rx.recv_timeout(Duration::from_secs(1)) {
+        Ok(result) => result,
+        Err(_) => {
+            drop(client.take());
+            let result = join_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("daemon should join after client disconnect");
+            joiner.join().expect("join helper should join");
+            result.expect("daemon should exit cleanly after client disconnect");
+            unsafe {
+                std::env::remove_var("AGENTD_GITHUB_TOKEN");
+            }
+            panic!("daemon shutdown should not wait for a non-reading progress client");
+        }
+    };
+
+    drop(client.take());
+    joiner.join().expect("join helper should join");
+    join_result.expect("daemon should exit cleanly");
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
     }

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -1,12 +1,14 @@
+use std::io::{BufRead, Write};
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
-use std::{io::Write, sync::mpsc::Sender};
 
 use agentd::config::{Config, ConfigError};
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
@@ -115,16 +117,22 @@ struct BurstProgressExecutor {
     progress_line: String,
 }
 
+const SATURATING_PROGRESS_EVENTS: usize = 4096;
+
 impl BurstProgressExecutor {
     fn new(completed: Sender<()>) -> Self {
         Self {
             completed,
-            progress_events: 32,
+            progress_events: SATURATING_PROGRESS_EVENTS,
             progress_line: format!(
                 r#"{{"schema_version":1,"source":"runa","kind":"agent_input","content":"{}"}}"#,
-                "x".repeat(256 * 1024)
+                "x".repeat(8 * 1024)
             ),
         }
+    }
+
+    fn total_progress_bytes(&self) -> usize {
+        self.progress_events * self.progress_line.len()
     }
 }
 
@@ -295,6 +303,22 @@ fn run_daemon_until_shutdown_for_test(
     run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
         Ok(StartupReconciliationReport::default())
     })
+}
+
+fn socket_send_buffer_size(stream: &UnixStream) -> usize {
+    let mut size = 0_i32;
+    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &mut size as *mut i32 as *mut libc::c_void,
+            &mut size_len,
+        )
+    };
+    assert_eq!(result, 0, "SO_SNDBUF should be readable");
+    usize::try_from(size).expect("SO_SNDBUF should be non-negative")
 }
 
 #[test]
@@ -525,6 +549,7 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     let daemon_shutdown = shutdown.clone();
     let (completed_tx, completed_rx) = mpsc::channel();
     let executor = BurstProgressExecutor::new(completed_tx);
+    let offered_progress_bytes = executor.total_progress_bytes();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
     });
@@ -532,6 +557,11 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
 
     let mut client =
         Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
+    let send_buffer_size = socket_send_buffer_size(client.as_ref().expect("client should exist"));
+    assert!(
+        offered_progress_bytes > send_buffer_size * 16,
+        "test must offer enough progress to saturate the socket send buffer: offered={offered_progress_bytes} SO_SNDBUF={send_buffer_size}"
+    );
     writeln!(
         client.as_mut().expect("client should exist"),
         "{}",
@@ -545,7 +575,7 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     )
     .expect("client request should write");
 
-    if completed_rx.recv_timeout(Duration::from_secs(1)).is_err() {
+    if completed_rx.recv_timeout(Duration::from_secs(5)).is_err() {
         drop(client.take());
         shutdown.store(true, Ordering::Release);
         handle
@@ -583,9 +613,49 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
         }
     };
 
-    drop(client.take());
     joiner.join().expect("join helper should join");
     join_result.expect("daemon should exit cleanly");
+
+    let client = client.take().expect("client should still be connected");
+    client
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("client read timeout should be set");
+    let mut reader = std::io::BufReader::new(client);
+    let mut lines = Vec::new();
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader
+            .read_line(&mut line)
+            .expect("daemon stream should remain valid JSONL until EOF");
+        if bytes_read == 0 {
+            break;
+        }
+        lines.push(line);
+    }
+
+    assert!(
+        !lines.is_empty(),
+        "daemon should write at least the terminal response"
+    );
+    let mut progress_frames = 0_usize;
+    let mut saw_terminal_outcome = false;
+    for line in &lines {
+        let value: serde_json::Value =
+            serde_json::from_str(line).expect("daemon must not emit partial JSON frames");
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("progress") => progress_frames += 1,
+            Some("session_outcome") => saw_terminal_outcome = true,
+            other => panic!("unexpected response type after saturated progress writes: {other:?}"),
+        }
+    }
+    assert!(
+        saw_terminal_outcome,
+        "terminal outcome must survive saturated progress writes: {lines:?}"
+    );
+    assert!(
+        progress_frames < SATURATING_PROGRESS_EVENTS,
+        "saturated non-reading client should force progress drops, got all {progress_frames} frames"
+    );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
     }

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -7,7 +7,7 @@ use agentd::config::{Config, ConfigError};
 use agentd::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 use agentd_runner::{
     InvocationInput, ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
-    SessionSpec,
+    SessionProgressObserver, SessionSpec,
 };
 use serde_json::json;
 
@@ -59,6 +59,7 @@ impl SessionExecutor for RecordingExecutor {
         &self,
         spec: SessionSpec,
         invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         let mut state = self.state.lock().expect("recording state should lock");
         state.last_spec = Some(spec);

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -259,6 +259,40 @@ fn operator_intent_documentation_describes_wish_and_run_intent_boundaries() {
 }
 
 #[test]
+fn manual_session_documentation_describes_live_progress_observation() {
+    let readme = read_workspace_file("README.md");
+    let quickstart = read_workspace_file("docs/quickstart.md");
+    let socket_protocol = read_workspace_file("docs/socket-protocol.md");
+    let architecture = read_workspace_file("ARCHITECTURE.md");
+    let changelog = read_workspace_file("CHANGELOG.md");
+
+    assert!(
+        readme.contains("`agentd wish` and `agentd run` stream live session progress")
+            && readme.contains("--progress summary")
+            && readme.contains("--progress full"),
+        "README should document live progress and its verbosity controls"
+    );
+    assert!(
+        quickstart.contains("streams live progress in that terminal"),
+        "quickstart should tell operators that the launching command shows progress"
+    );
+    assert!(
+        socket_protocol.contains("\"type\": \"progress\"")
+            && socket_protocol.contains("dispatch_started")
+            && socket_protocol.contains("--progress full"),
+        "socket protocol docs should describe progress frames and CLI rendering levels"
+    );
+    assert!(
+        architecture.contains("progress frames over that same client connection"),
+        "ARCHITECTURE.md should explain that live observation stays on the manual client connection"
+    );
+    assert!(
+        changelog.contains("stream live session progress"),
+        "CHANGELOG.md should record the operator-facing live progress feature"
+    );
+}
+
+#[test]
 fn release_adoption_verification_checks_hostile_user_config_cannot_override_workspace_pins() {
     let script = read_workspace_file("scripts/verify-release-adoption.sh");
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,8 +72,9 @@ In a second shell, trigger the canonical integration intent
 `wish` greets you and prompts for the statement. For this smoke test, enter
 ``add a `greet(name)` function`` at the intent prompt and leave the target
 prompt blank. The command streams live progress in that terminal while it waits
-for the session to finish, then reports the terminal outcome. `success` means
-the work completed; any other label is
+for the session to finish, printing concise transcript event names by default.
+Use `--progress full` to include raw transcript event detail. It then reports
+the terminal outcome. `success` means the work completed; any other label is
 interpreted per
 [commons EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,8 +71,9 @@ In a second shell, trigger the canonical integration intent
 
 `wish` greets you and prompts for the statement. For this smoke test, enter
 ``add a `greet(name)` function`` at the intent prompt and leave the target
-prompt blank. The command blocks until the session reaches a terminal outcome
-and reports it. `success` means the work completed; any other label is
+prompt blank. The command streams live progress in that terminal while it waits
+for the session to finish, then reports the terminal outcome. `success` means
+the work completed; any other label is
 interpreted per
 [commons EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
 

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -59,11 +59,13 @@ target prompt; `agentd run --intent` has no target flag.
 
 `{"type": "pong"}` — answer to `ping`.
 
-`{"type": "progress", "progress": {"stage": "dispatch_started", ...}}` —
-non-terminal live progress for a run request. `agentd wish` and `agentd run`
-render these frames in the invoking terminal while they wait for the terminal
-outcome; `--progress summary` is the default and `--progress full` includes
-all fields carried by the frame.
+`{"type": "progress", "progress": {"stage": "...", ...}}` — non-terminal
+live progress for a run request. `dispatch_started` is a start marker;
+`transcript_event` carries execution-phase events from the running session's
+`agentd/transcript/events.jsonl` stream. `agentd wish` and `agentd run` render
+these frames in the invoking terminal while they wait for the terminal outcome;
+`--progress summary` prints concise event names and `--progress full` includes
+the raw transcript event line.
 
 `{"type": "error", "message": "..."}` — the request was rejected before a
 session outcome existed (malformed request, unknown agent, dispatch
@@ -81,6 +83,13 @@ operator connection and is dispatching it into session execution:
 
 ```json
 {"type":"progress","progress":{"stage":"dispatch_started","agent":"site-builder","work_unit":"issue-42","input_present":false}}
+```
+
+`transcript_event` means the running session appended a structured transcript
+event that the daemon forwarded before the terminal outcome:
+
+```json
+{"type":"progress","progress":{"stage":"transcript_event","session_id":"7f5a1c2d9e0b3a44","line":"{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"...\"}"}}
 ```
 
 ## Outcome statuses

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -15,11 +15,12 @@ integration surfaces are the CLI and the audit record
 ## Framing and connection lifecycle
 
 - Transport: `SOCK_STREAM` Unix domain socket.
-- Framing: newline-delimited JSON — one request line, one response line.
-- Lifecycle: connect → write one request + `\n` → read one response line →
-  connection closes. One session trigger per connection; the response is
-  not written until the session reaches a terminal outcome, so `run`
-  connections stay open for the session's duration.
+- Framing: newline-delimited JSON — one request line, followed by one or
+  more response lines.
+- Lifecycle: connect → write one request + `\n` → read response lines until
+  one terminal `session_outcome` or `error` line → connection closes. One
+  session trigger per connection; `run` connections stay open for the
+  session's duration and may carry progress lines before the terminal line.
 - An empty connection (EOF before a line) is ignored. A malformed request
   line gets an `error` response.
 
@@ -58,6 +59,12 @@ target prompt; `agentd run --intent` has no target flag.
 
 `{"type": "pong"}` — answer to `ping`.
 
+`{"type": "progress", "progress": {"stage": "dispatch_started", ...}}` —
+non-terminal live progress for a run request. `agentd wish` and `agentd run`
+render these frames in the invoking terminal while they wait for the terminal
+outcome; `--progress summary` is the default and `--progress full` includes
+all fields carried by the frame.
+
 `{"type": "error", "message": "..."}` — the request was rejected before a
 session outcome existed (malformed request, unknown agent, dispatch
 failure).
@@ -66,6 +73,15 @@ failure).
 session ran to a terminal outcome. A `session_outcome` response means the
 transport and dispatch succeeded; the work may still have failed — read
 `status`.
+
+### Progress stages
+
+`dispatch_started` means the daemon has accepted the run request on the
+operator connection and is dispatching it into session execution:
+
+```json
+{"type":"progress","progress":{"stage":"dispatch_started","agent":"site-builder","work_unit":"issue-42","input_present":false}}
+```
 
 ## Outcome statuses
 

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -65,7 +65,13 @@ live progress for a run request. `dispatch_started` is a start marker;
 `agentd/transcript/events.jsonl` stream. `agentd wish` and `agentd run` render
 these frames in the invoking terminal while they wait for the terminal outcome;
 `--progress summary` prints concise event names and `--progress full` includes
-the raw transcript event line.
+the raw transcript event line. Progress delivery is best-effort: oversized
+transcript records and progress frames that cannot fit without preserving room
+for the terminal response are dropped whole. The daemon never emits partial
+progress JSON frames, and the terminal `session_outcome` or terminal `error`
+remains the authoritative completion response. CLI rendering control-escapes
+untrusted request and transcript fields before they reach the operator's
+terminal.
 
 `{"type": "error", "message": "..."}` — the request was rejected before a
 session outcome existed (malformed request, unknown agent, dispatch


### PR DESCRIPTION
## Summary

Regenerates the live observation implementation for #122 so `agentd wish` and `agentd run` show session-owned progress during execution, not only a dispatch/start banner.

- adds a runner progress observer that tails active `agentd/transcript/events.jsonl` while the session container is running
- forwards transcript events over the daemon socket as `transcript_event` progress frames
- renders `--progress summary` as concise event names and `--progress full` with session id plus raw transcript event detail
- updates CLI help, README, architecture, socket protocol, quickstart, and changelog language to match the execution-phase stream

## Contract coverage

- Manual `wish`/`run` launch path streams progress over the invoking daemon connection while waiting for the terminal `SessionOutcome`.
- The stream is derived from the running session transcript events, so a dispatch-only implementation fails the daemon socket test.
- Summary and full progress levels differ in the detail shown.
- Help and docs describe live transcript observation and the control flag.

## Verification

- `cargo build`
- `cargo test`
- `cargo clippy --all-targets`
- `cargo fmt --check`

## Gated evidence

The requested real-session demonstration is still environment-gated here: this host does not have `podman` installed (`podman: command not found`). The non-deployment-gated automated proxy is included and passing.
