### PR TITLE
fix(cli): reframe wish copy to desired state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agentd run` now supports work-mode invocation from a matching supplied
   `work-unit` artifact, using `--work-unit <ID> --artifact-type work-unit
   --artifact-file <ID>.json`.
-- `agentd wish` starts an intent-seeded session through an evocative
+- `agentd wish` starts an intent-seeded session through a desired-state
   operator prompt, collecting the statement and optional target before reusing
   the existing canonical intent intake.
 
@@ -64,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   socket `IntentText` variant, and `.runa/workspace/intent/operator-input.json`
   materialization. The generic `--artifact-file` path remains a full-document
   intake for any declared artifact type.
+
+- `agentd wish` now frames its greeting, statement prompt, optional target
+  prompt, help text, and wish-input errors around the desired state the operator
+  wants made true.
 
 - README hero rewritten for the ecosystem README pass: positions agentd as
   the daemon for running autonomous agents like production workloads, with

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Manual operator sessions flow through `agentd wish` or `agentd run`, and
 scheduled runs dispatch through the same daemon socket intake without
 introducing a separate job type.
 Operators may also start an intent-seeded session with `agentd wish`, which
-prompts for the intent statement and optional target before dispatching through
-that same socket intake. Manual runs may carry per-invocation work input
+prompts for the desired-state statement and optional target before dispatching
+through that same socket intake. Manual runs may carry per-invocation work input
 without modifying the agent: intent text can be synthesized into a canonical
 intent artifact, and complete JSON artifacts can be placed directly into the
 session workspace when the active methodology declares the relevant artifact
@@ -286,10 +286,12 @@ For operator intent, use `wish`:
 agentd wish site-builder
 ```
 
-`wish` greets the operator and prompts for the statement and optional target.
-When the target prompt is left blank, agentd authors `{statement, source}`.
-When a target is supplied, agentd authors `{statement, target, source}` and
-passes the target through unchanged for the runtime to interpret.
+`wish` greets the operator with `Speak a wish: the state you want made true.`,
+asks `What do you wish to be true?`, and then offers the optional target prompt
+`What is this wish aimed at? Leave blank if it has no target.` When the target
+prompt is left blank, agentd authors `{statement, source}`. When a target is
+supplied, agentd authors `{statement, target, source}` and passes the target
+through unchanged for the runtime to interpret.
 
 Manual invocation also supports lower-level intake-mode and work-mode
 surfaces:

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -15,9 +15,10 @@ use clap::{Args, Parser, Subcommand};
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 
 const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
-const WISH_GREETING: &str = "Speak your wish.";
-const WISH_STATEMENT_PROMPT: &str = "What do you wish the agent to do?";
-const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank for prose only.";
+const WISH_GREETING: &str = "Speak a wish: the state you want made true.";
+const WISH_STATEMENT_PROMPT: &str = "What do you wish to be true?";
+const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank if it has no target.";
+const WISH_ABOUT: &str = "Elicit a wish and seed one governed session.";
 
 #[derive(Debug)]
 enum RunCommandError {
@@ -86,7 +87,7 @@ impl fmt::Display for RunCommandError {
                 )
             }
             Self::EmptyWishStatement => {
-                write!(f, "wish statement must not be empty")
+                write!(f, "wish statement must name a desired state")
             }
         }
     }
@@ -132,10 +133,10 @@ enum Command {
         #[arg(long, requires = "artifact_file")]
         artifact_type: Option<String>,
     },
-    /// Greet the operator, elicit intent, and seed a session.
     #[command(
         display_name = "agentd",
-        after_help = "Prompts:\n  Speak your wish.\n  What do you wish the agent to do?\n  What is this wish aimed at? Leave blank for prose only."
+        about = WISH_ABOUT,
+        after_help = wish_after_help()
     )]
     Wish {
         agent: String,
@@ -158,6 +159,10 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn wish_after_help() -> String {
+    format!("Prompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}")
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -334,7 +339,7 @@ fn prompt_line<R: BufRead, W: Write>(
     if bytes_read == 0 {
         return Err(Box::new(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
-            "wish prompt reached end of input",
+            "wish input ended before the wish was complete",
         )));
     }
 

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -473,12 +473,14 @@ fn binary_wish_help_shows_evocative_intent_prompting_surface() {
         "wish help should advertise socket override: {stdout}"
     );
     assert!(
-        stdout.contains("What do you wish the agent to do?"),
-        "wish help should document the statement prompt: {stdout}"
+        stdout.contains("Elicit a wish and seed one governed session."),
+        "wish help should describe the wish session boundary exactly: {stdout}"
     );
     assert!(
-        stdout.contains("What is this wish aimed at?"),
-        "wish help should document the optional target prompt: {stdout}"
+        stdout.contains(
+            "Prompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
+        ),
+        "wish help should document the exact prompt block: {stdout}"
     );
 }
 
@@ -916,15 +918,15 @@ fn binary_wish_command_prompts_and_forwards_prose_as_intent_text() {
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
     assert!(
-        stdout.contains("Speak your wish."),
+        stdout.contains("Speak a wish: the state you want made true."),
         "wish should greet the operator before prompting: {stdout}"
     );
     assert!(
-        stdout.contains("What do you wish the agent to do?"),
+        stdout.contains("What do you wish to be true?"),
         "wish should elicit an intent statement: {stdout}"
     );
     assert!(
-        stdout.contains("What is this wish aimed at?"),
+        stdout.contains("What is this wish aimed at? Leave blank if it has no target."),
         "wish should elicit an optional target: {stdout}"
     );
 
@@ -992,6 +994,20 @@ fn binary_wish_command_forwards_target_bearing_intent_text_verbatim() {
         output.status.success(),
         "wish command should succeed with target-bearing input: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+    assert!(
+        stdout.contains("Speak a wish: the state you want made true."),
+        "wish should greet the operator before prompting: {stdout}"
+    );
+    assert!(
+        stdout.contains("What do you wish to be true?"),
+        "wish should elicit an intent statement: {stdout}"
+    );
+    assert!(
+        stdout.contains("What is this wish aimed at? Leave blank if it has no target."),
+        "wish should elicit an optional target: {stdout}"
     );
 
     let invocation = invocations.lock().expect("invocations should lock")[0].clone();

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -69,11 +69,13 @@ In a second shell, trigger the canonical integration intent
 ./target/release/agentd wish site-builder
 ```
 
-`wish` greets you and prompts for the statement. For this smoke test, enter
-``add a `greet(name)` function`` at the intent prompt and leave the target
-prompt blank. The command blocks until the session reaches a terminal outcome
-and reports it. `success` means the work completed; any other label is
-interpreted per
+`wish` greets you with `Speak a wish: the state you want made true.` and asks
+`What do you wish to be true?` For this smoke test, enter
+``add a `greet(name)` function`` at that statement prompt, then leave the target
+prompt blank when asked `What is this wish aimed at? Leave blank if it has no
+target.` The command blocks until the session reaches a terminal outcome and
+reports it. `success` means the work completed; any other label is interpreted
+per
 [commons EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
 
 ## 6. Inspect the audit record


### PR DESCRIPTION
## Summary

Implements tesserine/agentd#166 against the accepted plan in comment 4892801769 and the contract of record in comment 4892670830.

- Re-derived the `agentd wish` operator-visible copy to desired-state framing.
- Made the `after_help` prompt block derive from the prompt constants instead of a second hand-synced literal.
- Updated the three contract-named CLI surface tests so prompt copy is pinned as independent full-string assertions, including the target-bearing test that previously pinned no prompt copy.
- Updated README, quickstart, and changelog prose that quotes or describes the shipped prompt surface while preserving the doc fragments pinned by `workspace_contract.rs::operator_intent_documentation_describes_wish_and_run_intent_boundaries`.

## Derivation

| String | Constituent that earns it |
|---|---|
| `Speak a wish: the state you want made true.` | Orients a cold operator to the act as desired-state content. |
| `What do you wish to be true?` | Elicits the WHAT, not a procedure or task list. |
| `What is this wish aimed at? Leave blank if it has no target.` | Keeps the aim optional and teaches how to release the wish without one. |
| `Elicit a wish and seed one governed session.` | Promises the command's actual behavior without promising realization. |
| `Prompts:\n  ...` help block | Derived from the prompt constants so the second rendered locus cannot drift by hand. |
| `wish statement must name a desired state` | Names the missing desired-state statement at the surface that rejects it. |
| `wish input ended before the wish was complete` | Names incomplete wish input without changing flow, variants, or exit behavior. |

## RED/GREEN Evidence

RED, after updating only the test pins and before changing production copy:

```sh
cargo test --test cli_surface binary_wish -- --nocapture
```

Result: failed as expected. All three contract-named tests failed against the pre-change copy:

- `binary_wish_help_shows_evocative_intent_prompting_surface`
- `binary_wish_command_prompts_and_forwards_prose_as_intent_text`
- `binary_wish_command_forwards_target_bearing_intent_text_verbatim`

GREEN after implementation:

```sh
cargo test --test cli_surface binary_wish -- --nocapture
```

Result: passed, 3 passed.

## Verification

```sh
cargo fmt --check
cargo build
cargo test --workspace
cargo clippy --all-targets
```

All passed.

Additional sweeps:

- Old prompt/process-framed fragments removed from the scoped docs/code/tests: `What do you wish the agent to do`, `Speak your wish`, `Leave blank for prose only`, `intent prompt`, `prompts for the intent statement`, `evocative operator prompt`.
- `cargo test --test workspace_contract operator_intent_documentation_describes_wish_and_run_intent_boundaries` passed, preserving the plan-protected doc pins.

## Scope

Copy-only. No grammar, schema, flow, target interpretation, error variants, or exit-code behavior changed.

Refs #166
