### PR TITLE
feat(cli): stream live session progress

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,11 +166,11 @@ received, so client and daemon responsibility boundaries stay clean.
 While a manual `agentd wish` or `agentd run` request is in flight, the daemon
 may send progress frames over that same client connection before the terminal
 session outcome. The runner tails the active transcript event stream it already
-owns under `agentd/transcript/events.jsonl`, and the daemon forwards those
-events to the launching client while the session executes. The CLI renders
-those frames according to the operator's selected progress level, so the
-launching terminal can observe the session without knowing container names,
-daemon log layout, or audit-record paths.
+owns under runa's nested per-stage transcript event store, and the daemon
+forwards those events to the launching client while the session executes. The
+CLI renders those frames according to the operator's selected progress level,
+so the launching terminal can observe the session without knowing container
+names, daemon log layout, or audit-record paths.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,7 +316,9 @@ layout:
 - `runa/` — preserved runa state written naturally by the runtime
 - `agentd/transcript/deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.jsonl` — structured transcript events emitted by
   runa and runa-mcp when observable; deployment and run id are agentd-owned
-  values injected through the runa environment
+  values injected through the runa environment. agentd opens this nested path
+  component by component from the trusted transcript base without following
+  symlinked ancestors.
 - `agentd/transcript/transcript.md` — human-readable rendering of the event
   stream
 - `agentd/transcript/manifest.json` — transcript manifest schema version,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,9 +165,12 @@ default-repo resolution happen daemon-side after the socket request is
 received, so client and daemon responsibility boundaries stay clean.
 While a manual `agentd wish` or `agentd run` request is in flight, the daemon
 may send progress frames over that same client connection before the terminal
-session outcome. The CLI renders those frames according to the operator's
-selected progress level, so the launching terminal can observe the session
-without knowing container names, daemon log layout, or audit-record paths.
+session outcome. The runner tails the active transcript event stream it already
+owns under `agentd/transcript/events.jsonl`, and the daemon forwards those
+events to the launching client while the session executes. The CLI renders
+those frames according to the operator's selected progress level, so the
+launching terminal can observe the session without knowing container names,
+daemon log layout, or audit-record paths.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,6 +163,11 @@ and operators must either fix the XDG runtime environment or provide explicit
 paths. There is no implicit `/tmp` or `/run` fallback. Agent lookup and
 default-repo resolution happen daemon-side after the socket request is
 received, so client and daemon responsibility boundaries stay clean.
+While a manual `agentd wish` or `agentd run` request is in flight, the daemon
+may send progress frames over that same client connection before the terminal
+session outcome. The CLI renders those frames according to the operator's
+selected progress level, so the launching terminal can observe the session
+without knowing container names, daemon log layout, or audit-record paths.
 
 Operational visibility for that lifecycle uses structured tracing events written
 to stderr. The production default is timestamped JSON lines at `info` so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,7 +200,7 @@ The runner prepares the execution environment:
 
 ### Phase 3: Execution (`agentd-runner`)
 
-The runner drops privileges with `gosu` and launches `runa run [--work-unit <id>] --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange. agentd sets `RUNA_TRANSCRIPT_DIR=/agentd/transcript` and `RUNA_TRANSCRIPT_REDACT_ENV` so runa can persist the execution events it observes.
+The runner drops privileges with `gosu` and launches `runa run [--work-unit <id>] --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange. agentd sets `RUNA_TRANSCRIPT_DIR=/agentd/transcript`, `RUNA_TRANSCRIPT_DEPLOYMENT`, `RUNA_TRANSCRIPT_RUN_ID`, and `RUNA_TRANSCRIPT_REDACT_ENV` so runa can persist the execution events it observes at an agentd-addressable nested path without linking agentd to runa internals.
 
 ### Phase 4: Teardown (`agentd-runner`)
 
@@ -314,12 +314,14 @@ Host audit records live under the resolved audit root, by default
 layout:
 
 - `runa/` — preserved runa state written naturally by the runtime
-- `agentd/transcript/events.jsonl` — structured transcript events emitted by
-  runa and runa-mcp when observable
+- `agentd/transcript/deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.jsonl` — structured transcript events emitted by
+  runa and runa-mcp when observable; deployment and run id are agentd-owned
+  values injected through the runa environment
 - `agentd/transcript/transcript.md` — human-readable rendering of the event
   stream
-- `agentd/transcript/manifest.json` — transcript schema version and coverage:
-  `full`, `missing_mcp_events`, `no_events`, or `finalization_failed`
+- `agentd/transcript/manifest.json` — transcript manifest schema version,
+  event schema versions, and coverage: `full`, `missing_mcp_events`,
+  `no_events`, or `finalization_failed`
 - `agentd/session.json` — agentd-written metadata (`schema_version: 2`,
   `session_id`, `agent`, `repo_url`, optional `work_unit`, timestamps, outcome,
   exit code when applicable) written by atomic temp-file replacement within the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the existing canonical intent intake.
 - `agentd wish` and `agentd run` now stream live session progress in the
   invoking terminal, with `--progress summary` as the default and
-  `--progress full` for all fields currently carried by progress frames.
+  `--progress full` for raw transcript event detail while the session executes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agentd wish` starts an intent-seeded session through a desired-state
   operator prompt, collecting the statement and optional target before reusing
   the existing canonical intent intake.
+- `agentd wish` and `agentd run` now stream live session progress in the
+  invoking terminal, with `--progress summary` as the default and
+  `--progress full` for all fields currently carried by progress frames.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "time",
  "toml",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -383,9 +383,11 @@ under `deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.json
 a human-readable `transcript.md`, and `manifest.json` with coverage of `full`,
 `missing_mcp_events`, `no_events`, or `finalization_failed`. agentd injects the
 deployment and run id that address the runa event store, and the manifest records
-the runa event schema versions it assembled. Full MCP tool-call coverage depends
-on the agent runtime launching `runa-mcp`; otherwise the transcript still records
-the observable runa boundary without claiming MCP events that never occurred.
+the runa event schema versions it assembled. Nested transcript reads refuse
+symlinked ancestors below `agentd/transcript` rather than following them outside
+the audit record. Full MCP tool-call coverage depends on the agent runtime
+launching `runa-mcp`; otherwise the transcript still records the observable runa
+boundary without claiming MCP events that never occurred.
 
 If teardown cleanup fails, or if audit finalization attempts closeout and
 fails, metadata remains intentionally incomplete with no `end_timestamp` or

--- a/README.md
+++ b/README.md
@@ -316,9 +316,8 @@ The file stem becomes the artifact id, so the file stem must match
 
 `agentd wish` and `agentd run` stream live session progress to the invoking
 terminal while the daemon runs the session. The default `--progress summary`
-prints concise lifecycle output before the terminal `session <status>` line;
-`--progress full` includes every field currently carried by the progress
-stream.
+prints concise transcript event names before the terminal `session <status>`
+line; `--progress full` includes the session id and raw transcript event line.
 
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:

--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ agentd run site-builder --work-unit issue-42 --artifact-type work-unit --artifac
 The file stem becomes the artifact id, so the file stem must match
 `--work-unit`.
 
+`agentd wish` and `agentd run` stream live session progress to the invoking
+terminal while the daemon runs the session. The default `--progress summary`
+prints concise lifecycle output before the terminal `session <status>` line;
+`--progress full` includes every field currently carried by the progress
+stream.
+
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:
 

--- a/README.md
+++ b/README.md
@@ -379,11 +379,13 @@ persists on the host under the resolved audit root
 `<audit_root>/<agent>/<session_id>/`, with runa state in `runa/`, agentd
 metadata in `agentd/session.json`, and transcript artifacts in
 `agentd/transcript/`. Transcript artifacts include structured JSON Lines events
-at `events.jsonl`, a human-readable `transcript.md`, and `manifest.json` with
-coverage of `full`, `missing_mcp_events`, `no_events`, or
-`finalization_failed`. Full MCP tool-call coverage depends on the agent runtime
-launching `runa-mcp`; otherwise the transcript still records the observable runa
-boundary without claiming MCP events that never occurred.
+under `deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.jsonl`,
+a human-readable `transcript.md`, and `manifest.json` with coverage of `full`,
+`missing_mcp_events`, `no_events`, or `finalization_failed`. agentd injects the
+deployment and run id that address the runa event store, and the manifest records
+the runa event schema versions it assembled. Full MCP tool-call coverage depends
+on the agent runtime launching `runa-mcp`; otherwise the transcript still records
+the observable runa boundary without claiming MCP events that never occurred.
 
 If teardown cleanup fails, or if audit finalization attempts closeout and
 fails, metadata remains intentionally incomplete with no `end_timestamp` or

--- a/crates/agentd-runner/Cargo.toml
+++ b/crates/agentd-runner/Cargo.toml
@@ -12,6 +12,7 @@ jsonschema = { version = "0.46.2", default-features = false }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 time = { version = "0.3.44", features = ["formatting"] }
 toml = "0.8"
 tracing = "0.1.41"

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -41,7 +41,7 @@
 //!   user-namespace re-entry happens during finalization; the startup
 //!   audit-root probe verified this authority before any dispatch.
 
-use crate::transcript::{TranscriptEventSource, TranscriptIdentity};
+use crate::transcript::{TranscriptEventFile, TranscriptEventSource, TranscriptIdentity};
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
 use serde_json::Value;
@@ -53,7 +53,7 @@ use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
@@ -247,8 +247,8 @@ fn finalize_session_transcript_artifacts(
     let event_paths = source
         .discover_event_files()
         .map_err(|error| runner_artifact_failure(EVENTS_ARTIFACT, error))?;
-    let summary = transcript_summary(&event_paths)?;
-    write_transcript_markdown(record, &event_paths)?;
+    let summary = transcript_summary(&source, &event_paths)?;
+    write_transcript_markdown(record, &source, &event_paths)?;
     write_transcript_manifest(
         record,
         summary.coverage(),
@@ -354,7 +354,8 @@ fn write_transcript_manifest(
 
 fn write_transcript_markdown(
     record: &SessionAuditRecord,
-    event_paths: &[PathBuf],
+    source: &TranscriptEventSource,
+    event_paths: &[TranscriptEventFile],
 ) -> Result<(), TranscriptFinalizationFailure> {
     let mut markdown = create_new_transcript_artifact(
         &record.transcript_dir.join(MARKDOWN_ARTIFACT),
@@ -366,8 +367,8 @@ fn write_transcript_markdown(
 
     let mut line = String::new();
     let mut wrote_event = false;
-    for event_path in event_paths {
-        let events = open_transcript_events(event_path)?;
+    for event_file in event_paths {
+        let events = open_transcript_events(source, event_file)?;
         let mut reader = BufReader::new(events);
         loop {
             line.clear();
@@ -414,41 +415,13 @@ fn write_transcript_markdown(
     Ok(())
 }
 
-fn open_transcript_events(path: &Path) -> Result<File, TranscriptFinalizationFailure> {
-    let metadata = match fs::symlink_metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) => return Err(artifact_failure(EVENTS_ARTIFACT, error)),
-    };
-
-    if !metadata.is_file() {
-        return Err(unsafe_artifact_failure(
-            EVENTS_ARTIFACT,
-            "is not a regular file",
-        ));
-    }
-
-    let file = OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
-        .open(path)
-        .map_err(|error| match error.raw_os_error() {
-            Some(libc::ELOOP) => unsafe_artifact_failure(EVENTS_ARTIFACT, "is not a regular file"),
-            _ => artifact_failure(EVENTS_ARTIFACT, error),
-        })?;
-    let open_metadata = file
-        .metadata()
-        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
-    if !open_metadata.is_file()
-        || open_metadata.dev() != metadata.dev()
-        || open_metadata.ino() != metadata.ino()
-    {
-        return Err(unsafe_artifact_failure(
-            EVENTS_ARTIFACT,
-            "is not a regular file",
-        ));
-    }
-
-    Ok(file)
+fn open_transcript_events(
+    source: &TranscriptEventSource,
+    event_file: &TranscriptEventFile,
+) -> Result<File, TranscriptFinalizationFailure> {
+    source
+        .open_event_file(event_file)
+        .map_err(|error| runner_artifact_failure(EVENTS_ARTIFACT, error))
 }
 
 fn write_new_transcript_artifact(
@@ -564,11 +537,12 @@ impl TranscriptSummary {
 }
 
 fn transcript_summary(
-    event_paths: &[PathBuf],
+    source: &TranscriptEventSource,
+    event_paths: &[TranscriptEventFile],
 ) -> Result<TranscriptSummary, TranscriptFinalizationFailure> {
     let mut summary = TranscriptSummary::default();
-    for event_path in event_paths {
-        let events = open_transcript_events(event_path)?;
+    for event_file in event_paths {
+        let events = open_transcript_events(source, event_file)?;
         summarize_transcript_events(events, &mut summary)?;
     }
     Ok(summary)
@@ -1564,12 +1538,11 @@ mod tests {
         )
         .expect("first nested event file should be written");
 
-        assert_eq!(
-            source
-                .discover_event_files()
-                .expect("first discovery should succeed"),
-            vec![first_path.clone()]
-        );
+        let discovered = source
+            .discover_event_files()
+            .expect("first discovery should succeed");
+        let discovered_paths: Vec<_> = discovered.iter().map(|event| event.path()).collect();
+        assert_eq!(discovered_paths, vec![first_path.as_path()]);
 
         let second_path = source.event_file_path_for_work_unit("take/stage#1");
         fs::create_dir_all(second_path.parent().expect("event path parent"))
@@ -1583,9 +1556,20 @@ mod tests {
         let discovered = source
             .discover_event_files()
             .expect("second discovery should succeed");
-        assert_eq!(discovered.len(), 2, "source must re-scan for new stages");
-        assert!(discovered.contains(&first_path), "{discovered:?}");
-        assert!(discovered.contains(&second_path), "{discovered:?}");
+        let discovered_paths: Vec<_> = discovered.iter().map(|event| event.path()).collect();
+        assert_eq!(
+            discovered_paths.len(),
+            2,
+            "source must re-scan for new stages"
+        );
+        assert!(
+            discovered_paths.contains(&first_path.as_path()),
+            "{discovered:?}"
+        );
+        assert!(
+            discovered_paths.contains(&second_path.as_path()),
+            "{discovered:?}"
+        );
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
@@ -1639,6 +1623,256 @@ mod tests {
         assert_eq!(manifest["event_schema_versions"], serde_json::json!([2]));
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_refuses_symlinked_nested_transcript_ancestors() {
+        use std::os::unix::fs::symlink;
+
+        for ancestor in SymlinkAncestor::refused_cases() {
+            let root = unique_test_dir(&format!(
+                "agentd-audit-symlinked-transcript-{}",
+                ancestor.name()
+            ));
+            let record = prepare_session_audit_record_at(
+                &root,
+                &format!("symlinked-{}", ancestor.name()),
+                &test_session_spec(),
+                &SessionInvocation {
+                    repo_url: "https://example.com/agentd.git".to_string(),
+                    repo_token: None,
+                    work_unit: None,
+                    input: None,
+                    timeout: None,
+                },
+            )
+            .expect("audit record should be created");
+            let outside_root = root.join("outside-transcript");
+            let outside_events = create_outside_nested_events(&record, &outside_root);
+            fs::set_permissions(&outside_events, fs::Permissions::from_mode(0o600))
+                .expect("outside events should start with controlled mode");
+            let before_mode = fs::metadata(&outside_events)
+                .expect("outside events metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777;
+
+            let link_path = ancestor.link_path(&record);
+            if let Some(parent) = link_path.parent() {
+                fs::create_dir_all(parent).expect("symlink parent should be created");
+            }
+            symlink(ancestor.outside_target(&record, &outside_root), &link_path)
+                .expect("symlinked transcript ancestor should be created");
+
+            let result = super::finalize_session_transcript(&record);
+
+            let after_mode = fs::metadata(&outside_events)
+                .expect("outside events metadata should exist")
+                .permissions()
+                .mode()
+                & 0o777;
+            let markdown =
+                fs::read_to_string(record.transcript_dir.join("transcript.md")).unwrap_or_default();
+            let manifest =
+                fs::read_to_string(record.transcript_dir.join("manifest.json")).unwrap_or_default();
+
+            assert!(
+                result.is_err(),
+                "known symlinked ancestor {} should be refused",
+                ancestor.name()
+            );
+            assert_eq!(
+                before_mode,
+                after_mode,
+                "outside target must not be chmoded through {}",
+                ancestor.name()
+            );
+            assert!(
+                !markdown.contains("outside secret"),
+                "outside events must not be rendered through {}: {markdown}",
+                ancestor.name()
+            );
+            assert!(
+                !manifest.contains("full"),
+                "outside events must not contribute coverage through {}: {manifest}",
+                ancestor.name()
+            );
+
+            fs::remove_file(link_path).expect("symlink should be removable");
+            make_tree_writable(&root);
+            fs::remove_dir_all(root).expect("temporary audit root should be removed");
+        }
+    }
+
+    #[test]
+    fn transcript_event_source_skips_symlinked_work_unit_entries() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_test_dir("agentd-audit-symlinked-work-unit-entry");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "symlinked-work-unit-entry",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let outside_root = root.join("outside-transcript");
+        let outside_events = create_outside_nested_events(&record, &outside_root);
+        let source = crate::transcript::TranscriptEventSource::from_record(&record);
+        let work_unit_link = source.event_file_path_for_work_unit("survey");
+        let work_unit_link = work_unit_link
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .expect("work-unit path should have an encoded work-unit ancestor")
+            .to_path_buf();
+        fs::create_dir_all(work_unit_link.parent().expect("work-unit parent"))
+            .expect("work-units directory should be created");
+        symlink(
+            outside_events
+                .parent()
+                .and_then(Path::parent)
+                .and_then(Path::parent)
+                .expect("outside events should have a work-unit ancestor"),
+            &work_unit_link,
+        )
+        .expect("symlinked work-unit entry should be created");
+
+        super::finalize_session_transcript(&record).expect("transcript should finalize safely");
+
+        let markdown = fs::read_to_string(record.transcript_dir.join("transcript.md"))
+            .expect("transcript markdown should exist");
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("manifest should exist"),
+        )
+        .expect("manifest should be json");
+        assert!(!markdown.contains("outside secret"), "{markdown}");
+        assert_eq!(manifest["coverage"], "no_events");
+
+        fs::remove_file(work_unit_link).expect("work-unit symlink should be removable");
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum SymlinkAncestor {
+        Deployments,
+        Deployment,
+        WorkUnits,
+        Runs,
+        RunId,
+    }
+
+    impl SymlinkAncestor {
+        fn refused_cases() -> [Self; 5] {
+            [
+                Self::Deployments,
+                Self::Deployment,
+                Self::WorkUnits,
+                Self::Runs,
+                Self::RunId,
+            ]
+        }
+
+        fn name(self) -> &'static str {
+            match self {
+                Self::Deployments => "deployments",
+                Self::Deployment => "deployment",
+                Self::WorkUnits => "work-units",
+                Self::Runs => "runs",
+                Self::RunId => "run-id",
+            }
+        }
+
+        fn link_path(self, record: &super::SessionAuditRecord) -> PathBuf {
+            let source = crate::transcript::TranscriptEventSource::from_record(record);
+            let event_path = source.event_file_path_for_work_unit("survey");
+            match self {
+                Self::Deployments => record.transcript_dir.join("deployments"),
+                Self::Deployment => event_path
+                    .ancestors()
+                    .nth(5)
+                    .expect("event path should have deployment ancestor")
+                    .to_path_buf(),
+                Self::WorkUnits => event_path
+                    .ancestors()
+                    .nth(4)
+                    .expect("event path should have work-units ancestor")
+                    .to_path_buf(),
+                Self::Runs => event_path
+                    .ancestors()
+                    .nth(2)
+                    .expect("event path should have runs ancestor")
+                    .to_path_buf(),
+                Self::RunId => event_path
+                    .parent()
+                    .expect("event path should have run-id parent")
+                    .to_path_buf(),
+            }
+        }
+
+        fn outside_target(
+            self,
+            record: &super::SessionAuditRecord,
+            outside_root: &Path,
+        ) -> PathBuf {
+            let source = crate::transcript::TranscriptEventSource::from_record(record);
+            let outside_events = outside_root.join(
+                source
+                    .event_file_path_for_work_unit("survey")
+                    .strip_prefix(&record.transcript_dir)
+                    .expect("event path should live under transcript dir"),
+            );
+            match self {
+                Self::Deployments => outside_root.join("deployments"),
+                Self::Deployment => outside_events
+                    .ancestors()
+                    .nth(5)
+                    .expect("outside event path should have deployment ancestor")
+                    .to_path_buf(),
+                Self::WorkUnits => outside_events
+                    .ancestors()
+                    .nth(4)
+                    .expect("outside event path should have work-units ancestor")
+                    .to_path_buf(),
+                Self::Runs => outside_events
+                    .ancestors()
+                    .nth(2)
+                    .expect("outside event path should have runs ancestor")
+                    .to_path_buf(),
+                Self::RunId => outside_events
+                    .parent()
+                    .expect("outside event path should have run-id parent")
+                    .to_path_buf(),
+            }
+        }
+    }
+
+    fn create_outside_nested_events(
+        record: &super::SessionAuditRecord,
+        outside_root: &Path,
+    ) -> PathBuf {
+        let source = crate::transcript::TranscriptEventSource::from_record(record);
+        let outside_events = outside_root.join(
+            source
+                .event_file_path_for_work_unit("survey")
+                .strip_prefix(&record.transcript_dir)
+                .expect("event path should live under transcript dir"),
+        );
+        fs::create_dir_all(outside_events.parent().expect("outside events parent"))
+            .expect("outside nested event directory should be created");
+        fs::write(
+            &outside_events,
+            "{\"schema_version\":2,\"source\":\"runa-mcp\",\"kind\":\"tool_call\",\"content\":\"outside secret\"}\n",
+        )
+        .expect("outside events should be written");
+        outside_events
     }
 
     fn write_nested_events(record: &super::SessionAuditRecord, work_unit: &str, events: &str) {

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -11,7 +11,7 @@
 //!    half-built record is never observable.
 //! 2. The session runs; runa writes `runa/` state and transcript events
 //!    arrive in `agentd/transcript/` through the session-user identity.
-//! 3. [`finalize_session_transcript`] — render `events.jsonl` into
+//! 3. [`finalize_session_transcript`] — render runa's nested event files into
 //!    `transcript.md` and record a coverage verdict in `manifest.json`.
 //!    A rendering failure is itself recorded (`finalization_failed`) so
 //!    the manifest never silently overstates coverage.
@@ -41,15 +41,17 @@
 //!   user-namespace re-entry happens during finalization; the startup
 //!   audit-root probe verified this authority before any dispatch.
 
+use crate::transcript::{TranscriptEventSource, TranscriptIdentity};
 use crate::{RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use serde::Serialize;
 use serde_json::Value;
 #[cfg(test)]
 use std::cell::Cell;
+use std::collections::BTreeSet;
 use std::ffi::CString;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
@@ -68,7 +70,7 @@ const SEALED_FILE_MODE: u32 = 0o444;
 /// Sealed directories: traversal without write, same tradeoff as files.
 const SEALED_DIRECTORY_MODE: u32 = 0o555;
 /// `manifest.json` schema version for the transcript coverage verdict.
-const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+const TRANSCRIPT_MANIFEST_SCHEMA_VERSION: u32 = 1;
 const EVENTS_ARTIFACT: &str = "events.jsonl";
 const MANIFEST_ARTIFACT: &str = "manifest.json";
 const MARKDOWN_ARTIFACT: &str = "transcript.md";
@@ -89,6 +91,7 @@ pub(crate) struct SessionAuditRecord {
     pub(crate) agent: String,
     pub(crate) repo_url: String,
     pub(crate) work_unit: Option<String>,
+    pub(crate) transcript_identity: TranscriptIdentity,
     pub(crate) start_timestamp: String,
 }
 
@@ -173,6 +176,11 @@ fn prepare_session_audit_record_at(
             agent: spec.agent_name.clone(),
             repo_url: invocation.repo_url.clone(),
             work_unit: invocation.work_unit.clone(),
+            transcript_identity: TranscriptIdentity::new(
+                &spec.forge_type,
+                &invocation.repo_url,
+                session_id,
+            ),
             start_timestamp,
         };
 
@@ -219,8 +227,13 @@ pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result
         Err(failure) => {
             let failure_message = failure.to_string();
             if failure.artifact != MANIFEST_ARTIFACT {
-                write_transcript_manifest(record, "finalization_failed", Some(&failure_message))
-                    .map_err(|manifest_failure| manifest_failure.error)?;
+                write_transcript_manifest(
+                    record,
+                    "finalization_failed",
+                    Vec::new(),
+                    Some(&failure_message),
+                )
+                .map_err(|manifest_failure| manifest_failure.error)?;
             }
             Err(failure.error)
         }
@@ -230,14 +243,18 @@ pub(crate) fn finalize_session_transcript(record: &SessionAuditRecord) -> Result
 fn finalize_session_transcript_artifacts(
     record: &SessionAuditRecord,
 ) -> Result<(), TranscriptFinalizationFailure> {
-    let events_path = record.transcript_dir.join(EVENTS_ARTIFACT);
-    let mut events = open_or_create_transcript_events(&events_path)?;
-    let coverage = transcript_coverage(&mut events)?;
-    events
-        .seek(SeekFrom::Start(0))
-        .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
-    write_transcript_markdown(record, &mut events)?;
-    write_transcript_manifest(record, coverage, None)?;
+    let source = TranscriptEventSource::from_record(record);
+    let event_paths = source
+        .discover_event_files()
+        .map_err(|error| runner_artifact_failure(EVENTS_ARTIFACT, error))?;
+    let summary = transcript_summary(&event_paths)?;
+    write_transcript_markdown(record, &event_paths)?;
+    write_transcript_manifest(
+        record,
+        summary.coverage(),
+        summary.event_schema_versions(),
+        None,
+    )?;
     Ok(())
 }
 
@@ -300,6 +317,7 @@ fn current_timestamp() -> Result<String, RunnerError> {
 struct TranscriptManifest<'a> {
     schema_version: u32,
     coverage: &'a str,
+    event_schema_versions: Vec<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     finalization_error: Option<&'a str>,
 }
@@ -322,11 +340,13 @@ fn write_transcript_manifest_payload(
 fn write_transcript_manifest(
     record: &SessionAuditRecord,
     coverage: &str,
+    event_schema_versions: Vec<u64>,
     finalization_error: Option<&str>,
 ) -> Result<(), TranscriptFinalizationFailure> {
     let manifest = TranscriptManifest {
-        schema_version: TRANSCRIPT_SCHEMA_VERSION,
+        schema_version: TRANSCRIPT_MANIFEST_SCHEMA_VERSION,
         coverage,
+        event_schema_versions,
         finalization_error,
     };
     write_transcript_manifest_payload(record, manifest)
@@ -334,7 +354,7 @@ fn write_transcript_manifest(
 
 fn write_transcript_markdown(
     record: &SessionAuditRecord,
-    events: &mut File,
+    event_paths: &[PathBuf],
 ) -> Result<(), TranscriptFinalizationFailure> {
     let mut markdown = create_new_transcript_artifact(
         &record.transcript_dir.join(MARKDOWN_ARTIFACT),
@@ -344,40 +364,43 @@ fn write_transcript_markdown(
         .write_all(b"# Session Transcript\n\n")
         .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
 
-    let mut reader = BufReader::new(events);
     let mut line = String::new();
     let mut wrote_event = false;
-    loop {
-        line.clear();
-        let bytes_read = reader
-            .read_line(&mut line)
-            .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
-        if bytes_read == 0 {
-            break;
-        }
-
-        let line = line.trim_end_matches(['\r', '\n']);
-        if line.trim().is_empty() {
-            continue;
-        }
-
-        wrote_event = true;
-        match serde_json::from_str::<Value>(line) {
-            Ok(event) => {
-                let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
-                writeln!(markdown, "## {kind}\n")
-                    .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
-                if let Some(content) = event.get("content").and_then(Value::as_str) {
-                    write_fenced_code_block(&mut markdown, "text", content)?;
-                } else {
-                    write_fenced_code_block(&mut markdown, "json", line)?;
-                }
+    for event_path in event_paths {
+        let events = open_transcript_events(event_path)?;
+        let mut reader = BufReader::new(events);
+        loop {
+            line.clear();
+            let bytes_read = reader
+                .read_line(&mut line)
+                .map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?;
+            if bytes_read == 0 {
+                break;
             }
-            Err(_) => {
-                markdown
-                    .write_all(b"## unparsed_event\n\n")
-                    .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
-                write_fenced_code_block(&mut markdown, "text", line)?;
+
+            let line = line.trim_end_matches(['\r', '\n']);
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            wrote_event = true;
+            match serde_json::from_str::<Value>(line) {
+                Ok(event) => {
+                    let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
+                    writeln!(markdown, "## {kind}\n")
+                        .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+                    if let Some(content) = event.get("content").and_then(Value::as_str) {
+                        write_fenced_code_block(&mut markdown, "text", content)?;
+                    } else {
+                        write_fenced_code_block(&mut markdown, "json", line)?;
+                    }
+                }
+                Err(_) => {
+                    markdown
+                        .write_all(b"## unparsed_event\n\n")
+                        .map_err(|error| artifact_failure(MARKDOWN_ARTIFACT, error))?;
+                    write_fenced_code_block(&mut markdown, "text", line)?;
+                }
             }
         }
     }
@@ -391,13 +414,9 @@ fn write_transcript_markdown(
     Ok(())
 }
 
-fn open_or_create_transcript_events(path: &Path) -> Result<File, TranscriptFinalizationFailure> {
+fn open_transcript_events(path: &Path) -> Result<File, TranscriptFinalizationFailure> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            create_empty_transcript_artifact(path, EVENTS_ARTIFACT)?;
-            fs::symlink_metadata(path).map_err(|error| artifact_failure(EVENTS_ARTIFACT, error))?
-        }
         Err(error) => return Err(artifact_failure(EVENTS_ARTIFACT, error)),
     };
 
@@ -430,15 +449,6 @@ fn open_or_create_transcript_events(path: &Path) -> Result<File, TranscriptFinal
     }
 
     Ok(file)
-}
-
-fn create_empty_transcript_artifact(
-    path: &Path,
-    artifact: &'static str,
-) -> Result<(), TranscriptFinalizationFailure> {
-    let file = create_new_transcript_artifact(path, artifact)?;
-    drop(file);
-    Ok(())
 }
 
 fn write_new_transcript_artifact(
@@ -477,6 +487,13 @@ fn artifact_failure(
         artifact,
         error: RunnerError::Io(error),
     }
+}
+
+fn runner_artifact_failure(
+    artifact: &'static str,
+    error: RunnerError,
+) -> TranscriptFinalizationFailure {
+    TranscriptFinalizationFailure { artifact, error }
 }
 
 fn unsafe_artifact_failure(artifact: &'static str, reason: &str) -> TranscriptFinalizationFailure {
@@ -523,11 +540,46 @@ fn max_consecutive_backticks(content: &str) -> usize {
     max
 }
 
-fn transcript_coverage(events: &mut File) -> Result<&'static str, TranscriptFinalizationFailure> {
+#[derive(Debug, Default)]
+struct TranscriptSummary {
+    saw_event: bool,
+    saw_mcp_event: bool,
+    event_schema_versions: BTreeSet<u64>,
+}
+
+impl TranscriptSummary {
+    fn coverage(&self) -> &'static str {
+        if self.saw_mcp_event {
+            "full"
+        } else if self.saw_event {
+            "missing_mcp_events"
+        } else {
+            "no_events"
+        }
+    }
+
+    fn event_schema_versions(&self) -> Vec<u64> {
+        self.event_schema_versions.iter().copied().collect()
+    }
+}
+
+fn transcript_summary(
+    event_paths: &[PathBuf],
+) -> Result<TranscriptSummary, TranscriptFinalizationFailure> {
+    let mut summary = TranscriptSummary::default();
+    for event_path in event_paths {
+        let events = open_transcript_events(event_path)?;
+        summarize_transcript_events(events, &mut summary)?;
+    }
+    Ok(summary)
+}
+
+fn summarize_transcript_events(
+    events: File,
+    summary: &mut TranscriptSummary,
+) -> Result<(), TranscriptFinalizationFailure> {
     let mut reader = BufReader::new(events);
     let mut line = String::new();
-    let mut saw_event = false;
-    let mut saw_mcp_event = false;
     loop {
         line.clear();
         let bytes_read = reader
@@ -542,26 +594,18 @@ fn transcript_coverage(events: &mut File) -> Result<&'static str, TranscriptFina
             continue;
         }
 
-        saw_event = true;
-        if serde_json::from_str::<Value>(line)
-            .ok()
-            .and_then(|event| {
-                (event.get("source").and_then(Value::as_str) == Some("runa-mcp")).then_some(())
-            })
-            .is_some()
-        {
-            saw_mcp_event = true;
+        summary.saw_event = true;
+        if let Ok(event) = serde_json::from_str::<Value>(line) {
+            if event.get("source").and_then(Value::as_str) == Some("runa-mcp") {
+                summary.saw_mcp_event = true;
+            }
+            if let Some(schema_version) = event.get("schema_version").and_then(Value::as_u64) {
+                summary.event_schema_versions.insert(schema_version);
+            }
         }
     }
 
-    let coverage = if saw_mcp_event {
-        "full"
-    } else if saw_event {
-        "missing_mcp_events"
-    } else {
-        "no_events"
-    };
-    Ok(coverage)
+    Ok(())
 }
 
 fn rollback_record_dir_on_error<T, F>(record_dir: &Path, init: F) -> Result<T, RunnerError>
@@ -1460,7 +1504,7 @@ mod tests {
     }
 
     #[test]
-    fn finalize_session_transcript_creates_empty_events_jsonl_when_no_events_were_emitted() {
+    fn finalize_session_transcript_reports_no_events_without_creating_flat_events_jsonl() {
         let root = unique_test_dir("agentd-audit-empty-transcript");
         let record = prepare_session_audit_record_at(
             &root,
@@ -1478,16 +1522,10 @@ mod tests {
 
         super::finalize_session_transcript(&record).expect("transcript should finalize");
 
-        let events_path = record.transcript_dir.join("events.jsonl");
-        let events =
-            fs::read_to_string(&events_path).expect("empty structured transcript should exist");
         assert!(
-            events.is_empty(),
-            "empty jsonl file should contain no events"
+            !record.transcript_dir.join("events.jsonl").exists(),
+            "agentd should not create a flat transcript event stream"
         );
-        for line in events.lines() {
-            let _event: Value = serde_json::from_str(line).expect("jsonl line should be json");
-        }
 
         let manifest: Value = serde_json::from_str(
             &fs::read_to_string(record.transcript_dir.join("manifest.json"))
@@ -1495,8 +1533,120 @@ mod tests {
         )
         .expect("manifest should be json");
         assert_eq!(manifest["coverage"], "no_events");
+        assert_eq!(manifest["event_schema_versions"], serde_json::json!([]));
 
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn transcript_event_source_discovers_stage_file_created_after_first_scan() {
+        let root = unique_test_dir("agentd-audit-nested-growth");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "nested-growth",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        let source = crate::transcript::TranscriptEventSource::from_record(&record);
+        let first_path = source.event_file_path_for_work_unit("survey");
+        fs::create_dir_all(first_path.parent().expect("event path parent"))
+            .expect("first nested event dir should be created");
+        fs::write(
+            &first_path,
+            "{\"schema_version\":2,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"survey\"}\n",
+        )
+        .expect("first nested event file should be written");
+
+        assert_eq!(
+            source
+                .discover_event_files()
+                .expect("first discovery should succeed"),
+            vec![first_path.clone()]
+        );
+
+        let second_path = source.event_file_path_for_work_unit("take/stage#1");
+        fs::create_dir_all(second_path.parent().expect("event path parent"))
+            .expect("second nested event dir should be created");
+        fs::write(
+            &second_path,
+            "{\"schema_version\":2,\"source\":\"runa-mcp\",\"kind\":\"tool_call\",\"content\":\"take\"}\n",
+        )
+        .expect("second nested event file should be written");
+
+        let discovered = source
+            .discover_event_files()
+            .expect("second discovery should succeed");
+        assert_eq!(discovered.len(), 2, "source must re-scan for new stages");
+        assert!(discovered.contains(&first_path), "{discovered:?}");
+        assert!(discovered.contains(&second_path), "{discovered:?}");
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn finalize_session_transcript_reads_nested_runa_events_not_flat_events_jsonl() {
+        let root = unique_test_dir("agentd-audit-nested-transcript");
+        let record = prepare_session_audit_record_at(
+            &root,
+            "nested-transcript",
+            &test_session_spec(),
+            &SessionInvocation {
+                repo_url: "https://example.com/agentd.git".to_string(),
+                repo_token: None,
+                work_unit: None,
+                input: None,
+                timeout: None,
+            },
+        )
+        .expect("audit record should be created");
+        fs::write(
+            record.transcript_dir.join("events.jsonl"),
+            "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"flat\"}\n",
+        )
+        .expect("flat event file should be written");
+        write_nested_events(
+            &record,
+            "survey",
+            "{\"schema_version\":2,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"nested survey\"}\n",
+        );
+        write_nested_events(
+            &record,
+            "take/stage#1",
+            "{\"schema_version\":2,\"source\":\"runa-mcp\",\"kind\":\"tool_call\",\"content\":\"nested take\"}\n",
+        );
+
+        super::finalize_session_transcript(&record).expect("transcript should finalize");
+
+        let markdown = fs::read_to_string(record.transcript_dir.join("transcript.md"))
+            .expect("transcript markdown should exist");
+        assert!(markdown.contains("nested survey"), "{markdown}");
+        assert!(markdown.contains("nested take"), "{markdown}");
+        assert!(!markdown.contains("flat"), "{markdown}");
+
+        let manifest: Value = serde_json::from_str(
+            &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+                .expect("transcript manifest should exist"),
+        )
+        .expect("manifest should be json");
+        assert_eq!(manifest["coverage"], "full");
+        assert_eq!(manifest["event_schema_versions"], serde_json::json!([2]));
+
+        fs::remove_dir_all(root).expect("temporary audit root should be removed");
+    }
+
+    fn write_nested_events(record: &super::SessionAuditRecord, work_unit: &str, events: &str) {
+        let source = crate::transcript::TranscriptEventSource::from_record(record);
+        let path = source.event_file_path_for_work_unit(work_unit);
+        fs::create_dir_all(path.parent().expect("event path parent"))
+            .expect("nested event directory should be created");
+        fs::write(path, events).expect("nested events should be written");
     }
 
     #[test]
@@ -1515,11 +1665,11 @@ mod tests {
             },
         )
         .expect("audit record should be created");
-        fs::write(
-            record.transcript_dir.join("events.jsonl"),
+        write_nested_events(
+            &record,
+            "survey",
             "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"hello\"}\n",
-        )
-        .expect("events jsonl should be created");
+        );
         fs::set_permissions(&record.transcript_dir, fs::Permissions::from_mode(0o000))
             .expect("transcript dir should become restrictive");
 
@@ -1558,7 +1708,10 @@ mod tests {
             },
         )
         .expect("audit record should be created");
-        let events_path = record.transcript_dir.join("events.jsonl");
+        let events_path = crate::transcript::TranscriptEventSource::from_record(&record)
+            .event_file_path_for_work_unit("survey");
+        fs::create_dir_all(events_path.parent().expect("event path parent"))
+            .expect("nested event directory should be created");
         fs::write(
             &events_path,
             "{\"schema_version\":1,\"source\":\"runa-mcp\",\"kind\":\"tool_call\"}\n",
@@ -1607,7 +1760,11 @@ mod tests {
         .expect("runa target should be created");
         fs::set_permissions(&runa_target, fs::Permissions::from_mode(0o000))
             .expect("runa target should start unreadable");
-        fs::hard_link(&runa_target, record.transcript_dir.join("events.jsonl"))
+        let events_path = crate::transcript::TranscriptEventSource::from_record(&record)
+            .event_file_path_for_work_unit("survey");
+        fs::create_dir_all(events_path.parent().expect("event path parent"))
+            .expect("nested event directory should be created");
+        fs::hard_link(&runa_target, &events_path)
             .expect("hard-linked transcript events should be created");
 
         let before_mode = fs::metadata(&runa_target)
@@ -1699,7 +1856,11 @@ mod tests {
         .expect("audit record should be created");
         let outside_target = root.join("outside-events.jsonl");
         fs::write(&outside_target, "outside secret\n").expect("outside target should be created");
-        symlink(&outside_target, record.transcript_dir.join("events.jsonl"))
+        let events_path = crate::transcript::TranscriptEventSource::from_record(&record)
+            .event_file_path_for_work_unit("survey");
+        fs::create_dir_all(events_path.parent().expect("event path parent"))
+            .expect("nested event directory should be created");
+        symlink(&outside_target, &events_path)
             .expect("symlinked events artifact should be created");
 
         let error = super::finalize_session_transcript(&record)
@@ -1716,11 +1877,10 @@ mod tests {
         assert_eq!(
             fs::read_to_string(record.transcript_dir.join("manifest.json"))
                 .expect("failure manifest should be written"),
-            "{\n  \"schema_version\": 1,\n  \"coverage\": \"finalization_failed\",\n  \"finalization_error\": \"unsafe transcript artifact: events.jsonl is not a regular file\"\n}\n"
+            "{\n  \"schema_version\": 1,\n  \"coverage\": \"finalization_failed\",\n  \"event_schema_versions\": [],\n  \"finalization_error\": \"unsafe transcript artifact: events.jsonl is not a regular file\"\n}\n"
         );
 
-        fs::remove_file(record.transcript_dir.join("events.jsonl"))
-            .expect("symlink should be removable");
+        fs::remove_file(events_path).expect("symlink should be removable");
         fs::remove_dir_all(root).expect("temporary audit root should be removed");
     }
 
@@ -1740,7 +1900,10 @@ mod tests {
             },
         )
         .expect("audit record should be created");
-        let fifo_path = record.transcript_dir.join("events.jsonl");
+        let fifo_path = crate::transcript::TranscriptEventSource::from_record(&record)
+            .event_file_path_for_work_unit("survey");
+        fs::create_dir_all(fifo_path.parent().expect("event path parent"))
+            .expect("nested event directory should be created");
         let status = Command::new("mkfifo")
             .arg(&fifo_path)
             .status()
@@ -1788,11 +1951,11 @@ mod tests {
             },
         )
         .expect("audit record should be created");
-        fs::write(
-            record.transcript_dir.join("events.jsonl"),
+        write_nested_events(
+            &record,
+            "survey",
             "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\"}\n",
-        )
-        .expect("events jsonl should be created");
+        );
         fs::write(record.transcript_dir.join("transcript.md"), "preexisting\n")
             .expect("preexisting markdown should be created");
 
@@ -1840,11 +2003,11 @@ mod tests {
             },
         )
         .expect("audit record should be created");
-        fs::write(
-            record.transcript_dir.join("events.jsonl"),
+        write_nested_events(
+            &record,
+            "survey",
             "{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\"}\n",
-        )
-        .expect("events jsonl should be created");
+        );
         fs::write(record.transcript_dir.join("manifest.json"), "preexisting\n")
             .expect("preexisting manifest should be created");
 
@@ -1887,11 +2050,7 @@ mod tests {
             "kind": "agent_output",
             "content": content,
         });
-        fs::write(
-            record.transcript_dir.join("events.jsonl"),
-            format!("{event}\n"),
-        )
-        .expect("events jsonl should be writable");
+        write_nested_events(&record, "survey", &format!("{event}\n"));
 
         super::finalize_session_transcript(&record).expect("transcript should finalize");
 
@@ -1935,9 +2094,11 @@ mod tests {
         fs::create_dir_all(&root).expect("coverage fixture dir should be created");
         let events_path = root.join("events.jsonl");
         fs::write(&events_path, events).expect("coverage fixture should be written");
-        let mut events_file = fs::File::open(&events_path).expect("coverage fixture should open");
-        let coverage = super::transcript_coverage(&mut events_file)
+        let events_file = fs::File::open(&events_path).expect("coverage fixture should open");
+        let mut summary = super::TranscriptSummary::default();
+        super::summarize_transcript_events(events_file, &mut summary)
             .expect("coverage classification should run");
+        let coverage = summary.coverage();
         fs::remove_dir_all(root).expect("coverage fixture dir should be removed");
         coverage
     }
@@ -1977,7 +2138,10 @@ mod tests {
             },
         )
         .expect("audit record should be created");
-        let events_path = record.transcript_dir.join("events.jsonl");
+        let events_path = crate::transcript::TranscriptEventSource::from_record(&record)
+            .event_file_path_for_work_unit("survey");
+        fs::create_dir_all(events_path.parent().expect("event path parent"))
+            .expect("nested event directory should be created");
         let mut events_file =
             fs::File::create(&events_path).expect("large events should be created");
         let content = "x".repeat(512);

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -16,6 +16,7 @@ use crate::session_paths::{
     session_home_dir, session_internal_audit_dir, session_internal_audit_runa_dir,
     session_repo_dir, session_repo_runa_dir, session_transcript_mount_dir,
 };
+use crate::transcript::{TRANSCRIPT_DEPLOYMENT_ENV, TRANSCRIPT_RUN_ID_ENV, TranscriptIdentity};
 use crate::types::{BindMount, RunnerError, SessionInvocation, SessionOutcome, SessionSpec};
 use crate::validation::{
     REPO_TOKEN_ENV, RepoUrlKind, TRANSCRIPT_DIR_ENV, TRANSCRIPT_REDACT_ENV, repo_url_kind,
@@ -183,6 +184,7 @@ pub(crate) fn cleanup_container(container_name: &str) -> Result<(), RunnerError>
 fn build_container_script(
     spec: &SessionSpec,
     invocation: &SessionInvocation,
+    transcript_identity: &TranscriptIdentity,
     resolved_input: Option<&ResolvedInvocationInput>,
 ) -> String {
     let username = &spec.agent_name;
@@ -261,6 +263,14 @@ fn build_container_script(
     script.push_str(&shell_quote(
         &session_transcript_mount_dir().display().to_string(),
     ));
+    script.push_str("\nexport ");
+    script.push_str(TRANSCRIPT_DEPLOYMENT_ENV);
+    script.push('=');
+    script.push_str(&shell_quote(transcript_identity.deployment()));
+    script.push_str("\nexport ");
+    script.push_str(TRANSCRIPT_RUN_ID_ENV);
+    script.push('=');
+    script.push_str(&shell_quote(transcript_identity.run_id()));
     let redact_env = transcript_redact_environment(spec, invocation);
     script.push_str("\nexport ");
     script.push_str(TRANSCRIPT_REDACT_ENV);
@@ -484,7 +494,12 @@ fn build_create_container_args(
     args.push("/bin/sh".to_string());
     args.push(spec.base_image.clone());
     args.push("-lc".to_string());
-    args.push(build_container_script(spec, invocation, resolved_input));
+    args.push(build_container_script(
+        spec,
+        invocation,
+        &resources.audit_record.transcript_identity,
+        resolved_input,
+    ));
 
     args
 }

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -27,6 +27,11 @@ fn test_audit_record() -> SessionAuditRecord {
         agent: "site-builder".to_string(),
         repo_url: VALID_REMOTE_REPO_URL.to_string(),
         work_unit: None,
+        transcript_identity: crate::transcript::TranscriptIdentity::new(
+            "github",
+            VALID_REMOTE_REPO_URL,
+            "0123456789abcdef",
+        ),
         start_timestamp: "2026-04-16T00:00:00Z".to_string(),
     }
 }
@@ -273,7 +278,12 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
         &invocation,
         None,
     );
-    let expected_script = build_container_script(&spec, &invocation, None);
+    let expected_script = build_container_script(
+        &spec,
+        &invocation,
+        &test_audit_record().transcript_identity,
+        None,
+    );
 
     let image_index = args
         .iter()
@@ -283,6 +293,72 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
     assert_eq!(
         args.get(image_index + 2).map(String::as_str),
         Some(expected_script.as_str())
+    );
+}
+
+#[test]
+fn container_script_exports_agentd_owned_transcript_identity_for_runa() {
+    let spec = SessionSpec {
+        forge_type: "github".to_string(),
+        ..test_session_spec()
+    };
+    let invocation = SessionInvocation {
+        repo_url: "https://example.com/agentd.git".to_string(),
+        repo_token: None,
+        work_unit: Some("issue-162".to_string()),
+        input: None,
+        timeout: None,
+    };
+    let resources = SessionResources {
+        container_name: "agentd-agent-session".to_string(),
+        methodology_staging_dir: PathBuf::from("/tmp/staging"),
+        methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
+        audit_record: test_audit_record(),
+        audit_mount: PreparedBindMount {
+            source: PathBuf::from("/tmp/staging/audit-runa"),
+            target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
+            read_only: false,
+            relabel_shared: true,
+        },
+        transcript_mount: PreparedBindMount {
+            source: PathBuf::from("/tmp/staging/transcript"),
+            target: PathBuf::from("/agentd/transcript"),
+            read_only: false,
+            relabel_shared: true,
+        },
+        invocation_input_mount: None,
+        additional_mounts: Vec::new(),
+        environment_secret_bindings: Vec::new(),
+        repo_token_secret_binding: None,
+    };
+
+    let args = build_create_container_args(&resources, &spec, &invocation, None);
+    let script = args
+        .last()
+        .expect("podman create should include shell script");
+    let identity = crate::transcript::TranscriptIdentity::new(
+        &spec.forge_type,
+        &invocation.repo_url,
+        &resources.audit_record.session_id,
+    );
+
+    assert!(
+        script.contains(&format!(
+            "export RUNA_TRANSCRIPT_DEPLOYMENT='{}'",
+            identity.deployment()
+        )),
+        "container script should export agentd-owned deployment identity:\n{script}"
+    );
+    assert!(
+        script.contains(&format!(
+            "export RUNA_TRANSCRIPT_RUN_ID='{}'",
+            identity.run_id()
+        )),
+        "container script should export agentd-owned run id:\n{script}"
+    );
+    assert!(
+        script.contains("export RUNA_TRANSCRIPT_DIR='/agentd/transcript'"),
+        "container script should still export transcript root:\n{script}"
     );
 }
 
@@ -375,6 +451,7 @@ fn build_container_script_terminates_git_clone_options_before_repo_url() {
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -392,6 +469,7 @@ fn build_container_script_disables_git_terminal_prompts() {
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -418,6 +496,7 @@ fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -469,6 +548,7 @@ fn build_container_script_uses_mode_based_audit_mount_writability_without_chown(
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -478,6 +558,8 @@ fn build_container_script_uses_mode_based_audit_mount_writability_without_chown(
              export HOME='/home/myagent'\n\
              unset AGENTD_WORK_UNIT\n\
              export RUNA_TRANSCRIPT_DIR='/agentd/transcript'\n\
+             export RUNA_TRANSCRIPT_DEPLOYMENT='agentd-2C6C759AB37A9E75FEB2499655C2FD69300DC8BFCB5B57357AB19BAD66BDBBB6'\n\
+             export RUNA_TRANSCRIPT_RUN_ID='0123456789abcdef'\n\
              export RUNA_TRANSCRIPT_REDACT_ENV=''\n\
              gosu 'myagent:myagent' runa init"
         ),
@@ -503,6 +585,7 @@ fn build_container_script_materializes_invocation_input_without_audit_workspace_
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         Some(&ResolvedInvocationInput {
             artifact_type: "intent".to_string(),
             artifact_id: "operator-input".to_string(),
@@ -537,6 +620,7 @@ fn build_container_script_materializes_work_unit_input_before_work_mode_run() {
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         Some(&ResolvedInvocationInput {
             artifact_type: "work-unit".to_string(),
             artifact_id: "issue-76".to_string(),
@@ -597,6 +681,7 @@ fn build_container_script_uses_find_prune_to_reown_home_without_touching_mount_t
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -643,6 +728,7 @@ fn build_container_script_does_not_emit_intermediate_home_chown_commands() {
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -670,6 +756,7 @@ fn build_container_script_unsets_work_unit_when_invocation_omits_it() {
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 
@@ -787,6 +874,7 @@ fn build_container_script_runs_ssh_clone_as_session_user_with_session_home() {
             input: None,
             timeout: None,
         },
+        &test_audit_record().transcript_identity,
         None,
     );
 

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -297,7 +297,7 @@ fn create_container_args_pass_shell_flags_after_image_argument() {
 }
 
 #[test]
-fn container_script_exports_agentd_owned_transcript_identity_for_runa() {
+fn container_script_exports_session_stable_transcript_run_id_for_multistage_runa_events() {
     let spec = SessionSpec {
         forge_type: "github".to_string(),
         ..test_session_spec()
@@ -309,11 +309,21 @@ fn container_script_exports_agentd_owned_transcript_identity_for_runa() {
         input: None,
         timeout: None,
     };
+    let root = unique_test_dir("agentd-runner-transcript-run-id");
+    let audit_record = SessionAuditRecord {
+        record_dir: root.join("site-builder/0123456789abcdef"),
+        runa_dir: root.join("site-builder/0123456789abcdef/runa"),
+        transcript_dir: root.join("site-builder/0123456789abcdef/agentd/transcript"),
+        metadata_path: root.join("site-builder/0123456789abcdef/agentd/session.json"),
+        ..test_audit_record()
+    };
+    fs::create_dir_all(&audit_record.transcript_dir)
+        .expect("test transcript directory should be created");
     let resources = SessionResources {
         container_name: "agentd-agent-session".to_string(),
         methodology_staging_dir: PathBuf::from("/tmp/staging"),
         methodology_mount_source: PathBuf::from("/tmp/staging/methodology"),
-        audit_record: test_audit_record(),
+        audit_record,
         audit_mount: PreparedBindMount {
             source: PathBuf::from("/tmp/staging/audit-runa"),
             target: PathBuf::from("/home/site-builder/.agentd/audit/runa"),
@@ -360,6 +370,74 @@ fn container_script_exports_agentd_owned_transcript_identity_for_runa() {
         script.contains("export RUNA_TRANSCRIPT_DIR='/agentd/transcript'"),
         "container script should still export transcript root:\n{script}"
     );
+
+    write_runa_style_transcript_event(
+        &resources.audit_record.transcript_dir,
+        identity.deployment(),
+        "_unscoped",
+        "run-1783430832991738225-1",
+        "{\"schema_version\":2,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"lost first stage\"}\n",
+    );
+    write_runa_style_transcript_event(
+        &resources.audit_record.transcript_dir,
+        identity.deployment(),
+        "issue-162",
+        "run-1783431017466125708-1",
+        "{\"schema_version\":2,\"source\":\"runa-mcp\",\"kind\":\"tool_call\",\"content\":\"lost second stage\"}\n",
+    );
+
+    crate::audit::finalize_session_transcript(&resources.audit_record)
+        .expect("stage-varying run ids should finalize as an empty addressed stream");
+    let manifest = read_transcript_manifest(&resources.audit_record);
+    assert_eq!(
+        manifest["coverage"], "no_events",
+        "stage-varying runa-minted run ids must not satisfy agentd's single-run contract"
+    );
+    assert_eq!(manifest["event_schema_versions"], serde_json::json!([]));
+    assert!(
+        !fs::read_to_string(resources.audit_record.transcript_dir.join("transcript.md"))
+            .expect("transcript markdown should exist")
+            .contains("lost"),
+        "agentd must not recover missing run identity by scanning arbitrary run subtrees"
+    );
+
+    let stable_record = SessionAuditRecord {
+        record_dir: root.join("site-builder/fedcba9876543210"),
+        runa_dir: root.join("site-builder/fedcba9876543210/runa"),
+        transcript_dir: root.join("site-builder/fedcba9876543210/agentd/transcript"),
+        metadata_path: root.join("site-builder/fedcba9876543210/agentd/session.json"),
+        session_id: "0123456789abcdef".to_string(),
+        transcript_identity: identity.clone(),
+        ..test_audit_record()
+    };
+    fs::create_dir_all(&stable_record.transcript_dir)
+        .expect("stable transcript directory should be created");
+    write_runa_style_transcript_event(
+        &stable_record.transcript_dir,
+        identity.deployment(),
+        "_unscoped",
+        identity.run_id(),
+        "{\"schema_version\":2,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"first stage\"}\n",
+    );
+    write_runa_style_transcript_event(
+        &stable_record.transcript_dir,
+        identity.deployment(),
+        "issue-162",
+        identity.run_id(),
+        "{\"schema_version\":2,\"source\":\"runa-mcp\",\"kind\":\"tool_call\",\"content\":\"second stage\"}\n",
+    );
+
+    crate::audit::finalize_session_transcript(&stable_record)
+        .expect("session-stable run id should finalize");
+    let manifest = read_transcript_manifest(&stable_record);
+    assert_eq!(manifest["coverage"], "full");
+    assert_eq!(manifest["event_schema_versions"], serde_json::json!([2]));
+    let markdown = fs::read_to_string(stable_record.transcript_dir.join("transcript.md"))
+        .expect("stable transcript markdown should exist");
+    assert!(markdown.contains("first stage"), "{markdown}");
+    assert!(markdown.contains("second stage"), "{markdown}");
+
+    fs::remove_dir_all(root).expect("temporary audit root should be removed");
 }
 
 #[test]
@@ -1902,6 +1980,38 @@ fn mount_src_value(mount: &str) -> Option<String> {
     mount
         .split(',')
         .find_map(|component| component.strip_prefix("src=").map(str::to_string))
+}
+
+fn write_runa_style_transcript_event(
+    transcript_dir: &Path,
+    deployment: &str,
+    work_unit_component: &str,
+    run_id: &str,
+    event: &str,
+) {
+    let events_path = transcript_dir
+        .join("deployments")
+        .join(deployment)
+        .join("work-units")
+        .join(work_unit_component)
+        .join("runs")
+        .join(run_id)
+        .join("events.jsonl");
+    fs::create_dir_all(
+        events_path
+            .parent()
+            .expect("event path should have a parent"),
+    )
+    .expect("runa-style transcript event directory should be created");
+    fs::write(events_path, event).expect("runa-style transcript event should be written");
+}
+
+fn read_transcript_manifest(record: &SessionAuditRecord) -> serde_json::Value {
+    serde_json::from_str(
+        &fs::read_to_string(record.transcript_dir.join("manifest.json"))
+            .expect("transcript manifest should exist"),
+    )
+    .expect("transcript manifest should be json")
 }
 
 fn unique_test_dir(prefix: &str) -> PathBuf {

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -66,6 +66,7 @@ use validation::{validate_invocation, validate_spec};
 
 const TRANSCRIPT_EVENTS_FILE: &str = "events.jsonl";
 const TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const MAX_LIVE_TRANSCRIPT_LINE_BYTES: usize = 32 * 1024;
 
 /// Executes a single session from validation through teardown.
 ///
@@ -338,30 +339,65 @@ fn observe_transcript_events(
         }
     };
 
-    let mut pending_line = String::new();
+    let mut pending_line = Vec::new();
+    let mut dropping_oversized_line = false;
     loop {
-        let mut chunk = String::new();
-        match reader.read_line(&mut chunk) {
-            Ok(0) => {
+        let consumed = match reader.fill_buf() {
+            Ok([]) => {
                 if stop.load(Ordering::Acquire) {
                     return;
                 }
                 thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+                continue;
             }
-            Ok(_) => {
-                let line_complete = chunk.ends_with('\n');
-                pending_line.push_str(&chunk);
-                if line_complete {
-                    let line = pending_line.trim_end_matches(['\r', '\n']).to_string();
-                    pending_line.clear();
-                    if line.trim().is_empty() {
+            Ok(buffer) => {
+                let mut consumed = 0;
+                while consumed < buffer.len() {
+                    let remaining = &buffer[consumed..];
+                    let segment_len = remaining
+                        .iter()
+                        .position(|byte| *byte == b'\n')
+                        .map_or(remaining.len(), |newline| newline + 1);
+                    let segment = &remaining[..segment_len];
+                    let line_complete = segment.ends_with(b"\n");
+
+                    if dropping_oversized_line {
+                        if line_complete {
+                            dropping_oversized_line = false;
+                        }
+                        consumed += segment_len;
                         continue;
                     }
-                    progress.observe(SessionProgressEvent::TranscriptEvent {
-                        session_id: session_id.to_string(),
-                        line,
-                    });
+
+                    if pending_line.len().saturating_add(segment.len())
+                        > MAX_LIVE_TRANSCRIPT_LINE_BYTES
+                    {
+                        pending_line.clear();
+                        dropping_oversized_line = !line_complete;
+                        tracing::debug!(
+                            event = "runner.transcript_progress_oversized_record_dropped",
+                            session_id = session_id,
+                            max_bytes = MAX_LIVE_TRANSCRIPT_LINE_BYTES,
+                            "dropped oversized live transcript progress record"
+                        );
+                        consumed += segment_len;
+                        continue;
+                    }
+
+                    pending_line.extend_from_slice(segment);
+                    consumed += segment_len;
+
+                    if line_complete {
+                        if let Some(line) = live_transcript_line_from_bytes(&pending_line) {
+                            progress.observe(SessionProgressEvent::TranscriptEvent {
+                                session_id: session_id.to_string(),
+                                line,
+                            });
+                        }
+                        pending_line.clear();
+                    }
                 }
+                consumed
             }
             Err(error) => {
                 tracing::warn!(
@@ -373,8 +409,26 @@ fn observe_transcript_events(
                 );
                 return;
             }
-        }
+        };
+
+        reader.consume(consumed);
     }
+}
+
+fn live_transcript_line_from_bytes(bytes: &[u8]) -> Option<String> {
+    let line = String::from_utf8_lossy(trim_line_end_bytes(bytes)).into_owned();
+    if line.trim().is_empty() {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn trim_line_end_bytes(mut bytes: &[u8]) -> &[u8] {
+    while matches!(bytes.last(), Some(b'\r' | b'\n')) {
+        bytes = &bytes[..bytes.len() - 1];
+    }
+    bytes
 }
 
 fn open_live_transcript_events(path: &Path) -> Result<File, io::Error> {
@@ -564,6 +618,73 @@ mod tests {
                     session_id: "session-123".to_string(),
                     line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#.to_string(),
                 }
+            );
+
+            stop.store(true, Ordering::Release);
+            handle.join().expect("observer should not panic");
+        });
+        fs::remove_dir_all(transcript_dir).expect("transcript dir should be removed");
+    }
+
+    #[test]
+    fn transcript_observer_drops_oversized_records_whole_and_resumes_after_newline() {
+        let transcript_dir = unique_temp_dir("agentd-live-transcript-observer-oversized");
+        fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
+        let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+        fs::write(&events_path, "").expect("transcript events should be created");
+        let stop = AtomicBool::new(false);
+        let (tx, rx) = mpsc::channel();
+        thread::scope(|scope| {
+            let observer = |event| {
+                tx.send(event).expect("progress event should send");
+            };
+            let observer_transcript_dir = &transcript_dir;
+            let observer_stop = &stop;
+            let handle = scope.spawn(move || {
+                observe_transcript_events(
+                    observer_transcript_dir,
+                    "session-123",
+                    &observer,
+                    observer_stop,
+                );
+            });
+
+            let mut events = fs::OpenOptions::new()
+                .append(true)
+                .open(&events_path)
+                .expect("transcript events should reopen");
+            events
+                .write_all(&vec![b'x'; MAX_LIVE_TRANSCRIPT_LINE_BYTES + 1])
+                .expect("oversized unterminated transcript event should be written");
+            events
+                .flush()
+                .expect("oversized transcript event should flush");
+
+            assert!(
+                rx.recv_timeout(Duration::from_millis(250)).is_err(),
+                "observer must not report an oversized unterminated transcript record"
+            );
+
+            events
+                .write_all(
+                    br#"
+{"schema_version":1,"source":"runa","kind":"agent_input","content":"after oversized"}
+"#,
+                )
+                .expect("oversized terminator and valid event should be written");
+            events.flush().expect("valid transcript event should flush");
+
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(2))
+                    .expect("observer should report the valid event after oversized drop"),
+                SessionProgressEvent::TranscriptEvent {
+                    session_id: "session-123".to_string(),
+                    line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"after oversized"}"#.to_string(),
+                }
+            );
+            assert!(
+                rx.recv_timeout(Duration::from_millis(250)).is_err(),
+                "oversized record should be dropped whole, not emitted as a fragment"
             );
 
             stop.store(true, Ordering::Release);

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -54,17 +54,15 @@ use resources::{
     ResourceAllocationFailure, SecretBinding, SessionResources, cleanup_methodology_staging_dir,
     cleanup_podman_secrets, prepare_session_resources, unique_suffix,
 };
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufRead, BufReader};
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-use std::path::Path;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
+use transcript::{TranscriptEventFile, TranscriptEventSource};
 use validation::{validate_invocation, validate_spec};
 
-const TRANSCRIPT_EVENTS_FILE: &str = "events.jsonl";
 const TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_LIVE_TRANSCRIPT_LINE_BYTES: usize = 32 * 1024;
 
@@ -277,13 +275,9 @@ fn run_container_with_transcript_progress(
     let stop = Arc::new(AtomicBool::new(false));
     thread::scope(|scope| {
         let observer_stop = Arc::clone(&stop);
+        let transcript_source = TranscriptEventSource::from_record(&resources.audit_record);
         let observer = scope.spawn(move || {
-            observe_transcript_events(
-                &resources.audit_record.transcript_dir,
-                session_id,
-                progress,
-                &observer_stop,
-            );
+            observe_transcript_events(&transcript_source, session_id, progress, &observer_stop);
         });
 
         let result = match timeout {
@@ -311,108 +305,164 @@ fn run_container_with_transcript_progress(
 }
 
 fn observe_transcript_events(
-    transcript_dir: &Path,
+    source: &TranscriptEventSource,
     session_id: &str,
     progress: &dyn SessionProgressObserver,
     stop: &AtomicBool,
 ) {
-    let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
-    let mut reader = loop {
-        match open_live_transcript_events(&events_path) {
-            Ok(file) => break BufReader::new(file),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                if stop.load(Ordering::Acquire) {
-                    return;
-                }
-                thread::sleep(TRANSCRIPT_POLL_INTERVAL);
-            }
+    let mut readers = Vec::new();
+    loop {
+        match discover_live_transcript_readers(source, &mut readers) {
+            Ok(()) => {}
             Err(error) => {
                 tracing::warn!(
                     event = "runner.transcript_progress_unavailable",
                     session_id = session_id,
-                    path = %events_path.display(),
                     error = %error,
                     "live transcript progress unavailable"
                 );
                 return;
             }
         }
-    };
 
-    let mut pending_line = Vec::new();
-    let mut dropping_oversized_line = false;
-    loop {
-        let consumed = match reader.fill_buf() {
-            Ok([]) => {
-                if stop.load(Ordering::Acquire) {
+        let mut observed_progress = false;
+        for reader in &mut readers {
+            match reader.observe_available(session_id, progress) {
+                Ok(observed) => observed_progress |= observed,
+                Err(error) => {
+                    tracing::warn!(
+                        event = "runner.transcript_progress_read_failed",
+                        session_id = session_id,
+                        error = %error,
+                        "failed to read live transcript progress"
+                    );
                     return;
                 }
-                thread::sleep(TRANSCRIPT_POLL_INTERVAL);
-                continue;
             }
-            Ok(buffer) => {
-                let mut consumed = 0;
-                while consumed < buffer.len() {
-                    let remaining = &buffer[consumed..];
-                    let segment_len = remaining
-                        .iter()
-                        .position(|byte| *byte == b'\n')
-                        .map_or(remaining.len(), |newline| newline + 1);
-                    let segment = &remaining[..segment_len];
-                    let line_complete = segment.ends_with(b"\n");
+        }
 
-                    if dropping_oversized_line {
-                        if line_complete {
-                            dropping_oversized_line = false;
-                        }
-                        consumed += segment_len;
-                        continue;
-                    }
+        if stop.load(Ordering::Acquire) && !observed_progress {
+            return;
+        }
 
-                    if pending_line.len().saturating_add(segment.len())
-                        > MAX_LIVE_TRANSCRIPT_LINE_BYTES
-                    {
-                        pending_line.clear();
-                        dropping_oversized_line = !line_complete;
-                        tracing::debug!(
-                            event = "runner.transcript_progress_oversized_record_dropped",
-                            session_id = session_id,
-                            max_bytes = MAX_LIVE_TRANSCRIPT_LINE_BYTES,
-                            "dropped oversized live transcript progress record"
-                        );
-                        consumed += segment_len;
-                        continue;
-                    }
-
-                    pending_line.extend_from_slice(segment);
-                    consumed += segment_len;
-
-                    if line_complete {
-                        if let Some(line) = live_transcript_line_from_bytes(&pending_line) {
-                            progress.observe(SessionProgressEvent::TranscriptEvent {
-                                session_id: session_id.to_string(),
-                                line,
-                            });
-                        }
-                        pending_line.clear();
-                    }
-                }
-                consumed
-            }
-            Err(error) => {
-                tracing::warn!(
-                    event = "runner.transcript_progress_read_failed",
-                    session_id = session_id,
-                    path = %events_path.display(),
-                    error = %error,
-                    "failed to read live transcript progress"
-                );
-                return;
-            }
-        };
-
-        reader.consume(consumed);
+        thread::sleep(TRANSCRIPT_POLL_INTERVAL);
     }
+}
+
+fn discover_live_transcript_readers(
+    source: &TranscriptEventSource,
+    readers: &mut Vec<LiveTranscriptReader>,
+) -> Result<(), RunnerError> {
+    for event_file in source.discover_event_files()? {
+        if readers.iter().any(|reader| reader.event_file == event_file) {
+            continue;
+        }
+        let events = source.open_event_file(&event_file)?;
+        readers.push(LiveTranscriptReader::new(event_file, events));
+    }
+    Ok(())
+}
+
+struct LiveTranscriptReader {
+    event_file: TranscriptEventFile,
+    reader: BufReader<File>,
+    pending_line: Vec<u8>,
+    dropping_oversized_line: bool,
+}
+
+impl LiveTranscriptReader {
+    fn new(event_file: TranscriptEventFile, events: File) -> Self {
+        Self {
+            event_file,
+            reader: BufReader::new(events),
+            pending_line: Vec::new(),
+            dropping_oversized_line: false,
+        }
+    }
+
+    fn observe_available(
+        &mut self,
+        session_id: &str,
+        progress: &dyn SessionProgressObserver,
+    ) -> Result<bool, RunnerError> {
+        let mut observed_progress = false;
+        loop {
+            let consumed = match self.reader.fill_buf() {
+                Ok([]) => return Ok(observed_progress),
+                Ok(buffer) => {
+                    let (consumed, observed) = consume_live_transcript_buffer(
+                        buffer,
+                        &mut self.pending_line,
+                        &mut self.dropping_oversized_line,
+                        session_id,
+                        progress,
+                    );
+                    observed_progress |= observed;
+                    consumed
+                }
+                Err(error) => return Err(RunnerError::Io(error)),
+            };
+
+            self.reader.consume(consumed);
+        }
+    }
+}
+
+fn consume_live_transcript_buffer(
+    buffer: &[u8],
+    pending_line: &mut Vec<u8>,
+    dropping_oversized_line: &mut bool,
+    session_id: &str,
+    progress: &dyn SessionProgressObserver,
+) -> (usize, bool) {
+    let mut consumed = 0;
+    let mut observed_progress = false;
+    while consumed < buffer.len() {
+        let remaining = &buffer[consumed..];
+        let segment_len = remaining
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(remaining.len(), |newline| newline + 1);
+        let segment = &remaining[..segment_len];
+        let line_complete = segment.ends_with(b"\n");
+
+        if *dropping_oversized_line {
+            if line_complete {
+                *dropping_oversized_line = false;
+            }
+            consumed += segment_len;
+            continue;
+        }
+
+        if pending_line.len().saturating_add(segment.len()) > MAX_LIVE_TRANSCRIPT_LINE_BYTES {
+            pending_line.clear();
+            *dropping_oversized_line = !line_complete;
+            tracing::debug!(
+                event = "runner.transcript_progress_oversized_record_dropped",
+                session_id = session_id,
+                max_bytes = MAX_LIVE_TRANSCRIPT_LINE_BYTES,
+                "dropped oversized live transcript progress record"
+            );
+            consumed += segment_len;
+            continue;
+        }
+
+        pending_line.extend_from_slice(segment);
+        consumed += segment_len;
+
+        if line_complete {
+            if let Some(line) = live_transcript_line_from_bytes(pending_line) {
+                progress.observe(SessionProgressEvent::TranscriptEvent {
+                    session_id: session_id.to_string(),
+                    line,
+                });
+                observed_progress = true;
+            }
+            pending_line.clear();
+        }
+    }
+
+    (consumed, observed_progress)
 }
 
 fn live_transcript_line_from_bytes(bytes: &[u8]) -> Option<String> {
@@ -429,37 +479,6 @@ fn trim_line_end_bytes(mut bytes: &[u8]) -> &[u8] {
         bytes = &bytes[..bytes.len() - 1];
     }
     bytes
-}
-
-fn open_live_transcript_events(path: &Path) -> Result<File, io::Error> {
-    let metadata = fs::symlink_metadata(path)?;
-    if !metadata.is_file() {
-        return Err(io::Error::other(format!(
-            "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
-        )));
-    }
-
-    let file = OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
-        .open(path)
-        .map_err(|error| match error.raw_os_error() {
-            Some(libc::ELOOP) => io::Error::other(format!(
-                "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
-            )),
-            _ => error,
-        })?;
-    let open_metadata = file.metadata()?;
-    if !open_metadata.is_file()
-        || open_metadata.dev() != metadata.dev()
-        || open_metadata.ino() != metadata.ino()
-    {
-        return Err(io::Error::other(format!(
-            "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
-        )));
-    }
-
-    Ok(file)
 }
 
 fn cleanup_session_resources(resources: &SessionResources) -> Result<(), RunnerError> {
@@ -563,36 +582,60 @@ mod tests {
 
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
 
+    fn test_invocation() -> SessionInvocation {
+        SessionInvocation {
+            repo_url: "https://example.com/agentd.git".to_string(),
+            repo_token: None,
+            work_unit: None,
+            input: None,
+            timeout: None,
+        }
+    }
+
+    fn live_transcript_source(name: &str) -> (PathBuf, TranscriptEventSource) {
+        let audit_root = unique_temp_dir(name);
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+        let spec = SessionSpec {
+            audit_root: audit_root.clone(),
+            ..test_session_spec()
+        };
+        let record =
+            crate::audit::prepare_session_audit_record("session-123", &spec, &test_invocation())
+                .expect("audit record should be prepared");
+        let source = TranscriptEventSource::from_record(&record);
+        (audit_root, source)
+    }
+
+    fn nested_events_file(source: &TranscriptEventSource, stage: &str) -> fs::File {
+        let path = source.event_file_path_for_work_unit(stage);
+        fs::create_dir_all(path.parent().expect("events file parent should exist"))
+            .expect("nested transcript events dir should be created");
+        fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .expect("nested transcript events should open")
+    }
+
     #[test]
     fn transcript_observer_waits_for_newline_before_reporting_live_event() {
-        let transcript_dir = unique_temp_dir("agentd-live-transcript-observer");
-        fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
-        let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
-        fs::write(&events_path, "").expect("transcript events should be created");
+        let (audit_root, source) = live_transcript_source("agentd-live-transcript-observer");
+        let mut events = nested_events_file(&source, "survey");
         let stop = AtomicBool::new(false);
         let (tx, rx) = mpsc::channel();
         thread::scope(|scope| {
             let observer = |event| {
                 tx.send(event).expect("progress event should send");
             };
-            let observer_transcript_dir = &transcript_dir;
+            let observer_source = &source;
             let observer_stop = &stop;
             let handle = scope.spawn(move || {
-                observe_transcript_events(
-                    observer_transcript_dir,
-                    "session-123",
-                    &observer,
-                    observer_stop,
-                );
+                observe_transcript_events(observer_source, "session-123", &observer, observer_stop);
             });
 
-            let mut events = fs::OpenOptions::new()
-                .append(true)
-                .open(&events_path)
-                .expect("transcript events should reopen");
             events
                 .write_all(
-                    br#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
+                    br#"{"schema_version":2,"source":"runa","kind":"agent_input","content":"working"}"#,
                 )
                 .expect("partial transcript event should be written");
             events
@@ -616,43 +659,33 @@ mod tests {
                     .expect("observer should report a live transcript event"),
                 SessionProgressEvent::TranscriptEvent {
                     session_id: "session-123".to_string(),
-                    line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#.to_string(),
+                    line: r#"{"schema_version":2,"source":"runa","kind":"agent_input","content":"working"}"#.to_string(),
                 }
             );
 
             stop.store(true, Ordering::Release);
             handle.join().expect("observer should not panic");
         });
-        fs::remove_dir_all(transcript_dir).expect("transcript dir should be removed");
+        fs::remove_dir_all(audit_root).expect("audit root should be removed");
     }
 
     #[test]
     fn transcript_observer_drops_oversized_records_whole_and_resumes_after_newline() {
-        let transcript_dir = unique_temp_dir("agentd-live-transcript-observer-oversized");
-        fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
-        let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
-        fs::write(&events_path, "").expect("transcript events should be created");
+        let (audit_root, source) =
+            live_transcript_source("agentd-live-transcript-observer-oversized");
+        let mut events = nested_events_file(&source, "survey");
         let stop = AtomicBool::new(false);
         let (tx, rx) = mpsc::channel();
         thread::scope(|scope| {
             let observer = |event| {
                 tx.send(event).expect("progress event should send");
             };
-            let observer_transcript_dir = &transcript_dir;
+            let observer_source = &source;
             let observer_stop = &stop;
             let handle = scope.spawn(move || {
-                observe_transcript_events(
-                    observer_transcript_dir,
-                    "session-123",
-                    &observer,
-                    observer_stop,
-                );
+                observe_transcript_events(observer_source, "session-123", &observer, observer_stop);
             });
 
-            let mut events = fs::OpenOptions::new()
-                .append(true)
-                .open(&events_path)
-                .expect("transcript events should reopen");
             events
                 .write_all(&vec![b'x'; MAX_LIVE_TRANSCRIPT_LINE_BYTES + 1])
                 .expect("oversized unterminated transcript event should be written");
@@ -668,7 +701,7 @@ mod tests {
             events
                 .write_all(
                     br#"
-{"schema_version":1,"source":"runa","kind":"agent_input","content":"after oversized"}
+{"schema_version":2,"source":"runa","kind":"agent_input","content":"after oversized"}
 "#,
                 )
                 .expect("oversized terminator and valid event should be written");
@@ -679,7 +712,7 @@ mod tests {
                     .expect("observer should report the valid event after oversized drop"),
                 SessionProgressEvent::TranscriptEvent {
                     session_id: "session-123".to_string(),
-                    line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"after oversized"}"#.to_string(),
+                    line: r#"{"schema_version":2,"source":"runa","kind":"agent_input","content":"after oversized"}"#.to_string(),
                 }
             );
             assert!(
@@ -690,7 +723,69 @@ mod tests {
             stop.store(true, Ordering::Release);
             handle.join().expect("observer should not panic");
         });
-        fs::remove_dir_all(transcript_dir).expect("transcript dir should be removed");
+        fs::remove_dir_all(audit_root).expect("audit root should be removed");
+    }
+
+    #[test]
+    fn transcript_observer_follows_stage_files_created_after_first_scan() {
+        let (audit_root, source) = live_transcript_source("agentd-live-transcript-observer-stages");
+        let stop = AtomicBool::new(false);
+        let (tx, rx) = mpsc::channel();
+        thread::scope(|scope| {
+            let observer = |event| {
+                tx.send(event).expect("progress event should send");
+            };
+            let observer_source = &source;
+            let observer_stop = &stop;
+            let handle = scope.spawn(move || {
+                observe_transcript_events(observer_source, "session-123", &observer, observer_stop);
+            });
+
+            thread::sleep(TRANSCRIPT_POLL_INTERVAL * 2);
+            let mut survey = nested_events_file(&source, "survey");
+            survey
+                .write_all(
+                    br#"{"schema_version":2,"source":"runa","kind":"agent_input","content":"survey"}"#,
+                )
+                .expect("survey event should be written");
+            survey
+                .write_all(b"\n")
+                .expect("survey newline should write");
+            survey.flush().expect("survey event should flush");
+
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(2))
+                    .expect("observer should report the survey stage event"),
+                SessionProgressEvent::TranscriptEvent {
+                    session_id: "session-123".to_string(),
+                    line: r#"{"schema_version":2,"source":"runa","kind":"agent_input","content":"survey"}"#.to_string(),
+                }
+            );
+
+            let mut decompose = nested_events_file(&source, "decompose");
+            decompose
+                .write_all(
+                    br#"{"schema_version":2,"source":"runa-mcp","kind":"tool_call","content":"decompose"}"#,
+                )
+                .expect("decompose event should be written");
+            decompose
+                .write_all(b"\n")
+                .expect("decompose newline should write");
+            decompose.flush().expect("decompose event should flush");
+
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(2))
+                    .expect("observer should report the later decompose stage event"),
+                SessionProgressEvent::TranscriptEvent {
+                    session_id: "session-123".to_string(),
+                    line: r#"{"schema_version":2,"source":"runa-mcp","kind":"tool_call","content":"decompose"}"#.to_string(),
+                }
+            );
+
+            stop.store(true, Ordering::Release);
+            handle.join().expect("observer should not panic");
+        });
+        fs::remove_dir_all(audit_root).expect("audit root should be removed");
     }
 
     fn reconcile_startup_resources_for_tests() -> Result<StartupReconciliationReport, RunnerError> {

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -338,10 +338,10 @@ fn observe_transcript_events(
         }
     };
 
-    let mut line = String::new();
+    let mut pending_line = String::new();
     loop {
-        line.clear();
-        match reader.read_line(&mut line) {
+        let mut chunk = String::new();
+        match reader.read_line(&mut chunk) {
             Ok(0) => {
                 if stop.load(Ordering::Acquire) {
                     return;
@@ -349,8 +349,14 @@ fn observe_transcript_events(
                 thread::sleep(TRANSCRIPT_POLL_INTERVAL);
             }
             Ok(_) => {
-                let line = line.trim_end_matches(['\r', '\n']).to_string();
-                if !line.trim().is_empty() {
+                let line_complete = chunk.ends_with('\n');
+                pending_line.push_str(&chunk);
+                if line_complete {
+                    let line = pending_line.trim_end_matches(['\r', '\n']).to_string();
+                    pending_line.clear();
+                    if line.trim().is_empty() {
+                        continue;
+                    }
                     progress.observe(SessionProgressEvent::TranscriptEvent {
                         session_id: session_id.to_string(),
                         line,
@@ -504,9 +510,11 @@ mod tests {
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
 
     #[test]
-    fn transcript_observer_reports_events_written_while_session_is_running() {
+    fn transcript_observer_waits_for_newline_before_reporting_live_event() {
         let transcript_dir = unique_temp_dir("agentd-live-transcript-observer");
         fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
+        let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+        fs::write(&events_path, "").expect("transcript events should be created");
         let stop = AtomicBool::new(false);
         let (tx, rx) = mpsc::channel();
         thread::scope(|scope| {
@@ -524,18 +532,30 @@ mod tests {
                 );
             });
 
-            let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
-            fs::write(
-                &events_path,
-                r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
-            )
-            .expect("transcript event should be written");
-            fs::OpenOptions::new()
+            let mut events = fs::OpenOptions::new()
                 .append(true)
                 .open(&events_path)
-                .expect("transcript events should reopen")
+                .expect("transcript events should reopen");
+            events
+                .write_all(
+                    br#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
+                )
+                .expect("partial transcript event should be written");
+            events
+                .flush()
+                .expect("partial transcript event should flush");
+
+            assert!(
+                rx.recv_timeout(Duration::from_millis(250)).is_err(),
+                "observer must not report a transcript event before its newline is written"
+            );
+
+            events
                 .write_all(b"\n")
                 .expect("transcript event newline should be written");
+            events
+                .flush()
+                .expect("complete transcript event should flush");
 
             assert_eq!(
                 rx.recv_timeout(Duration::from_secs(2))

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -20,6 +20,7 @@ mod podman;
 mod reconcile;
 mod resources;
 mod session_paths;
+mod transcript;
 mod types;
 mod validation;
 

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -30,8 +30,9 @@ pub(crate) mod test_support;
 pub use reconcile::reconcile_startup_resources;
 pub use types::{
     AgentNameValidationError, BindMount, EnvironmentNameValidationError, InvocationInput,
-    MountOverlapError, MountTargetValidationError, ResolvedEnvironmentVariable, RunnerError,
-    SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    MountOverlapError, MountTargetValidationError, NoopSessionProgressObserver,
+    ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
+    SessionProgressEvent, SessionProgressObserver, SessionSpec, StartupReconciliationReport,
 };
 pub use validation::{
     validate_agent_name, validate_environment_name, validate_mount_overlap, validate_mount_target,
@@ -50,10 +51,21 @@ use lifecycle::{
 };
 use naming::format_container_name;
 use resources::{
-    ResourceAllocationFailure, SessionResources, cleanup_methodology_staging_dir,
+    ResourceAllocationFailure, SecretBinding, SessionResources, cleanup_methodology_staging_dir,
     cleanup_podman_secrets, prepare_session_resources, unique_suffix,
 };
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
 use validation::{validate_invocation, validate_spec};
+
+const TRANSCRIPT_EVENTS_FILE: &str = "events.jsonl";
+const TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Executes a single session from validation through teardown.
 ///
@@ -70,6 +82,16 @@ use validation::{validate_invocation, validate_spec};
 pub fn run_session(
     spec: SessionSpec,
     invocation: SessionInvocation,
+) -> Result<SessionOutcome, RunnerError> {
+    run_session_with_progress(spec, invocation, &NoopSessionProgressObserver)
+}
+
+/// Executes a single session and reports best-effort transcript progress while
+/// the session process is running.
+pub fn run_session_with_progress(
+    spec: SessionSpec,
+    invocation: SessionInvocation,
+    progress: &dyn SessionProgressObserver,
 ) -> Result<SessionOutcome, RunnerError> {
     validate_spec(&spec)?;
     validate_invocation(&invocation)?;
@@ -189,17 +211,13 @@ pub fn run_session(
     }
 
     let secret_bindings = resources.all_secret_bindings();
-    let start_result = match invocation.timeout {
-        Some(timeout) => run_container_with_timeout(
-            &resources.container_name,
-            &session_id,
-            &secret_bindings,
-            timeout,
-        ),
-        None => {
-            run_container_to_completion(&resources.container_name, &session_id, &secret_bindings)
-        }
-    };
+    let start_result = run_container_with_transcript_progress(
+        &resources,
+        &session_id,
+        &secret_bindings,
+        invocation.timeout,
+        progress,
+    );
 
     match &start_result {
         Ok(outcome) => log_session_outcome(&session_id, &resources.container_name, outcome),
@@ -248,6 +266,142 @@ pub fn run_session(
     }
 }
 
+fn run_container_with_transcript_progress(
+    resources: &SessionResources,
+    session_id: &str,
+    secret_bindings: &[SecretBinding],
+    timeout: Option<Duration>,
+    progress: &dyn SessionProgressObserver,
+) -> Result<SessionOutcome, RunnerError> {
+    let stop = Arc::new(AtomicBool::new(false));
+    thread::scope(|scope| {
+        let observer_stop = Arc::clone(&stop);
+        let observer = scope.spawn(move || {
+            observe_transcript_events(
+                &resources.audit_record.transcript_dir,
+                session_id,
+                progress,
+                &observer_stop,
+            );
+        });
+
+        let result = match timeout {
+            Some(timeout) => run_container_with_timeout(
+                &resources.container_name,
+                session_id,
+                secret_bindings,
+                timeout,
+            ),
+            None => {
+                run_container_to_completion(&resources.container_name, session_id, secret_bindings)
+            }
+        };
+        stop.store(true, Ordering::Release);
+        if observer.join().is_err() {
+            tracing::warn!(
+                event = "runner.transcript_progress_observer_panicked",
+                session_id = session_id,
+                container_name = %resources.container_name,
+                "transcript progress observer panicked"
+            );
+        }
+        result
+    })
+}
+
+fn observe_transcript_events(
+    transcript_dir: &Path,
+    session_id: &str,
+    progress: &dyn SessionProgressObserver,
+    stop: &AtomicBool,
+) {
+    let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+    let mut reader = loop {
+        match open_live_transcript_events(&events_path) {
+            Ok(file) => break BufReader::new(file),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if stop.load(Ordering::Acquire) {
+                    return;
+                }
+                thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "runner.transcript_progress_unavailable",
+                    session_id = session_id,
+                    path = %events_path.display(),
+                    error = %error,
+                    "live transcript progress unavailable"
+                );
+                return;
+            }
+        }
+    };
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                if stop.load(Ordering::Acquire) {
+                    return;
+                }
+                thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+            }
+            Ok(_) => {
+                let line = line.trim_end_matches(['\r', '\n']).to_string();
+                if !line.trim().is_empty() {
+                    progress.observe(SessionProgressEvent::TranscriptEvent {
+                        session_id: session_id.to_string(),
+                        line,
+                    });
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "runner.transcript_progress_read_failed",
+                    session_id = session_id,
+                    path = %events_path.display(),
+                    error = %error,
+                    "failed to read live transcript progress"
+                );
+                return;
+            }
+        }
+    }
+}
+
+fn open_live_transcript_events(path: &Path) -> Result<File, io::Error> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_file() {
+        return Err(io::Error::other(format!(
+            "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
+        )));
+    }
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|error| match error.raw_os_error() {
+            Some(libc::ELOOP) => io::Error::other(format!(
+                "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
+            )),
+            _ => error,
+        })?;
+    let open_metadata = file.metadata()?;
+    if !open_metadata.is_file()
+        || open_metadata.dev() != metadata.dev()
+        || open_metadata.ino() != metadata.ino()
+    {
+        return Err(io::Error::other(format!(
+            "unsafe transcript artifact: {TRANSCRIPT_EVENTS_FILE} is not a regular file"
+        )));
+    }
+
+    Ok(file)
+}
+
 fn cleanup_session_resources(resources: &SessionResources) -> Result<(), RunnerError> {
     let container_result = container::cleanup_container(&resources.container_name);
     let secret_bindings = resources.all_secret_bindings();
@@ -293,8 +447,11 @@ mod tests {
     };
     use serde_json::Value;
     use std::fs;
+    use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
     use std::thread;
     use std::time::{Duration, Instant};
 
@@ -345,6 +502,55 @@ mod tests {
     }
 
     const TEST_DAEMON_INSTANCE_ID: &str = "1a2b3c4d";
+
+    #[test]
+    fn transcript_observer_reports_events_written_while_session_is_running() {
+        let transcript_dir = unique_temp_dir("agentd-live-transcript-observer");
+        fs::create_dir_all(&transcript_dir).expect("transcript dir should be created");
+        let stop = AtomicBool::new(false);
+        let (tx, rx) = mpsc::channel();
+        thread::scope(|scope| {
+            let observer = |event| {
+                tx.send(event).expect("progress event should send");
+            };
+            let observer_transcript_dir = &transcript_dir;
+            let observer_stop = &stop;
+            let handle = scope.spawn(move || {
+                observe_transcript_events(
+                    observer_transcript_dir,
+                    "session-123",
+                    &observer,
+                    observer_stop,
+                );
+            });
+
+            let events_path = transcript_dir.join(TRANSCRIPT_EVENTS_FILE);
+            fs::write(
+                &events_path,
+                r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#,
+            )
+            .expect("transcript event should be written");
+            fs::OpenOptions::new()
+                .append(true)
+                .open(&events_path)
+                .expect("transcript events should reopen")
+                .write_all(b"\n")
+                .expect("transcript event newline should be written");
+
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(2))
+                    .expect("observer should report a live transcript event"),
+                SessionProgressEvent::TranscriptEvent {
+                    session_id: "session-123".to_string(),
+                    line: r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working"}"#.to_string(),
+                }
+            );
+
+            stop.store(true, Ordering::Release);
+            handle.join().expect("observer should not panic");
+        });
+        fs::remove_dir_all(transcript_dir).expect("transcript dir should be removed");
+    }
 
     fn reconcile_startup_resources_for_tests() -> Result<StartupReconciliationReport, RunnerError> {
         reconcile_startup_resources(TEST_DAEMON_INSTANCE_ID)

--- a/crates/agentd-runner/src/resources.rs
+++ b/crates/agentd-runner/src/resources.rs
@@ -580,6 +580,11 @@ mod tests {
             agent: "site-builder".to_string(),
             repo_url: "https://example.com/repo.git".to_string(),
             work_unit: None,
+            transcript_identity: crate::transcript::TranscriptIdentity::new(
+                "github",
+                "https://example.com/repo.git",
+                session_id,
+            ),
             start_timestamp: "2026-04-16T00:00:00Z".to_string(),
         }
     }

--- a/crates/agentd-runner/src/transcript.rs
+++ b/crates/agentd-runner/src/transcript.rs
@@ -8,8 +8,13 @@
 use crate::audit::SessionAuditRecord;
 use crate::types::RunnerError;
 use sha2::{Digest, Sha256};
-use std::fs;
-use std::path::PathBuf;
+use std::ffi::{CString, OsStr, OsString};
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
 
 pub(crate) const TRANSCRIPT_DEPLOYMENT_ENV: &str = "RUNA_TRANSCRIPT_DEPLOYMENT";
 pub(crate) const TRANSCRIPT_RUN_ID_ENV: &str = "RUNA_TRANSCRIPT_RUN_ID";
@@ -50,6 +55,19 @@ pub(crate) struct TranscriptEventSource {
     identity: TranscriptIdentity,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TranscriptEventFile {
+    path: PathBuf,
+    work_unit_component: OsString,
+}
+
+impl TranscriptEventFile {
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
 impl TranscriptEventSource {
     pub(crate) fn from_record(record: &SessionAuditRecord) -> Self {
         Self {
@@ -67,37 +85,76 @@ impl TranscriptEventSource {
             .join(EVENTS_FILE)
     }
 
-    pub(crate) fn discover_event_files(&self) -> Result<Vec<PathBuf>, RunnerError> {
-        let work_units_dir = self.work_units_dir();
-        let entries = match fs::read_dir(&work_units_dir) {
-            Ok(entries) => entries,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(Vec::new());
-            }
-            Err(error) => return Err(RunnerError::Io(error)),
+    pub(crate) fn discover_event_files(&self) -> Result<Vec<TranscriptEventFile>, RunnerError> {
+        let base_dir = open_base_dir(&self.transcript_dir)?;
+        let Some(deployments_dir) = open_optional_dir_at(&base_dir, OsStr::new(DEPLOYMENTS_DIR))?
+        else {
+            return Ok(Vec::new());
+        };
+        let encoded_deployment = encode_path_component(self.identity.deployment());
+        let Some(deployment_dir) =
+            open_optional_dir_at(&deployments_dir, OsStr::new(&encoded_deployment))?
+        else {
+            return Ok(Vec::new());
+        };
+        let Some(work_units_dir) =
+            open_optional_dir_at(&deployment_dir, OsStr::new(WORK_UNITS_DIR))?
+        else {
+            return Ok(Vec::new());
         };
 
-        let encoded_run_id = encode_path_component(self.identity.run_id());
+        let encoded_run_id = OsString::from(encode_path_component(self.identity.run_id()));
+        let work_units_path = self.work_units_dir();
         let mut event_files = Vec::new();
-        for entry in entries {
-            let entry = entry?;
-            let metadata = fs::symlink_metadata(entry.path())?;
-            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        for work_unit_component in read_dir_names(&work_units_dir)? {
+            let Some(metadata) = metadata_at(&work_units_dir, &work_unit_component)? else {
+                continue;
+            };
+            if !is_directory(metadata.st_mode) {
                 continue;
             }
-            let event_path = entry
-                .path()
-                .join(RUNS_DIR)
-                .join(&encoded_run_id)
-                .join(EVENTS_FILE);
-            match fs::symlink_metadata(&event_path) {
-                Ok(_) => event_files.push(event_path),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(RunnerError::Io(error)),
+
+            let Some(work_unit_dir) = open_optional_dir_at(&work_units_dir, &work_unit_component)?
+            else {
+                continue;
+            };
+            let Some(runs_dir) = open_optional_dir_at(&work_unit_dir, OsStr::new(RUNS_DIR))? else {
+                continue;
+            };
+            let Some(run_dir) = open_optional_dir_at(&runs_dir, &encoded_run_id)? else {
+                continue;
+            };
+            if entry_exists_at(&run_dir, OsStr::new(EVENTS_FILE))? {
+                let path = work_units_path
+                    .join(&work_unit_component)
+                    .join(RUNS_DIR)
+                    .join(&encoded_run_id)
+                    .join(EVENTS_FILE);
+                event_files.push(TranscriptEventFile {
+                    path,
+                    work_unit_component,
+                });
             }
         }
-        event_files.sort();
+        event_files.sort_by(|left, right| left.path.cmp(&right.path));
         Ok(event_files)
+    }
+
+    pub(crate) fn open_event_file(
+        &self,
+        event_file: &TranscriptEventFile,
+    ) -> Result<File, RunnerError> {
+        let base_dir = open_base_dir(&self.transcript_dir)?;
+        let deployments_dir = open_required_dir_at(&base_dir, OsStr::new(DEPLOYMENTS_DIR))?;
+        let encoded_deployment = encode_path_component(self.identity.deployment());
+        let deployment_dir =
+            open_required_dir_at(&deployments_dir, OsStr::new(&encoded_deployment))?;
+        let work_units_dir = open_required_dir_at(&deployment_dir, OsStr::new(WORK_UNITS_DIR))?;
+        let work_unit_dir = open_required_dir_at(&work_units_dir, &event_file.work_unit_component)?;
+        let runs_dir = open_required_dir_at(&work_unit_dir, OsStr::new(RUNS_DIR))?;
+        let encoded_run_id = OsString::from(encode_path_component(self.identity.run_id()));
+        let run_dir = open_required_dir_at(&runs_dir, &encoded_run_id)?;
+        open_regular_file_at(&run_dir, OsStr::new(EVENTS_FILE))
     }
 
     fn work_units_dir(&self) -> PathBuf {
@@ -106,6 +163,180 @@ impl TranscriptEventSource {
             .join(encode_path_component(self.identity.deployment()))
             .join(WORK_UNITS_DIR)
     }
+}
+
+fn open_base_dir(path: &Path) -> Result<File, RunnerError> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|error| match error.raw_os_error() {
+            Some(libc::ELOOP) | Some(libc::ENOTDIR) => {
+                unsafe_transcript_path_error(&path.display().to_string(), "is not a directory")
+            }
+            _ => RunnerError::Io(error),
+        })
+}
+
+fn open_required_dir_at(parent: &File, component: &OsStr) -> Result<File, RunnerError> {
+    open_optional_dir_at(parent, component)?.ok_or_else(|| {
+        RunnerError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "transcript directory component not found: {}",
+                component.to_string_lossy()
+            ),
+        ))
+    })
+}
+
+fn open_optional_dir_at(parent: &File, component: &OsStr) -> Result<Option<File>, RunnerError> {
+    let component = cstring_component(component)?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            component.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd >= 0 {
+        return Ok(Some(unsafe { File::from_raw_fd(fd) }));
+    }
+
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ENOENT) => Ok(None),
+        Some(libc::ELOOP) | Some(libc::ENOTDIR) => Err(unsafe_transcript_path_error(
+            &component.to_string_lossy(),
+            "is not a directory",
+        )),
+        _ => Err(RunnerError::Io(error)),
+    }
+}
+
+fn read_dir_names(dir: &File) -> Result<Vec<OsString>, RunnerError> {
+    let proc_fd_path = PathBuf::from(format!("/proc/self/fd/{}", dir.as_raw_fd()));
+    let mut names = Vec::new();
+    for entry in fs::read_dir(proc_fd_path)? {
+        names.push(entry?.file_name());
+    }
+    Ok(names)
+}
+
+fn metadata_at(parent: &File, component: &OsStr) -> Result<Option<libc::stat>, RunnerError> {
+    let component = cstring_component(component)?;
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    let result = unsafe {
+        libc::fstatat(
+            parent.as_raw_fd(),
+            component.as_ptr(),
+            metadata.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result == 0 {
+        return Ok(Some(unsafe { metadata.assume_init() }));
+    }
+
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ENOENT) => Ok(None),
+        _ => Err(RunnerError::Io(error)),
+    }
+}
+
+fn entry_exists_at(parent: &File, component: &OsStr) -> Result<bool, RunnerError> {
+    metadata_at(parent, component).map(|metadata| metadata.is_some())
+}
+
+fn open_regular_file_at(parent: &File, component: &OsStr) -> Result<File, RunnerError> {
+    let metadata = metadata_at(parent, component)?.ok_or_else(|| {
+        RunnerError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "transcript event file not found: {}",
+                component.to_string_lossy()
+            ),
+        ))
+    })?;
+    if !is_regular_file(metadata.st_mode) {
+        return Err(unsafe_transcript_artifact_error(
+            EVENTS_FILE,
+            "is not a regular file",
+        ));
+    }
+
+    let component = cstring_component(component)?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            component.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        let error = io::Error::last_os_error();
+        return Err(match error.raw_os_error() {
+            Some(libc::ELOOP) => {
+                unsafe_transcript_artifact_error(EVENTS_FILE, "is not a regular file")
+            }
+            _ => RunnerError::Io(error),
+        });
+    }
+
+    let file = unsafe { File::from_raw_fd(fd) };
+    let mut open_metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    let result = unsafe { libc::fstat(file.as_raw_fd(), open_metadata.as_mut_ptr()) };
+    if result != 0 {
+        return Err(RunnerError::Io(io::Error::last_os_error()));
+    }
+    let open_metadata = unsafe { open_metadata.assume_init() };
+    if !is_regular_file(open_metadata.st_mode)
+        || open_metadata.st_dev != metadata.st_dev
+        || open_metadata.st_ino != metadata.st_ino
+    {
+        return Err(unsafe_transcript_artifact_error(
+            EVENTS_FILE,
+            "is not a regular file",
+        ));
+    }
+
+    Ok(file)
+}
+
+fn cstring_component(component: &OsStr) -> Result<CString, RunnerError> {
+    if component.as_bytes().contains(&b'/') {
+        return Err(unsafe_transcript_path_error(
+            &component.to_string_lossy(),
+            "contains a path separator",
+        ));
+    }
+    CString::new(component.as_bytes()).map_err(|error| {
+        RunnerError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path component contains interior nul byte: {error}"),
+        ))
+    })
+}
+
+fn is_directory(mode: libc::mode_t) -> bool {
+    (mode & libc::S_IFMT) == libc::S_IFDIR
+}
+
+fn is_regular_file(mode: libc::mode_t) -> bool {
+    (mode & libc::S_IFMT) == libc::S_IFREG
+}
+
+fn unsafe_transcript_path_error(component: &str, reason: &str) -> RunnerError {
+    RunnerError::Io(io::Error::other(format!(
+        "unsafe transcript path: {component} {reason}"
+    )))
+}
+
+fn unsafe_transcript_artifact_error(artifact: &str, reason: &str) -> RunnerError {
+    RunnerError::Io(io::Error::other(format!(
+        "unsafe transcript artifact: {artifact} {reason}"
+    )))
 }
 
 #[cfg(test)]

--- a/crates/agentd-runner/src/transcript.rs
+++ b/crates/agentd-runner/src/transcript.rs
@@ -1,0 +1,197 @@
+//! Shared transcript identity and path resolution for runa event records.
+//!
+//! Runa emits events below
+//! `deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.jsonl`.
+//! agentd owns the deployment and run identifiers it injects into runa, then
+//! reads only paths addressable from those injected values.
+
+use crate::audit::SessionAuditRecord;
+use crate::types::RunnerError;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::PathBuf;
+
+pub(crate) const TRANSCRIPT_DEPLOYMENT_ENV: &str = "RUNA_TRANSCRIPT_DEPLOYMENT";
+pub(crate) const TRANSCRIPT_RUN_ID_ENV: &str = "RUNA_TRANSCRIPT_RUN_ID";
+
+const DEPLOYMENTS_DIR: &str = "deployments";
+const WORK_UNITS_DIR: &str = "work-units";
+const RUNS_DIR: &str = "runs";
+const EVENTS_FILE: &str = "events.jsonl";
+#[cfg(test)]
+const UNSCOPED_WORK_UNIT: &str = "_unscoped";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TranscriptIdentity {
+    deployment: String,
+    run_id: String,
+}
+
+impl TranscriptIdentity {
+    pub(crate) fn new(forge_type: &str, repo_url: &str, session_id: &str) -> Self {
+        Self {
+            deployment: deployment_identity(forge_type, repo_url),
+            run_id: session_id.to_string(),
+        }
+    }
+
+    pub(crate) fn deployment(&self) -> &str {
+        &self.deployment
+    }
+
+    pub(crate) fn run_id(&self) -> &str {
+        &self.run_id
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TranscriptEventSource {
+    transcript_dir: PathBuf,
+    identity: TranscriptIdentity,
+}
+
+impl TranscriptEventSource {
+    pub(crate) fn from_record(record: &SessionAuditRecord) -> Self {
+        Self {
+            transcript_dir: record.transcript_dir.clone(),
+            identity: record.transcript_identity.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn event_file_path_for_work_unit(&self, work_unit: &str) -> PathBuf {
+        self.work_units_dir()
+            .join(encode_path_component(work_unit))
+            .join(RUNS_DIR)
+            .join(encode_path_component(self.identity.run_id()))
+            .join(EVENTS_FILE)
+    }
+
+    pub(crate) fn discover_event_files(&self) -> Result<Vec<PathBuf>, RunnerError> {
+        let work_units_dir = self.work_units_dir();
+        let entries = match fs::read_dir(&work_units_dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(RunnerError::Io(error)),
+        };
+
+        let encoded_run_id = encode_path_component(self.identity.run_id());
+        let mut event_files = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            let metadata = fs::symlink_metadata(entry.path())?;
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                continue;
+            }
+            let event_path = entry
+                .path()
+                .join(RUNS_DIR)
+                .join(&encoded_run_id)
+                .join(EVENTS_FILE);
+            match fs::symlink_metadata(&event_path) {
+                Ok(_) => event_files.push(event_path),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(RunnerError::Io(error)),
+            }
+        }
+        event_files.sort();
+        Ok(event_files)
+    }
+
+    fn work_units_dir(&self) -> PathBuf {
+        self.transcript_dir
+            .join(DEPLOYMENTS_DIR)
+            .join(encode_path_component(self.identity.deployment()))
+            .join(WORK_UNITS_DIR)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn scoped_work_unit_component(work_unit: Option<&str>) -> &str {
+    work_unit.unwrap_or(UNSCOPED_WORK_UNIT)
+}
+
+pub(crate) fn encode_path_component(component: &str) -> String {
+    if component.is_empty() {
+        return "_empty".to_string();
+    }
+
+    let all_dots = component.bytes().all(|byte| byte == b'.');
+    let mut encoded = String::new();
+    for byte in component.bytes() {
+        if !all_dots && is_safe_path_component_byte(byte) {
+            encoded.push(byte as char);
+        } else {
+            encoded.push('%');
+            encoded.push(nibble_to_hex(byte >> 4));
+            encoded.push(nibble_to_hex(byte & 0x0f));
+        }
+    }
+    encoded
+}
+
+fn deployment_identity(forge_type: &str, repo_url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"agentd transcript deployment identity v1\0");
+    hasher.update(forge_type.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(repo_url.as_bytes());
+    let digest = hasher.finalize();
+
+    let mut identity = String::from("agentd-");
+    for byte in digest {
+        identity.push(nibble_to_hex(byte >> 4));
+        identity.push(nibble_to_hex(byte & 0x0f));
+    }
+    identity
+}
+
+fn is_safe_path_component_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+}
+
+fn nibble_to_hex(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        10..=15 => (b'A' + (nibble - 10)) as char,
+        _ => unreachable!("nibble must be four bits"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_path_component_matches_runa_for_safe_empty_dotted_and_unsafe_segments() {
+        assert_eq!(encode_path_component("safe-AZaz09_."), "safe-AZaz09_.");
+        assert_eq!(encode_path_component(""), "_empty");
+        assert_eq!(encode_path_component("."), "%2E");
+        assert_eq!(encode_path_component("..."), "%2E%2E%2E");
+        assert_eq!(
+            encode_path_component("take/stage#1 space"),
+            "take%2Fstage%231%20space"
+        );
+    }
+
+    #[test]
+    fn transcript_identity_is_stable_for_project_and_uses_session_id_as_run_id() {
+        let first = TranscriptIdentity::new("github", "https://example.com/agentd.git", "abc123");
+        let second = TranscriptIdentity::new("github", "https://example.com/agentd.git", "abc123");
+        let other_repo =
+            TranscriptIdentity::new("github", "https://example.com/other.git", "abc123");
+
+        assert_eq!(first, second);
+        assert_ne!(first.deployment(), other_repo.deployment());
+        assert_eq!(first.run_id(), "abc123");
+        assert!(first.deployment().starts_with("agentd-"));
+    }
+
+    #[test]
+    fn unscoped_work_unit_component_matches_runa_fallback_component() {
+        assert_eq!(scoped_work_unit_component(None), "_unscoped");
+        assert_eq!(scoped_work_unit_component(Some("issue-162")), "issue-162");
+    }
+}

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -139,7 +139,7 @@ pub struct SessionInvocation {
 /// Non-terminal progress observed while a session is executing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionProgressEvent {
-    /// One complete line from `agentd/transcript/events.jsonl`.
+    /// One complete line from a runa nested transcript `events.jsonl`.
     TranscriptEvent { session_id: String, line: String },
 }
 

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -136,6 +136,35 @@ pub struct SessionInvocation {
     pub timeout: Option<Duration>,
 }
 
+/// Non-terminal progress observed while a session is executing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionProgressEvent {
+    /// One complete line from `agentd/transcript/events.jsonl`.
+    TranscriptEvent { session_id: String, line: String },
+}
+
+/// Receives best-effort execution progress while a session is running.
+pub trait SessionProgressObserver: Send + Sync {
+    fn observe(&self, event: SessionProgressEvent);
+}
+
+impl<F> SessionProgressObserver for F
+where
+    F: Fn(SessionProgressEvent) + Send + Sync,
+{
+    fn observe(&self, event: SessionProgressEvent) {
+        self(event);
+    }
+}
+
+/// Progress observer used by callers that only need the terminal outcome.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopSessionProgressObserver;
+
+impl SessionProgressObserver for NoopSessionProgressObserver {
+    fn observe(&self, _event: SessionProgressEvent) {}
+}
+
 /// Terminal outcome of a completed session.
 ///
 /// Labels and exit-code semantics implement the shared session-outcome

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -53,7 +53,8 @@ pub struct SessionSpec {
     /// are passed as direct `--env` assignments.
     /// Names reserved for runner-owned values such as `AGENT_NAME`,
     /// `GROUNDWORK_FORGE_TYPE`, `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`,
-    /// `RUNA_TRANSCRIPT_DIR`, and `RUNA_TRANSCRIPT_REDACT_ENV` are rejected
+    /// `RUNA_TRANSCRIPT_DIR`, `RUNA_TRANSCRIPT_DEPLOYMENT`,
+    /// `RUNA_TRANSCRIPT_RUN_ID`, and `RUNA_TRANSCRIPT_REDACT_ENV` are rejected
     /// during validation.
     pub environment: Vec<ResolvedEnvironmentVariable>,
 }
@@ -435,7 +436,10 @@ impl fmt::Display for RunnerError {
             RunnerError::ReservedEnvironmentName { name } => {
                 if matches!(
                     name.as_str(),
-                    "RUNA_TRANSCRIPT_DIR" | "RUNA_TRANSCRIPT_REDACT_ENV"
+                    "RUNA_TRANSCRIPT_DIR"
+                        | "RUNA_TRANSCRIPT_DEPLOYMENT"
+                        | "RUNA_TRANSCRIPT_RUN_ID"
+                        | "RUNA_TRANSCRIPT_REDACT_ENV"
                 ) {
                     write!(
                         f,

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -9,6 +9,7 @@
 use crate::input::INVOCATION_INPUT_MOUNT_PATH;
 use crate::naming::is_daemon_instance_id;
 use crate::session_paths::{session_home_dir, session_internal_agentd_dir, session_repo_dir};
+use crate::transcript::{TRANSCRIPT_DEPLOYMENT_ENV, TRANSCRIPT_RUN_ID_ENV};
 use crate::types::{
     AgentNameValidationError, BindMount, EnvironmentNameValidationError, InvocationInput,
     MountOverlapError, MountTargetValidationError, RunnerError, SessionInvocation, SessionSpec,
@@ -199,7 +200,8 @@ fn validate_work_mode_input(work_unit: &str, input: &InvocationInput) -> Result<
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
 /// runner-managed names such as `AGENT_NAME`, `GROUNDWORK_FORGE_TYPE`,
-/// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`, and
+/// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`,
+/// `RUNA_TRANSCRIPT_DEPLOYMENT`, `RUNA_TRANSCRIPT_RUN_ID`, and
 /// `RUNA_TRANSCRIPT_REDACT_ENV`. Used both by
 /// [`run_session`](crate::run_session) during spec validation and by the
 /// configuration layer for credential name validation.
@@ -404,6 +406,8 @@ fn is_reserved_environment_name(name: &str) -> bool {
             | WORK_UNIT_ENV
             | REPO_TOKEN_ENV
             | TRANSCRIPT_DIR_ENV
+            | TRANSCRIPT_DEPLOYMENT_ENV
+            | TRANSCRIPT_RUN_ID_ENV
             | TRANSCRIPT_REDACT_ENV
     )
 }
@@ -518,6 +522,8 @@ mod tests {
             WORK_UNIT_ENV,
             REPO_TOKEN_ENV,
             "RUNA_TRANSCRIPT_DIR",
+            "RUNA_TRANSCRIPT_DEPLOYMENT",
+            "RUNA_TRANSCRIPT_RUN_ID",
             "RUNA_TRANSCRIPT_REDACT_ENV",
         ] {
             let error = validate_spec(&SessionSpec {

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -57,6 +57,32 @@ fn wait_for_session_record_dir(audit_root: &Path, agent_name: &str, timeout: Dur
     }
 }
 
+fn nested_transcript_event_files(transcript_dir: &Path) -> Vec<PathBuf> {
+    let mut event_files = Vec::new();
+    collect_nested_transcript_event_files(transcript_dir, &mut event_files);
+    event_files.sort();
+    event_files
+}
+
+fn collect_nested_transcript_event_files(path: &Path, event_files: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.expect("transcript directory entry should be readable");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_nested_transcript_event_files(&path, event_files);
+        } else if path.file_name().and_then(|name| name.to_str()) == Some("events.jsonl")
+            && path
+                .components()
+                .any(|component| component.as_os_str() == std::ffi::OsStr::new("deployments"))
+        {
+            event_files.push(path);
+        }
+    }
+}
+
 fn write_methodology_manifest(path: &Path, artifact_types: &[&str]) {
     let mut manifest = String::from("name = \"test-methodology\"\n");
     for artifact_type in artifact_types {
@@ -1078,8 +1104,14 @@ fn persists_session_transcript_under_agentd_audit_dir() {
     assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
 
     let transcript_dir = fixture.only_session_record_dir().join("agentd/transcript");
-    let events = fs::read_to_string(transcript_dir.join("events.jsonl"))
-        .expect("structured transcript events should persist");
+    assert!(
+        !transcript_dir.join("events.jsonl").exists(),
+        "agentd should not use a flat transcript event stream"
+    );
+    let event_files = nested_transcript_event_files(&transcript_dir);
+    assert_eq!(event_files.len(), 1, "expected one nested runa event file");
+    let events =
+        fs::read_to_string(&event_files[0]).expect("structured transcript events should persist");
     assert!(events.contains("\"kind\":\"agent_input\""), "{events}");
     assert!(events.contains("\"kind\":\"agent_exit\""), "{events}");
 
@@ -1090,13 +1122,14 @@ fn persists_session_transcript_under_agentd_audit_dir() {
     .expect("transcript manifest should be json");
     assert_eq!(manifest["schema_version"], 1);
     assert_eq!(manifest["coverage"], "missing_mcp_events");
+    assert_eq!(manifest["event_schema_versions"], serde_json::json!([2]));
 
     let markdown = fs::read_to_string(transcript_dir.join("transcript.md"))
         .expect("human-readable transcript should persist");
     assert!(markdown.contains("# Session Transcript"), "{markdown}");
     assert!(markdown.contains("agent_input"), "{markdown}");
 
-    let events_mode = fs::metadata(transcript_dir.join("events.jsonl"))
+    let events_mode = fs::metadata(&event_files[0])
         .expect("events permissions should exist")
         .permissions()
         .mode();
@@ -1158,6 +1191,7 @@ fn finalizes_session_after_runtime_restricts_transcript_directory_permissions() 
         serde_json::from_str(&manifest_result.expect("transcript manifest should persist"))
             .expect("transcript manifest should be json");
     assert_eq!(manifest["coverage"], "missing_mcp_events");
+    assert_eq!(manifest["event_schema_versions"], serde_json::json!([2]));
 
     let markdown = fs::read_to_string(transcript_dir.join("transcript.md"))
         .expect("human-readable transcript should persist");
@@ -1225,17 +1259,17 @@ fn finalizes_session_after_runtime_restricts_events_jsonl_permissions() {
 
     let record_dir = fixture.only_session_record_dir();
     let transcript_dir = record_dir.join("agentd/transcript");
-    let events_path = transcript_dir.join("events.jsonl");
     let manifest_result = fs::read_to_string(transcript_dir.join("manifest.json"));
-    if manifest_result.is_err() {
-        let _ = fs::set_permissions(&events_path, fs::Permissions::from_mode(0o644));
-    }
     let manifest: Value =
         serde_json::from_str(&manifest_result.expect("transcript manifest should persist"))
             .expect("transcript manifest should be json");
     assert_eq!(manifest["coverage"], "missing_mcp_events");
+    assert_eq!(manifest["event_schema_versions"], serde_json::json!([2]));
 
-    let events = fs::read_to_string(&events_path).expect("structured transcript should persist");
+    let event_files = nested_transcript_event_files(&transcript_dir);
+    assert_eq!(event_files.len(), 1, "expected one nested runa event file");
+    let events_path = &event_files[0];
+    let events = fs::read_to_string(events_path).expect("structured transcript should persist");
     assert!(events.contains("\"kind\":\"agent_input\""), "{events}");
 
     let session: Value = serde_json::from_str(
@@ -1245,7 +1279,7 @@ fn finalizes_session_after_runtime_restricts_events_jsonl_permissions() {
     .expect("session metadata should be json");
     assert_eq!(session["outcome"], "success");
 
-    let events_mode = fs::metadata(&events_path)
+    let events_mode = fs::metadata(events_path)
         .expect("events metadata should exist")
         .permissions()
         .mode()
@@ -2418,6 +2452,21 @@ exit 97
 const RUNA_STUB: &str = r#"#!/bin/sh
 set -eu
 
+transcript_events_file() {
+    work_unit_component="${1:-_unscoped}"
+    printf '%s/deployments/%s/work-units/%s/runs/%s/events.jsonl' \
+        "${RUNA_TRANSCRIPT_DIR:?}" \
+        "${RUNA_TRANSCRIPT_DEPLOYMENT:?}" \
+        "$work_unit_component" \
+        "${RUNA_TRANSCRIPT_RUN_ID:?}"
+}
+
+append_transcript_event() {
+    event_file="$(transcript_events_file "$1")"
+    mkdir -p "$(dirname "$event_file")"
+    printf '%s\n' "$2" >> "$event_file"
+}
+
 subcommand="${1:-}"
         if [ "$#" -gt 0 ]; then
             shift
@@ -2476,9 +2525,8 @@ EOF
                         printf 'run --agent-command -- %s\n' "$*" >> .runa/calls.log
                     fi
                     if [ -n "${RUNA_TRANSCRIPT_DIR:-}" ]; then
-                        mkdir -p "${RUNA_TRANSCRIPT_DIR}"
-                        printf '{"schema_version":1,"source":"runa","kind":"agent_input","content":"stub prompt"}\n' >> "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
-                        printf '{"schema_version":1,"source":"runa","kind":"agent_exit","success":true}\n' >> "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
+                        append_transcript_event "$work_unit" '{"schema_version":2,"source":"runa","kind":"agent_input","content":"stub prompt"}'
+                        append_transcript_event "$work_unit" '{"schema_version":2,"source":"runa","kind":"agent_exit","success":true}'
                     fi
                     exec "$@"
                     ;;
@@ -2622,6 +2670,21 @@ fn write_http_response(stream: &mut TcpStream, status: &str, body: &[u8], head_o
 const SITE_BUILDER_STUB: &str = r#"#!/bin/sh
 set -eu
 
+transcript_events_file() {
+    work_unit_component="${AGENTD_WORK_UNIT:-_unscoped}"
+    printf '%s/deployments/%s/work-units/%s/runs/%s/events.jsonl' \
+        "${RUNA_TRANSCRIPT_DIR:?}" \
+        "${RUNA_TRANSCRIPT_DEPLOYMENT:?}" \
+        "$work_unit_component" \
+        "${RUNA_TRANSCRIPT_RUN_ID:?}"
+}
+
+append_transcript_event() {
+    event_file="$(transcript_events_file)"
+    mkdir -p "$(dirname "$event_file")"
+    printf '%s\n' "$1" >> "$event_file"
+}
+
 command_name="$1"
 shift
 
@@ -2662,7 +2725,7 @@ case "$command_name" in
         fi
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "restrict-transcript-events" ]; then
-            chmod 000 "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
+            chmod 000 "$(transcript_events_file)"
             exit 0
         fi
 
@@ -2704,7 +2767,7 @@ case "$command_name" in
             printf '{"status":"landed"}\n' > "${HOME}/repo/.runa/workspace/completion-record/land.json"
             printf '{"events":[{"protocol":"specify","artifact":"behavior-contract","postcondition":"passed"},{"protocol":"plan","artifact":"implementation-plan","postcondition":"passed"},{"protocol":"implement","artifact":"patch","postcondition":"passed"},{"protocol":"verify","artifact":"test-evidence","postcondition":"passed"},{"protocol":"document","artifact":"documentation-record","postcondition":"passed"},{"protocol":"submit","artifact":"completion-record","postcondition":"passed"},{"protocol":"land","artifact":"completion-record","postcondition":"passed"}]}\n' > "${HOME}/repo/.runa/store/executions/0001.json"
             if [ -n "${RUNA_TRANSCRIPT_DIR:-}" ]; then
-                printf '{"schema_version":1,"source":"runa-mcp","kind":"tool_call","protocol":"take"}\n' >> "${RUNA_TRANSCRIPT_DIR}/events.jsonl"
+                append_transcript_event '{"schema_version":2,"source":"runa-mcp","kind":"tool_call","protocol":"take"}'
             fi
             exit 0
         fi

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -666,7 +666,7 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::InvalidCredentialName { agent, name } => write!(
                 f,
-                "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, GROUNDWORK_FORGE_TYPE, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
+                "agent '{agent}' defines invalid credential name '{name}'; credential names must not contain ',' or '=' and must not use runner-owned names such as AGENT_NAME, GROUNDWORK_FORGE_TYPE, AGENTD_WORK_UNIT, AGENTD_REPO_TOKEN, RUNA_TRANSCRIPT_DIR, RUNA_TRANSCRIPT_DEPLOYMENT, RUNA_TRANSCRIPT_RUN_ID, or RUNA_TRANSCRIPT_REDACT_ENV; transcript subsystem names are set internally"
             ),
             ConfigError::EmptyField {
                 field,

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -1100,25 +1100,54 @@ fn write_progress_frame(
 
 fn write_terminal_frame(stream: &UnixStream, bytes: &[u8]) -> ProgressWriterWriteResult {
     let deadline = Instant::now() + PROGRESS_WRITE_TIMEOUT;
+    let mut offset = 0;
     loop {
-        match socket_output_queue_bytes(stream) {
-            Ok(0) => match send_complete_frame_nonblocking(stream, bytes) {
-                Ok(()) => return ProgressWriterWriteResult::Written,
-                Err(error) if peer_disconnected_during_response(&error) => {
-                    return ProgressWriterWriteResult::PeerDisconnected;
+        if offset == bytes.len() {
+            return ProgressWriterWriteResult::Written;
+        }
+
+        if offset == 0 {
+            match socket_output_queue_bytes(stream) {
+                Ok(0) => {}
+                Ok(_) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return ProgressWriterWriteResult::TimedOut;
+                    }
+                    thread::sleep(std::cmp::min(remaining, Duration::from_millis(1)));
+                    continue;
                 }
-                Err(error) if progress_writer_timed_out(&error) => {}
                 Err(error) => return ProgressWriterWriteResult::Failed(error),
-            },
-            Ok(_) => {}
+            }
+        }
+
+        match send_frame_chunk_nonblocking(stream, &bytes[offset..]) {
+            Ok(0) => {
+                return ProgressWriterWriteResult::Failed(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "progress writer wrote zero bytes for a terminal frame",
+                ));
+            }
+            Ok(written) => {
+                offset += written;
+                continue;
+            }
+            Err(error) if peer_disconnected_during_response(&error) => {
+                return ProgressWriterWriteResult::PeerDisconnected;
+            }
+            Err(error) if progress_writer_timed_out(&error) => {}
             Err(error) => return ProgressWriterWriteResult::Failed(error),
         }
 
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return ProgressWriterWriteResult::TimedOut;
+        if offset == 0 {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return ProgressWriterWriteResult::TimedOut;
+            }
+            thread::sleep(std::cmp::min(remaining, Duration::from_millis(1)));
+        } else {
+            thread::sleep(Duration::from_millis(1));
         }
-        thread::sleep(std::cmp::min(remaining, Duration::from_millis(1)));
     }
 }
 
@@ -1127,6 +1156,21 @@ fn send_complete_frame_nonblocking(stream: &UnixStream, bytes: &[u8]) -> Result<
         return Ok(());
     }
 
+    let written = send_frame_chunk_nonblocking(stream, bytes)?;
+    if written == bytes.len() {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::WriteZero,
+        format!(
+            "progress writer committed a partial frame ({written} of {} bytes)",
+            bytes.len()
+        ),
+    ))
+}
+
+fn send_frame_chunk_nonblocking(stream: &UnixStream, bytes: &[u8]) -> Result<usize, io::Error> {
     let written = unsafe {
         libc::send(
             stream.as_raw_fd(),
@@ -1139,19 +1183,8 @@ fn send_complete_frame_nonblocking(stream: &UnixStream, bytes: &[u8]) -> Result<
         return Err(io::Error::last_os_error());
     }
 
-    let written = usize::try_from(written)
-        .map_err(|_| io::Error::other("progress writer returned a negative byte count"))?;
-    if written == bytes.len() {
-        return Ok(());
-    }
-
-    Err(io::Error::new(
-        io::ErrorKind::WriteZero,
-        format!(
-            "progress writer committed a partial frame ({written} of {} bytes)",
-            bytes.len()
-        ),
-    ))
+    usize::try_from(written)
+        .map_err(|_| io::Error::other("progress writer returned a negative byte count"))
 }
 
 fn set_socket_send_buffer_bytes(stream: &UnixStream, bytes: usize) -> Result<(), io::Error> {
@@ -1499,6 +1532,31 @@ mod tests {
         frame
     }
 
+    fn terminal_error_frame_with_total_len(total_len: usize) -> Vec<u8> {
+        let prefix = br#"{"type":"error","message":""#;
+        let suffix = br#""}"#;
+        assert!(
+            total_len > prefix.len() + suffix.len() + 1,
+            "test frame length should leave room for content"
+        );
+        let content_len = total_len - prefix.len() - suffix.len() - 1;
+        let mut frame = Vec::with_capacity(total_len);
+        frame.extend_from_slice(prefix);
+        frame.extend(std::iter::repeat_n(b'x', content_len));
+        frame.extend_from_slice(suffix);
+        frame.push(b'\n');
+        assert_eq!(frame.len(), total_len);
+        frame
+    }
+
+    fn read_socket_to_end(mut stream: UnixStream) -> Vec<u8> {
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .expect("reader should drain daemon output");
+        response
+    }
+
     fn set_test_send_buffer(stream: &UnixStream, bytes: usize) {
         let bytes: libc::c_int = bytes
             .try_into()
@@ -1517,6 +1575,195 @@ mod tests {
             0,
             "test should configure socket send buffer: {}",
             io::Error::last_os_error()
+        );
+    }
+
+    #[test]
+    fn progress_writer_writes_fit_progress_frame_when_socket_has_room() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_test_send_buffer(&writer_stream, 8192);
+
+        let frame = progress_frame_with_total_len(1024);
+        let result = super::write_progress_frame(&writer_stream, &frame, 4096);
+        writer_stream
+            .shutdown(std::net::Shutdown::Write)
+            .expect("writer should close write half");
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::Written),
+            "fit progress frame should be written"
+        );
+        assert_eq!(read_socket_to_end(reader_stream), frame);
+    }
+
+    #[test]
+    fn progress_writer_drops_over_budget_progress_frame_without_writing_bytes() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+
+        let frame = progress_frame_with_total_len(4096);
+        let result = super::write_progress_frame(&writer_stream, &frame, 1024);
+        writer_stream
+            .shutdown(std::net::Shutdown::Write)
+            .expect("writer should close write half");
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::Dropped),
+            "over-budget progress frame should be dropped"
+        );
+        assert!(
+            read_socket_to_end(reader_stream).is_empty(),
+            "over-budget progress must not commit a partial frame"
+        );
+    }
+
+    #[test]
+    fn progress_writer_drops_backpressured_progress_frame_without_writing_bytes() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_test_send_buffer(&writer_stream, 4096);
+
+        let seed = progress_frame_with_total_len(4096);
+        let seed_result = super::write_progress_frame(&writer_stream, &seed, seed.len());
+        assert!(
+            matches!(seed_result, super::ProgressWriterWriteResult::Written),
+            "seed frame should fill some of the socket queue"
+        );
+
+        let frame = progress_frame_with_total_len(1024);
+        let result = super::write_progress_frame(&writer_stream, &frame, seed.len());
+        writer_stream
+            .shutdown(std::net::Shutdown::Write)
+            .expect("writer should close write half");
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::Dropped),
+            "backpressured progress frame should be dropped"
+        );
+        assert_eq!(
+            read_socket_to_end(reader_stream),
+            seed,
+            "backpressured progress must not commit a partial second frame"
+        );
+    }
+
+    #[test]
+    fn terminal_writer_writes_small_frame_whole() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+
+        let frame = terminal_error_frame_with_total_len(1024);
+        let result = super::write_terminal_frame(&writer_stream, &frame);
+        writer_stream
+            .shutdown(std::net::Shutdown::Write)
+            .expect("writer should close write half");
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::Written),
+            "small terminal frame should be written"
+        );
+        let response = read_socket_to_end(reader_stream);
+        assert_eq!(response, frame);
+        serde_json::from_slice::<serde_json::Value>(
+            response
+                .strip_suffix(b"\n")
+                .expect("terminal frame should be JSONL"),
+        )
+        .expect("terminal frame should be complete JSON");
+    }
+
+    #[test]
+    fn terminal_writer_writes_large_frame_to_completion() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_test_send_buffer(&writer_stream, 4096);
+        let send_buffer_bytes = super::socket_send_buffer_bytes(&writer_stream)
+            .expect("send buffer should be readable");
+        let frame = terminal_error_frame_with_total_len(send_buffer_bytes * 4);
+        let expected = frame.clone();
+
+        let reader = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(25));
+            read_socket_to_end(reader_stream)
+        });
+
+        let result = super::write_terminal_frame(&writer_stream, &frame);
+        writer_stream
+            .shutdown(std::net::Shutdown::Write)
+            .expect("writer should close write half");
+        let response = reader.join().expect("reader should join cleanly");
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::Written),
+            "large terminal frame should be written to completion"
+        );
+        assert_eq!(
+            response, expected,
+            "large terminal frame must arrive whole, not truncated"
+        );
+        serde_json::from_slice::<serde_json::Value>(
+            response
+                .strip_suffix(b"\n")
+                .expect("terminal frame should be JSONL"),
+        )
+        .expect("large terminal frame should be complete JSON");
+    }
+
+    #[test]
+    fn progress_writer_handles_peer_disconnect_without_panic() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        drop(reader_stream);
+
+        let frame = progress_frame_with_total_len(1024);
+        let result = super::write_progress_frame(&writer_stream, &frame, frame.len());
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::PeerDisconnected),
+            "progress writer should recognize a disconnected peer"
+        );
+    }
+
+    #[test]
+    fn terminal_writer_handles_peer_disconnect_without_panic() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        drop(reader_stream);
+
+        let frame = terminal_error_frame_with_total_len(1024);
+        let result = super::write_terminal_frame(&writer_stream, &frame);
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::PeerDisconnected),
+            "terminal writer should recognize a disconnected peer"
+        );
+    }
+
+    #[test]
+    fn terminal_writer_handles_peer_disconnect_after_partial_write() {
+        let (writer_stream, mut reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_test_send_buffer(&writer_stream, 4096);
+        let send_buffer_bytes = super::socket_send_buffer_bytes(&writer_stream)
+            .expect("send buffer should be readable");
+        let frame = terminal_error_frame_with_total_len(send_buffer_bytes * 16);
+
+        let reader = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(25));
+            let mut buffer = [0_u8; 1024];
+            reader_stream
+                .read(&mut buffer)
+                .expect("reader should receive the committed prefix")
+        });
+
+        let result = super::write_terminal_frame(&writer_stream, &frame);
+        let bytes_read = reader.join().expect("reader should join cleanly");
+
+        assert!(bytes_read > 0, "reader should receive a terminal prefix");
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::PeerDisconnected),
+            "terminal writer should stop cleanly when the peer disconnects mid-frame"
         );
     }
 

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -839,6 +839,7 @@ struct ProgressWriter {
 struct ProgressWriterShared {
     state: Mutex<ProgressWriterState>,
     available: Condvar,
+    max_frame_bytes: usize,
 }
 
 struct ProgressWriterState {
@@ -857,9 +858,17 @@ enum ProgressWriterFrame {
     Terminal(Vec<u8>),
 }
 
+enum ProgressWriterWriteResult {
+    Written,
+    Dropped,
+    PeerDisconnected,
+    TimedOut,
+    Failed(io::Error),
+}
+
 impl ProgressWriter {
     fn spawn(stream: UnixStream, registry: &ProgressWriterRegistry) -> Result<Self, io::Error> {
-        stream.set_write_timeout(Some(PROGRESS_WRITE_TIMEOUT))?;
+        let max_frame_bytes = configure_progress_writer_stream(&stream)?;
         let shared = Arc::new(ProgressWriterShared {
             state: Mutex::new(ProgressWriterState {
                 progress: VecDeque::new(),
@@ -867,6 +876,7 @@ impl ProgressWriter {
                 closed: false,
             }),
             available: Condvar::new(),
+            max_frame_bytes,
         });
         let writer_shared = Arc::clone(&shared);
         let handle = thread::spawn(move || {
@@ -901,11 +911,11 @@ impl ProgressWriter {
                 return;
             }
         };
-        if frame.len() > MAX_PROGRESS_FRAME_BYTES {
+        if frame.len() > self.shared.max_frame_bytes {
             tracing::debug!(
                 event = "agentd.manual_run_progress_dropped",
                 frame_bytes = frame.len(),
-                max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+                max_frame_bytes = self.shared.max_frame_bytes,
                 "dropped oversized manual run dispatch progress frame"
             );
             return;
@@ -944,11 +954,11 @@ impl ProgressWriter {
             }
         };
 
-        if frame.len() > MAX_PROGRESS_FRAME_BYTES {
+        if frame.len() > self.shared.max_frame_bytes {
             tracing::debug!(
                 event = "agentd.manual_run_progress_dropped",
                 frame_bytes = frame.len(),
-                max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+                max_frame_bytes = self.shared.max_frame_bytes,
                 "dropped oversized manual run progress frame"
             );
             return;
@@ -1008,28 +1018,39 @@ impl ProgressWriter {
     }
 }
 
-fn run_progress_writer(mut stream: UnixStream, shared: Arc<ProgressWriterShared>) {
+fn run_progress_writer(stream: UnixStream, shared: Arc<ProgressWriterShared>) {
     while let Some(frame) = next_progress_writer_frame(&shared) {
         let is_terminal = matches!(frame, ProgressWriterFrame::Terminal(_));
         let bytes = match frame {
             ProgressWriterFrame::Progress(bytes) | ProgressWriterFrame::Terminal(bytes) => bytes,
         };
 
-        match stream.write_all(&bytes) {
-            Ok(()) if is_terminal => return,
-            Ok(()) => {}
-            Err(error) if peer_disconnected_during_response(&error) => return,
-            Err(error) if progress_writer_timed_out(&error) => {
+        let write_result = if is_terminal {
+            write_terminal_frame(&stream, &bytes)
+        } else {
+            write_progress_frame(&stream, &bytes, shared.max_frame_bytes)
+        };
+
+        match write_result {
+            ProgressWriterWriteResult::Written if is_terminal => return,
+            ProgressWriterWriteResult::Written => {}
+            ProgressWriterWriteResult::Dropped => {
+                tracing::debug!(
+                    event = "agentd.manual_run_progress_dropped",
+                    "dropped manual run progress because the client socket is backpressured"
+                );
+            }
+            ProgressWriterWriteResult::PeerDisconnected => return,
+            ProgressWriterWriteResult::TimedOut => {
                 tracing::warn!(
                     event = "agentd.manual_run_progress_writer_timed_out",
-                    error = %error,
                     timeout_ms = PROGRESS_WRITE_TIMEOUT.as_millis(),
                     "manual run progress writer timed out and closed the client connection"
                 );
                 let _ = stream.shutdown(std::net::Shutdown::Both);
                 return;
             }
-            Err(error) => {
+            ProgressWriterWriteResult::Failed(error) => {
                 tracing::warn!(
                     event = "agentd.manual_run_progress_writer_failed",
                     error = %error,
@@ -1040,6 +1061,146 @@ fn run_progress_writer(mut stream: UnixStream, shared: Arc<ProgressWriterShared>
             }
         }
     }
+}
+
+fn configure_progress_writer_stream(stream: &UnixStream) -> Result<usize, io::Error> {
+    set_socket_send_buffer_bytes(stream, MAX_PROGRESS_FRAME_BYTES)?;
+    stream.set_write_timeout(Some(PROGRESS_WRITE_TIMEOUT))?;
+    let send_buffer_bytes = socket_send_buffer_bytes(stream)?;
+    let max_frame_bytes = std::cmp::min(MAX_PROGRESS_FRAME_BYTES, send_buffer_bytes / 2);
+    if max_frame_bytes == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "progress writer socket send buffer is too small",
+        ));
+    }
+    Ok(max_frame_bytes)
+}
+
+fn write_progress_frame(
+    stream: &UnixStream,
+    bytes: &[u8],
+    max_frame_bytes: usize,
+) -> ProgressWriterWriteResult {
+    match socket_output_queue_bytes(stream) {
+        Ok(queued_bytes) if queued_bytes.saturating_add(bytes.len()) <= max_frame_bytes => {}
+        Ok(_) => return ProgressWriterWriteResult::Dropped,
+        Err(error) => return ProgressWriterWriteResult::Failed(error),
+    }
+
+    match send_complete_frame_nonblocking(stream, bytes) {
+        Ok(()) => ProgressWriterWriteResult::Written,
+        Err(error) if peer_disconnected_during_response(&error) => {
+            ProgressWriterWriteResult::PeerDisconnected
+        }
+        Err(error) if progress_writer_timed_out(&error) => ProgressWriterWriteResult::Dropped,
+        Err(error) => ProgressWriterWriteResult::Failed(error),
+    }
+}
+
+fn write_terminal_frame(stream: &UnixStream, bytes: &[u8]) -> ProgressWriterWriteResult {
+    let deadline = Instant::now() + PROGRESS_WRITE_TIMEOUT;
+    loop {
+        match socket_output_queue_bytes(stream) {
+            Ok(0) => match send_complete_frame_nonblocking(stream, bytes) {
+                Ok(()) => return ProgressWriterWriteResult::Written,
+                Err(error) if peer_disconnected_during_response(&error) => {
+                    return ProgressWriterWriteResult::PeerDisconnected;
+                }
+                Err(error) if progress_writer_timed_out(&error) => {}
+                Err(error) => return ProgressWriterWriteResult::Failed(error),
+            },
+            Ok(_) => {}
+            Err(error) => return ProgressWriterWriteResult::Failed(error),
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return ProgressWriterWriteResult::TimedOut;
+        }
+        thread::sleep(std::cmp::min(remaining, Duration::from_millis(1)));
+    }
+}
+
+fn send_complete_frame_nonblocking(stream: &UnixStream, bytes: &[u8]) -> Result<(), io::Error> {
+    if bytes.is_empty() {
+        return Ok(());
+    }
+
+    let written = unsafe {
+        libc::send(
+            stream.as_raw_fd(),
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+            libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL,
+        )
+    };
+    if written < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let written = usize::try_from(written)
+        .map_err(|_| io::Error::other("progress writer returned a negative byte count"))?;
+    if written == bytes.len() {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::WriteZero,
+        format!(
+            "progress writer committed a partial frame ({written} of {} bytes)",
+            bytes.len()
+        ),
+    ))
+}
+
+fn set_socket_send_buffer_bytes(stream: &UnixStream, bytes: usize) -> Result<(), io::Error> {
+    let bytes: libc::c_int = bytes
+        .try_into()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "send buffer too large"))?;
+    let result = unsafe {
+        libc::setsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &bytes as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn socket_send_buffer_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
+    let mut bytes: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &mut bytes as *mut libc::c_int as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    usize::try_from(bytes)
+        .map_err(|_| io::Error::other("progress writer socket send buffer was negative"))
+}
+
+fn socket_output_queue_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
+    let mut bytes: libc::c_int = 0;
+    let result = unsafe { libc::ioctl(stream.as_raw_fd(), libc::TIOCOUTQ, &mut bytes) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    usize::try_from(bytes)
+        .map_err(|_| io::Error::other("progress writer socket output queue was negative"))
 }
 
 fn next_progress_writer_frame(shared: &ProgressWriterShared) -> Option<ProgressWriterFrame> {
@@ -1303,8 +1464,10 @@ mod tests {
         RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
         StartupReconciliationReport,
     };
+    use std::collections::VecDeque;
     use std::fs;
-    use std::io;
+    use std::io::{self, Read};
+    use std::os::fd::AsRawFd;
     use std::path::PathBuf;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -1317,6 +1480,45 @@ mod tests {
         os::unix::fs::FileTypeExt,
         os::unix::net::{UnixListener, UnixStream},
     };
+
+    fn progress_frame_with_total_len(total_len: usize) -> Vec<u8> {
+        let prefix =
+            br#"{"type":"progress","progress":{"stage":"transcript_event","session_id":"s","line":""#;
+        let suffix = br#""}}"#;
+        assert!(
+            total_len > prefix.len() + suffix.len() + 1,
+            "test frame length should leave room for content"
+        );
+        let content_len = total_len - prefix.len() - suffix.len() - 1;
+        let mut frame = Vec::with_capacity(total_len);
+        frame.extend_from_slice(prefix);
+        frame.extend(std::iter::repeat_n(b'x', content_len));
+        frame.extend_from_slice(suffix);
+        frame.push(b'\n');
+        assert_eq!(frame.len(), total_len);
+        frame
+    }
+
+    fn set_test_send_buffer(stream: &UnixStream, bytes: usize) {
+        let bytes: libc::c_int = bytes
+            .try_into()
+            .expect("test send buffer size should fit c_int");
+        let result = unsafe {
+            libc::setsockopt(
+                stream.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &bytes as *const libc::c_int as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(
+            result,
+            0,
+            "test should configure socket send buffer: {}",
+            io::Error::last_os_error()
+        );
+    }
 
     #[test]
     fn response_message_deserializes_blocked_outcome_payloads() {
@@ -1465,6 +1667,59 @@ source = "AGENTD_GITHUB_TOKEN"
             result.is_ok(),
             "closed peer during response write should be treated as normal completion"
         );
+    }
+
+    #[test]
+    fn progress_writer_drops_backpressured_progress_without_truncated_jsonl() {
+        let (writer_stream, mut reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_test_send_buffer(&writer_stream, 8192);
+        writer_stream
+            .set_write_timeout(Some(Duration::from_millis(100)))
+            .expect("test writer timeout should be configured");
+
+        let frame = progress_frame_with_total_len(8192);
+        let frame_len = frame.len();
+        let shared = Arc::new(super::ProgressWriterShared {
+            state: std::sync::Mutex::new(super::ProgressWriterState {
+                progress: VecDeque::from([
+                    super::QueuedProgressFrame {
+                        bytes: frame.clone(),
+                        deliver_before_terminal: false,
+                    },
+                    super::QueuedProgressFrame {
+                        bytes: frame,
+                        deliver_before_terminal: false,
+                    },
+                ]),
+                terminal: None,
+                closed: true,
+            }),
+            available: std::sync::Condvar::new(),
+            max_frame_bytes: frame_len,
+        });
+
+        let writer = thread::spawn(move || super::run_progress_writer(writer_stream, shared));
+        writer
+            .join()
+            .expect("progress writer should not panic under backpressure");
+
+        let mut response = Vec::new();
+        reader_stream
+            .read_to_end(&mut response)
+            .expect("reader should drain daemon output");
+        assert!(
+            response.is_empty() || response.ends_with(b"\n"),
+            "daemon must not leave a partial JSONL frame on the wire"
+        );
+
+        for line in response.split(|byte| *byte == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            serde_json::from_slice::<serde_json::Value>(line)
+                .expect("daemon should emit only complete JSON progress frames");
+        }
     }
 
     #[test]

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -5,14 +5,15 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
 use agentd_runner::{
-    RunnerError, SessionOutcome, StartupReconciliationReport, reconcile_startup_resources,
+    RunnerError, SessionOutcome, SessionProgressEvent, StartupReconciliationReport,
+    reconcile_startup_resources,
 };
 
 use crate::audit_root::prepare_audit_root;
@@ -515,9 +516,31 @@ fn render_progress<W: Write>(
                 if input_present { "present" } else { "absent" }
             )?;
         }
+        (ProgressMessage::TranscriptEvent { line, .. }, LiveObservationLevel::Summary) => {
+            writeln!(
+                writer,
+                "session event: {}",
+                summarize_transcript_event(&line)
+            )?;
+        }
+        (ProgressMessage::TranscriptEvent { session_id, line }, LiveObservationLevel::Full) => {
+            writeln!(writer, "session event: session_id={session_id} {line}")?;
+        }
     }
     writer.flush()?;
     Ok(())
+}
+
+fn summarize_transcript_event(line: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|event| {
+            event
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unparsed_event".to_string())
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -565,12 +588,36 @@ fn handle_connection_inner(
             work_unit,
             input,
         } => {
-            let progress = ResponseMessage::Progress {
+            let stream = Mutex::new(&mut stream);
+            let dispatch_progress = ResponseMessage::Progress {
                 progress: ProgressMessage::DispatchStarted {
                     agent: agent.clone(),
                     work_unit: work_unit.clone(),
                     input_present: input.is_some(),
                 },
+            };
+            let write_progress = |event: SessionProgressEvent| {
+                let SessionProgressEvent::TranscriptEvent { session_id, line } = event;
+                let progress = ResponseMessage::Progress {
+                    progress: ProgressMessage::TranscriptEvent { session_id, line },
+                };
+                match stream.lock() {
+                    Ok(mut stream) => {
+                        if let Err(error) = write_response(&mut stream, &progress) {
+                            tracing::warn!(
+                                event = "agentd.manual_run_progress_failed",
+                                error = %error,
+                                "failed to write manual run progress"
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            event = "agentd.manual_run_progress_lock_poisoned",
+                            "failed to lock manual run progress stream"
+                        );
+                    }
+                }
             };
             match dispatch_run_after_preflight(
                 config,
@@ -581,15 +628,24 @@ fn handle_connection_inner(
                     input,
                 },
                 executor,
-                || {
-                    if let Err(error) = write_response(&mut stream, &progress) {
+                || match stream.lock() {
+                    Ok(mut stream) => {
+                        if let Err(error) = write_response(&mut stream, &dispatch_progress) {
+                            tracing::warn!(
+                                event = "agentd.manual_run_progress_failed",
+                                error = %error,
+                                "failed to write manual run progress"
+                            );
+                        }
+                    }
+                    Err(_) => {
                         tracing::warn!(
-                            event = "agentd.manual_run_progress_failed",
-                            error = %error,
-                            "failed to write manual run progress"
+                            event = "agentd.manual_run_progress_lock_poisoned",
+                            "failed to lock manual run progress stream"
                         );
                     }
                 },
+                &write_progress,
             ) {
                 Ok(outcome) => {
                     log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
@@ -845,7 +901,8 @@ mod tests {
     use crate::config::Config;
     use crate::dispatch::SessionExecutor;
     use agentd_runner::{
-        RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+        RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
+        StartupReconciliationReport,
     };
     use std::fs;
     use std::io;
@@ -888,6 +945,7 @@ mod tests {
             &self,
             _spec: SessionSpec,
             _invocation: SessionInvocation,
+            _progress: &dyn SessionProgressObserver,
         ) -> Result<SessionOutcome, RunnerError> {
             Ok(SessionOutcome::Success { exit_code: 0 })
         }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -1099,7 +1099,15 @@ fn write_progress_frame(
 }
 
 fn write_terminal_frame(stream: &UnixStream, bytes: &[u8]) -> ProgressWriterWriteResult {
-    let deadline = Instant::now() + PROGRESS_WRITE_TIMEOUT;
+    write_terminal_frame_with_timeout(stream, bytes, PROGRESS_WRITE_TIMEOUT)
+}
+
+fn write_terminal_frame_with_timeout(
+    stream: &UnixStream,
+    bytes: &[u8],
+    timeout: Duration,
+) -> ProgressWriterWriteResult {
+    let deadline = Instant::now() + timeout;
     let mut offset = 0;
     loop {
         if offset == bytes.len() {
@@ -1139,15 +1147,11 @@ fn write_terminal_frame(stream: &UnixStream, bytes: &[u8]) -> ProgressWriterWrit
             Err(error) => return ProgressWriterWriteResult::Failed(error),
         }
 
-        if offset == 0 {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return ProgressWriterWriteResult::TimedOut;
-            }
-            thread::sleep(std::cmp::min(remaining, Duration::from_millis(1)));
-        } else {
-            thread::sleep(Duration::from_millis(1));
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return ProgressWriterWriteResult::TimedOut;
         }
+        thread::sleep(std::cmp::min(remaining, Duration::from_millis(1)));
     }
 }
 
@@ -1708,6 +1712,57 @@ mod tests {
                 .expect("terminal frame should be JSONL"),
         )
         .expect("large terminal frame should be complete JSON");
+    }
+
+    #[test]
+    fn terminal_writer_times_out_after_partial_write_to_stalled_peer() {
+        let (writer_stream, reader_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_test_send_buffer(&writer_stream, 4096);
+        let send_buffer_bytes = super::socket_send_buffer_bytes(&writer_stream)
+            .expect("send buffer should be readable");
+        let frame = terminal_error_frame_with_total_len(send_buffer_bytes * 64);
+        let frame_len = frame.len();
+        let timeout = Duration::from_millis(50);
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let writer = thread::spawn(move || {
+            let started = Instant::now();
+            let result = super::write_terminal_frame_with_timeout(&writer_stream, &frame, timeout);
+            result_tx
+                .send((result, started.elapsed()))
+                .expect("writer result should be delivered");
+        });
+
+        let (result, elapsed) = match result_rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => result,
+            Err(error) => {
+                drop(reader_stream);
+                writer
+                    .join()
+                    .expect("writer should stop when the stalled peer disconnects");
+                panic!("partial terminal write should return by deadline: {error}");
+            }
+        };
+        writer.join().expect("writer should join cleanly");
+
+        assert!(
+            matches!(result, super::ProgressWriterWriteResult::TimedOut),
+            "partial terminal write to a stalled peer should time out"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "partial terminal write should return promptly after its deadline"
+        );
+        let response = read_socket_to_end(reader_stream);
+        assert!(
+            !response.is_empty(),
+            "test should exercise the partial-send path after committing a prefix"
+        );
+        assert!(
+            response.len() < frame_len,
+            "stalled peer should receive only a partial terminal frame"
+        );
     }
 
     #[test]

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -1,12 +1,14 @@
+use std::collections::VecDeque;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, TryLockError};
+use std::sync::{Arc, Condvar, Mutex, TryLockError};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -28,7 +30,8 @@ const RUNTIME_DIR_MODE: u32 = 0o700;
 const SOCKET_MODE: u32 = 0o600;
 const SHUTDOWN_MESSAGE: &str = "agentd is shutting down";
 const MAX_PROGRESS_FRAME_BYTES: usize = 128 * 1024;
-const TERMINAL_RESPONSE_RESERVE_BYTES: usize = 16 * 1024;
+const PROGRESS_QUEUE_CAPACITY: usize = 64;
+const PROGRESS_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Startup or runtime failures for the foreground daemon loop.
 #[derive(Debug)]
@@ -625,100 +628,74 @@ fn handle_connection_inner(
             work_unit,
             input,
         } => {
-            let stream = Mutex::new(&mut stream);
-            let dispatch_progress = ResponseMessage::Progress {
-                progress: ProgressMessage::DispatchStarted {
-                    agent: agent.clone(),
-                    work_unit: work_unit.clone(),
-                    input_present: input.is_some(),
-                },
+            return handle_run_connection(
+                stream, config, executor, agent, repo_url, work_unit, input,
+            );
+        }
+    };
+
+    write_response(&mut stream, &response)
+}
+
+fn handle_run_connection(
+    stream: UnixStream,
+    config: &Config,
+    executor: &impl SessionExecutor,
+    agent: String,
+    repo_url: Option<String>,
+    work_unit: Option<String>,
+    input: Option<agentd_runner::InvocationInput>,
+) -> Result<(), io::Error> {
+    let writer = ProgressWriter::spawn(stream)?;
+    let response = {
+        let dispatch_progress = ResponseMessage::Progress {
+            progress: ProgressMessage::DispatchStarted {
+                agent: agent.clone(),
+                work_unit: work_unit.clone(),
+                input_present: input.is_some(),
+            },
+        };
+        let write_progress = |event: SessionProgressEvent| {
+            let SessionProgressEvent::TranscriptEvent { session_id, line } = event;
+            let progress = ResponseMessage::Progress {
+                progress: ProgressMessage::TranscriptEvent { session_id, line },
             };
-            let write_progress = |event: SessionProgressEvent| {
-                let SessionProgressEvent::TranscriptEvent { session_id, line } = event;
-                let progress = ResponseMessage::Progress {
-                    progress: ProgressMessage::TranscriptEvent { session_id, line },
-                };
-                match stream.try_lock() {
-                    Ok(mut stream) => {
-                        if let Err(error) = try_write_progress_response(&mut stream, &progress) {
-                            tracing::warn!(
-                                event = "agentd.manual_run_progress_failed",
-                                error = %error,
-                                "failed to write manual run progress"
-                            );
-                        }
-                    }
-                    Err(TryLockError::WouldBlock) => {
-                        tracing::debug!(
-                            event = "agentd.manual_run_progress_dropped",
-                            "dropped manual run progress while another response was in flight"
-                        );
-                    }
-                    Err(TryLockError::Poisoned(_)) => {
-                        tracing::warn!(
-                            event = "agentd.manual_run_progress_lock_poisoned",
-                            "failed to lock manual run progress stream"
-                        );
-                    }
+            writer.enqueue_progress(progress);
+        };
+        match dispatch_run_after_preflight(
+            config,
+            &RunRequest {
+                agent: agent.clone(),
+                repo_url,
+                work_unit: work_unit.clone(),
+                input,
+            },
+            executor,
+            || {
+                writer.enqueue_dispatch_progress(dispatch_progress);
+            },
+            &write_progress,
+        ) {
+            Ok(outcome) => {
+                log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
+                ResponseMessage::SessionOutcome {
+                    outcome: outcome.into(),
                 }
-            };
-            match dispatch_run_after_preflight(
-                config,
-                &RunRequest {
-                    agent: agent.clone(),
-                    repo_url,
-                    work_unit: work_unit.clone(),
-                    input,
-                },
-                executor,
-                || match stream.try_lock() {
-                    Ok(mut stream) => {
-                        if let Err(error) =
-                            try_write_progress_response(&mut stream, &dispatch_progress)
-                        {
-                            tracing::warn!(
-                                event = "agentd.manual_run_progress_failed",
-                                error = %error,
-                                "failed to write manual run progress"
-                            );
-                        }
-                    }
-                    Err(TryLockError::WouldBlock) => {
-                        tracing::debug!(
-                            event = "agentd.manual_run_progress_dropped",
-                            "dropped manual run progress while another response was in flight"
-                        );
-                    }
-                    Err(TryLockError::Poisoned(_)) => {
-                        tracing::warn!(
-                            event = "agentd.manual_run_progress_lock_poisoned",
-                            "failed to lock manual run progress stream"
-                        );
-                    }
-                },
-                &write_progress,
-            ) {
-                Ok(outcome) => {
-                    log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
-                    ResponseMessage::SessionOutcome {
-                        outcome: outcome.into(),
-                    }
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        event = "agentd.manual_run_rejected",
-                        error = %error,
-                        "run request rejected"
-                    );
-                    ResponseMessage::Error {
-                        message: dispatch_error_message(&error),
-                    }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_rejected",
+                    error = %error,
+                    "run request rejected"
+                );
+                ResponseMessage::Error {
+                    message: dispatch_error_message(&error),
                 }
             }
         }
     };
 
-    write_response(&mut stream, &response)
+    writer.finish(response)
 }
 
 fn write_response(stream: &mut UnixStream, response: &ResponseMessage) -> Result<(), io::Error> {
@@ -741,119 +718,267 @@ fn write_response_part(stream: &mut UnixStream, bytes: &[u8]) -> Result<(), io::
     }
 }
 
-fn try_write_progress_response(
-    stream: &mut UnixStream,
-    response: &ResponseMessage,
-) -> Result<(), io::Error> {
+fn serialize_response_frame(response: &ResponseMessage) -> Result<Vec<u8>, io::Error> {
     let mut payload = serde_json::to_vec(response)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     payload.push(b'\n');
-    if payload.len() > MAX_PROGRESS_FRAME_BYTES {
-        tracing::debug!(
-            event = "agentd.manual_run_progress_dropped",
-            frame_bytes = payload.len(),
-            max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
-            "dropped oversized manual run progress frame"
-        );
-        return Ok(());
+    Ok(payload)
+}
+
+#[derive(Clone)]
+struct ProgressWriter {
+    shared: Arc<ProgressWriterShared>,
+}
+
+struct ProgressWriterShared {
+    state: Mutex<ProgressWriterState>,
+    available: Condvar,
+}
+
+struct ProgressWriterState {
+    progress: VecDeque<QueuedProgressFrame>,
+    terminal: Option<Vec<u8>>,
+    closed: bool,
+}
+
+struct QueuedProgressFrame {
+    bytes: Vec<u8>,
+    deliver_before_terminal: bool,
+}
+
+enum ProgressWriterFrame {
+    Progress(Vec<u8>),
+    Terminal(Vec<u8>),
+}
+
+impl ProgressWriter {
+    fn spawn(stream: UnixStream) -> Result<Self, io::Error> {
+        stream.set_write_timeout(Some(PROGRESS_WRITE_TIMEOUT))?;
+        let shared = Arc::new(ProgressWriterShared {
+            state: Mutex::new(ProgressWriterState {
+                progress: VecDeque::new(),
+                terminal: None,
+                closed: false,
+            }),
+            available: Condvar::new(),
+        });
+        let writer_shared = Arc::clone(&shared);
+        thread::spawn(move || {
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                run_progress_writer(stream, writer_shared);
+            }));
+            if result.is_err() {
+                tracing::error!(
+                    event = "agentd.manual_run_progress_writer_panicked",
+                    "manual run progress writer panicked"
+                );
+            }
+        });
+
+        Ok(Self { shared })
     }
 
-    if !progress_frame_has_reserved_capacity(stream, payload.len())? {
-        tracing::debug!(
-            event = "agentd.manual_run_progress_dropped",
-            frame_bytes = payload.len(),
-            terminal_reserve_bytes = TERMINAL_RESPONSE_RESERVE_BYTES,
-            "dropped manual run progress frame because the client connection is backpressured"
-        );
-        return Ok(());
+    fn enqueue_progress(&self, response: ResponseMessage) {
+        self.enqueue_progress_frame(response, false);
     }
 
-    stream.set_nonblocking(true)?;
-    let write_result = write_progress_frame_nonblocking(stream, &payload);
-    let restore_result = stream.set_nonblocking(false);
-
-    match (write_result, restore_result) {
-        (Ok(()), Ok(())) => Ok(()),
-        (Err(error), Ok(())) if peer_disconnected_during_response(&error) => Ok(()),
-        (Err(error), Ok(())) if progress_response_would_block(&error) => Ok(()),
-        (Err(error), Ok(())) => Err(error),
-        (Ok(()), Err(error)) => Err(error),
-        (Err(write_error), Err(restore_error)) => {
-            tracing::warn!(
-                event = "agentd.manual_run_progress_blocking_restore_failed",
-                error = %restore_error,
-                "failed to restore blocking mode after manual run progress write"
+    fn enqueue_dispatch_progress(&self, response: ResponseMessage) {
+        let frame = match serialize_response_frame(&response) {
+            Ok(frame) => frame,
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_serialization_failed",
+                    error = %error,
+                    "failed to serialize manual run dispatch progress"
+                );
+                return;
+            }
+        };
+        if frame.len() > MAX_PROGRESS_FRAME_BYTES {
+            tracing::debug!(
+                event = "agentd.manual_run_progress_dropped",
+                frame_bytes = frame.len(),
+                max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+                "dropped oversized manual run dispatch progress frame"
             );
-            Err(write_error)
+            return;
+        }
+
+        let mut state = self
+            .shared
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.closed || state.terminal.is_some() {
+            tracing::debug!(
+                event = "agentd.manual_run_progress_dropped",
+                "dropped manual run dispatch progress after terminal response was queued"
+            );
+            return;
+        }
+
+        state.progress.push_back(QueuedProgressFrame {
+            bytes: frame,
+            deliver_before_terminal: true,
+        });
+        self.shared.available.notify_one();
+    }
+
+    fn enqueue_progress_frame(&self, response: ResponseMessage, deliver_before_terminal: bool) {
+        let frame = match serialize_response_frame(&response) {
+            Ok(frame) => frame,
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_serialization_failed",
+                    error = %error,
+                    "failed to serialize manual run progress"
+                );
+                return;
+            }
+        };
+
+        if frame.len() > MAX_PROGRESS_FRAME_BYTES {
+            tracing::debug!(
+                event = "agentd.manual_run_progress_dropped",
+                frame_bytes = frame.len(),
+                max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+                "dropped oversized manual run progress frame"
+            );
+            return;
+        }
+
+        match self.shared.state.try_lock() {
+            Ok(mut state) => {
+                if state.closed || state.terminal.is_some() {
+                    tracing::debug!(
+                        event = "agentd.manual_run_progress_dropped",
+                        "dropped manual run progress after terminal response was queued"
+                    );
+                    return;
+                }
+
+                if state.progress.len() >= PROGRESS_QUEUE_CAPACITY {
+                    tracing::debug!(
+                        event = "agentd.manual_run_progress_dropped",
+                        queue_capacity = PROGRESS_QUEUE_CAPACITY,
+                        "dropped manual run progress because the bounded queue is full"
+                    );
+                    return;
+                }
+
+                state.progress.push_back(QueuedProgressFrame {
+                    bytes: frame,
+                    deliver_before_terminal,
+                });
+                self.shared.available.notify_one();
+            }
+            Err(TryLockError::WouldBlock) => {
+                tracing::debug!(
+                    event = "agentd.manual_run_progress_dropped",
+                    "dropped manual run progress while the writer queue was busy"
+                );
+            }
+            Err(TryLockError::Poisoned(_)) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_queue_poisoned",
+                    "failed to lock manual run progress writer queue"
+                );
+            }
+        }
+    }
+
+    fn finish(&self, response: ResponseMessage) -> Result<(), io::Error> {
+        let terminal = serialize_response_frame(&response)?;
+        let mut state = self
+            .shared
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.progress.retain(|frame| frame.deliver_before_terminal);
+        state.terminal = Some(terminal);
+        self.shared.available.notify_one();
+        Ok(())
+    }
+}
+
+fn run_progress_writer(mut stream: UnixStream, shared: Arc<ProgressWriterShared>) {
+    while let Some(frame) = next_progress_writer_frame(&shared) {
+        let is_terminal = matches!(frame, ProgressWriterFrame::Terminal(_));
+        let bytes = match frame {
+            ProgressWriterFrame::Progress(bytes) | ProgressWriterFrame::Terminal(bytes) => bytes,
+        };
+
+        match stream.write_all(&bytes) {
+            Ok(()) if is_terminal => return,
+            Ok(()) => {}
+            Err(error) if peer_disconnected_during_response(&error) => return,
+            Err(error) if progress_writer_timed_out(&error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_writer_timed_out",
+                    error = %error,
+                    timeout_ms = PROGRESS_WRITE_TIMEOUT.as_millis(),
+                    "manual run progress writer timed out and closed the client connection"
+                );
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_writer_failed",
+                    error = %error,
+                    "manual run progress writer closed the client connection after a write failure"
+                );
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+                return;
+            }
         }
     }
 }
 
-fn write_progress_frame_nonblocking(
-    stream: &mut UnixStream,
-    bytes: &[u8],
-) -> Result<(), io::Error> {
-    match stream.write(bytes) {
-        Ok(written) if written == bytes.len() => Ok(()),
-        Ok(0) => Err(io::Error::new(
-            io::ErrorKind::WriteZero,
-            "failed to write progress response",
-        )),
-        Ok(written) => Err(io::Error::new(
-            io::ErrorKind::WouldBlock,
-            format!(
-                "partial progress frame write accepted {written} of {}",
-                bytes.len()
-            ),
-        )),
-        Err(error) if peer_disconnected_during_response(&error) => Ok(()),
-        Err(error) => Err(error),
+fn next_progress_writer_frame(shared: &ProgressWriterShared) -> Option<ProgressWriterFrame> {
+    let mut state = shared
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    loop {
+        if let Some(terminal) = state.terminal.take() {
+            if state
+                .progress
+                .front()
+                .is_some_and(|frame| frame.deliver_before_terminal)
+            {
+                let progress = state
+                    .progress
+                    .pop_front()
+                    .expect("front progress frame should exist");
+                state.terminal = Some(terminal);
+                return Some(ProgressWriterFrame::Progress(progress.bytes));
+            }
+            state.progress.clear();
+            state.closed = true;
+            return Some(ProgressWriterFrame::Terminal(terminal));
+        }
+
+        if let Some(progress) = state.progress.pop_front() {
+            return Some(ProgressWriterFrame::Progress(progress.bytes));
+        }
+
+        if state.closed {
+            return None;
+        }
+
+        state = shared
+            .available
+            .wait(state)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
     }
 }
 
-fn progress_frame_has_reserved_capacity(
-    stream: &UnixStream,
-    frame_bytes: usize,
-) -> Result<bool, io::Error> {
-    let send_buffer_bytes = socket_send_buffer_bytes(stream)?;
-    let queued_bytes = socket_queued_output_bytes(stream)?;
-    Ok(queued_bytes.saturating_add(frame_bytes)
-        <= send_buffer_bytes.saturating_sub(TERMINAL_RESPONSE_RESERVE_BYTES))
-}
-
-fn socket_send_buffer_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
-    let mut size = 0_i32;
-    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
-    let result = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_SNDBUF,
-            &mut size as *mut i32 as *mut libc::c_void,
-            &mut size_len,
-        )
-    };
-    if result == 0 {
-        usize::try_from(size)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "SO_SNDBUF was negative"))
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-fn socket_queued_output_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
-    let mut queued = 0_i32;
-    let result = unsafe { libc::ioctl(stream.as_raw_fd(), libc::TIOCOUTQ, &mut queued) };
-    if result == 0 {
-        usize::try_from(queued)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "TIOCOUTQ was negative"))
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-fn progress_response_would_block(error: &io::Error) -> bool {
-    matches!(error.kind(), io::ErrorKind::WouldBlock)
+fn progress_writer_timed_out(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+    )
 }
 
 fn peer_disconnected_during_response(error: &io::Error) -> bool {

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -17,9 +17,10 @@ use agentd_runner::{
 
 use crate::audit_root::prepare_audit_root;
 use crate::config::{Config, ConfigError};
-use crate::protocol::{RequestMessage, ResponseMessage};
+use crate::dispatch::dispatch_run_after_preflight;
+use crate::protocol::{ProgressMessage, RequestMessage, ResponseMessage};
 use crate::scheduler::{join_scheduler_thread, spawn_scheduler_thread};
-use crate::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
+use crate::{DispatchError, RunRequest, SessionExecutor};
 
 const ACCEPT_TIMEOUT: Duration = Duration::from_millis(100);
 const RUNTIME_DIR_MODE: u32 = 0o700;
@@ -81,6 +82,15 @@ pub enum ClientError {
     Io(io::Error),
     Protocol(serde_json::Error),
     Server { message: String },
+}
+
+/// Client-side rendering level for live session observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveObservationLevel {
+    /// Print concise lifecycle markers while waiting for the terminal outcome.
+    Summary,
+    /// Print lifecycle markers with every field carried by the progress frame.
+    Full,
 }
 
 impl fmt::Display for ClientError {
@@ -341,19 +351,41 @@ pub fn request_run(
     socket_path: impl AsRef<Path>,
     request: &RunRequest,
 ) -> Result<SessionOutcome, ClientError> {
+    request_run_inner::<io::Sink>(socket_path.as_ref(), request, None)
+}
+
+/// Trigger a run and render daemon progress messages while waiting.
+pub fn request_run_with_live_observation<W: Write>(
+    socket_path: impl AsRef<Path>,
+    request: &RunRequest,
+    level: LiveObservationLevel,
+    writer: &mut W,
+) -> Result<SessionOutcome, ClientError> {
+    request_run_inner(socket_path.as_ref(), request, Some((level, writer)))
+}
+
+fn request_run_inner<W: Write>(
+    socket_path: &Path,
+    request: &RunRequest,
+    observer: Option<(LiveObservationLevel, &mut W)>,
+) -> Result<SessionOutcome, ClientError> {
     match send_request(
-        socket_path.as_ref(),
+        socket_path,
         &RequestMessage::Run {
             agent: request.agent.clone(),
             repo_url: request.repo_url.clone(),
             work_unit: request.work_unit.clone(),
             input: request.input.clone(),
         },
+        observer,
     )? {
         ResponseMessage::SessionOutcome { outcome } => Ok(outcome.into()),
         ResponseMessage::Error { message } => Err(ClientError::Server { message }),
         ResponseMessage::Pong => Err(ClientError::Server {
             message: "unexpected pong from daemon".to_string(),
+        }),
+        ResponseMessage::Progress { .. } => Err(ClientError::Server {
+            message: "daemon closed the connection before reporting a terminal outcome".to_string(),
         }),
     }
 }
@@ -373,14 +405,15 @@ pub(crate) fn request_run_without_waiting(
     )
 }
 
-fn send_request(
+fn send_request<W: Write>(
     socket_path: &Path,
     request: &RequestMessage,
+    observer: Option<(LiveObservationLevel, &mut W)>,
 ) -> Result<ResponseMessage, ClientError> {
     let mut stream = connect_to_daemon(socket_path)?;
     write_request(&mut stream, request)?;
 
-    read_response(stream)
+    read_terminal_response(stream, observer)
 }
 
 fn send_request_without_response(
@@ -416,17 +449,75 @@ fn write_request(stream: &mut UnixStream, request: &RequestMessage) -> Result<()
     Ok(())
 }
 
-fn read_response(stream: UnixStream) -> Result<ResponseMessage, ClientError> {
+fn read_terminal_response<W: Write>(
+    stream: UnixStream,
+    mut observer: Option<(LiveObservationLevel, &mut W)>,
+) -> Result<ResponseMessage, ClientError> {
     let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    let bytes_read = reader.read_line(&mut line)?;
-    if bytes_read == 0 {
-        return Err(ClientError::Server {
-            message: "daemon closed the connection without a response".to_string(),
-        });
-    }
+    let mut saw_message = false;
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line)?;
+        if bytes_read == 0 {
+            let message = if saw_message {
+                "daemon closed the connection before reporting a terminal outcome"
+            } else {
+                "daemon closed the connection without a response"
+            };
+            return Err(ClientError::Server {
+                message: message.to_string(),
+            });
+        }
+        saw_message = true;
 
-    Ok(serde_json::from_str(&line)?)
+        let response = serde_json::from_str(&line)?;
+        match response {
+            ResponseMessage::Progress { progress } => {
+                if let Some((level, writer)) = observer.as_mut() {
+                    render_progress(progress, *level, &mut **writer)?;
+                }
+            }
+            terminal => return Ok(terminal),
+        }
+    }
+}
+
+fn render_progress<W: Write>(
+    progress: ProgressMessage,
+    level: LiveObservationLevel,
+    writer: &mut W,
+) -> Result<(), ClientError> {
+    match (progress, level) {
+        (
+            ProgressMessage::DispatchStarted {
+                agent, work_unit, ..
+            },
+            LiveObservationLevel::Summary,
+        ) => {
+            if let Some(work_unit) = work_unit {
+                writeln!(writer, "session running: {agent} ({work_unit})")?;
+            } else {
+                writeln!(writer, "session running: {agent}")?;
+            }
+        }
+        (
+            ProgressMessage::DispatchStarted {
+                agent,
+                work_unit,
+                input_present,
+            },
+            LiveObservationLevel::Full,
+        ) => {
+            writeln!(
+                writer,
+                "session running: agent={agent} work_unit={} input={}",
+                work_unit.as_deref().unwrap_or("-"),
+                if input_present { "present" } else { "absent" }
+            )?;
+        }
+    }
+    writer.flush()?;
+    Ok(())
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -473,33 +564,51 @@ fn handle_connection_inner(
             repo_url,
             work_unit,
             input,
-        } => match dispatch_run(
-            config,
-            &RunRequest {
-                agent: agent.clone(),
-                repo_url,
-                work_unit: work_unit.clone(),
-                input,
-            },
-            executor,
-        ) {
-            Ok(outcome) => {
-                log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
-                ResponseMessage::SessionOutcome {
-                    outcome: outcome.into(),
+        } => {
+            let progress = ResponseMessage::Progress {
+                progress: ProgressMessage::DispatchStarted {
+                    agent: agent.clone(),
+                    work_unit: work_unit.clone(),
+                    input_present: input.is_some(),
+                },
+            };
+            match dispatch_run_after_preflight(
+                config,
+                &RunRequest {
+                    agent: agent.clone(),
+                    repo_url,
+                    work_unit: work_unit.clone(),
+                    input,
+                },
+                executor,
+                || {
+                    if let Err(error) = write_response(&mut stream, &progress) {
+                        tracing::warn!(
+                            event = "agentd.manual_run_progress_failed",
+                            error = %error,
+                            "failed to write manual run progress"
+                        );
+                    }
+                },
+            ) {
+                Ok(outcome) => {
+                    log_manual_run_completed(&agent, work_unit.as_deref(), &outcome);
+                    ResponseMessage::SessionOutcome {
+                        outcome: outcome.into(),
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        event = "agentd.manual_run_rejected",
+                        error = %error,
+                        "run request rejected"
+                    );
+                    ResponseMessage::Error {
+                        message: dispatch_error_message(&error),
+                    }
                 }
             }
-            Err(error) => {
-                tracing::warn!(
-                    event = "agentd.manual_run_rejected",
-                    error = %error,
-                    "run request rejected"
-                );
-                ResponseMessage::Error {
-                    message: dispatch_error_message(&error),
-                }
-            }
-        },
+        }
     };
 
     write_response(&mut stream, &response)

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -538,9 +538,14 @@ fn summarize_transcript_event(line: &str) -> String {
             event
                 .get("kind")
                 .and_then(serde_json::Value::as_str)
-                .map(str::to_string)
+                .filter(|kind| !kind.is_empty())
+                .map(escape_transcript_event_kind)
         })
         .unwrap_or_else(|| "unparsed_event".to_string())
+}
+
+fn escape_transcript_event_kind(kind: &str) -> String {
+    kind.chars().flat_map(char::escape_default).collect()
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -895,11 +900,12 @@ fn read_pid(pid_file: &Path) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DaemonError, ResponseMessage, reap_finished_handlers,
+        DaemonError, LiveObservationLevel, ResponseMessage, reap_finished_handlers,
         run_daemon_until_shutdown_with_reconciler, write_response,
     };
     use crate::config::Config;
     use crate::dispatch::SessionExecutor;
+    use crate::protocol::ProgressMessage;
     use agentd_runner::{
         RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
         StartupReconciliationReport,
@@ -1065,6 +1071,28 @@ source = "AGENTD_GITHUB_TOKEN"
         assert!(
             result.is_ok(),
             "closed peer during response write should be treated as normal completion"
+        );
+    }
+
+    #[test]
+    fn summary_progress_escapes_untrusted_transcript_event_kind_controls() {
+        let mut output = Vec::new();
+
+        super::render_progress(
+            ProgressMessage::TranscriptEvent {
+                session_id: "fake-session-1".to_string(),
+                line: "{\"kind\":\"agent_input\\nspoof\\u001b[2J\"}".to_string(),
+            },
+            LiveObservationLevel::Summary,
+            &mut output,
+        )
+        .expect("summary progress should render");
+
+        let output = String::from_utf8(output).expect("summary progress should be utf8");
+        assert_eq!(output, "session event: agent_input\\nspoof\\u{1b}[2J\n");
+        assert!(
+            !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
+            "summary output should not contain embedded terminal controls: {output:?}"
         );
     }
 

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -27,6 +27,8 @@ const ACCEPT_TIMEOUT: Duration = Duration::from_millis(100);
 const RUNTIME_DIR_MODE: u32 = 0o700;
 const SOCKET_MODE: u32 = 0o600;
 const SHUTDOWN_MESSAGE: &str = "agentd is shutting down";
+const MAX_PROGRESS_FRAME_BYTES: usize = 128 * 1024;
+const TERMINAL_RESPONSE_RESERVE_BYTES: usize = 16 * 1024;
 
 /// Startup or runtime failures for the foreground daemon loop.
 #[derive(Debug)]
@@ -488,6 +490,19 @@ fn render_progress<W: Write>(
     level: LiveObservationLevel,
     writer: &mut W,
 ) -> Result<(), ClientError> {
+    writeln!(
+        writer,
+        "{}",
+        render_operator_progress_line(&progress, level)
+    )?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn render_operator_progress_line(
+    progress: &ProgressMessage,
+    level: LiveObservationLevel,
+) -> String {
     match (progress, level) {
         (
             ProgressMessage::DispatchStarted {
@@ -496,9 +511,13 @@ fn render_progress<W: Write>(
             LiveObservationLevel::Summary,
         ) => {
             if let Some(work_unit) = work_unit {
-                writeln!(writer, "session running: {agent} ({work_unit})")?;
+                format!(
+                    "session running: {} ({})",
+                    OperatorField(agent),
+                    OperatorField(work_unit)
+                )
             } else {
-                writeln!(writer, "session running: {agent}")?;
+                format!("session running: {}", OperatorField(agent))
             }
         }
         (
@@ -508,31 +527,44 @@ fn render_progress<W: Write>(
                 input_present,
             },
             LiveObservationLevel::Full,
-        ) => {
-            writeln!(
-                writer,
-                "session running: agent={agent} work_unit={} input={}",
-                work_unit.as_deref().unwrap_or("-"),
-                if input_present { "present" } else { "absent" }
-            )?;
-        }
+        ) => format!(
+            "session running: agent={} work_unit={} input={}",
+            OperatorField(agent),
+            work_unit
+                .as_deref()
+                .map(OperatorField)
+                .unwrap_or(OperatorField("-")),
+            if *input_present { "present" } else { "absent" }
+        ),
         (ProgressMessage::TranscriptEvent { line, .. }, LiveObservationLevel::Summary) => {
-            writeln!(
-                writer,
-                "session event: {}",
-                summarize_transcript_event(&line)
-            )?;
+            let summary = summarize_transcript_event(line);
+            format!("session event: {}", OperatorField(&summary))
         }
         (ProgressMessage::TranscriptEvent { session_id, line }, LiveObservationLevel::Full) => {
-            writeln!(
-                writer,
-                "session event: session_id={session_id} {}",
-                escape_control_chars(&line)
-            )?;
+            format!(
+                "session event: session_id={} {}",
+                OperatorField(session_id),
+                OperatorField(line)
+            )
         }
     }
-    writer.flush()?;
-    Ok(())
+}
+
+struct OperatorField<'a>(&'a str);
+
+impl fmt::Display for OperatorField<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for character in self.0.chars() {
+            if character.is_control() {
+                for escaped in character.escape_default() {
+                    write!(f, "{escaped}")?;
+                }
+            } else {
+                write!(f, "{character}")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 fn summarize_transcript_event(line: &str) -> String {
@@ -543,25 +575,9 @@ fn summarize_transcript_event(line: &str) -> String {
                 .get("kind")
                 .and_then(serde_json::Value::as_str)
                 .filter(|kind| !kind.is_empty())
-                .map(escape_transcript_event_kind)
+                .map(str::to_string)
         })
         .unwrap_or_else(|| "unparsed_event".to_string())
-}
-
-fn escape_transcript_event_kind(kind: &str) -> String {
-    kind.chars().flat_map(char::escape_default).collect()
-}
-
-fn escape_control_chars(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for character in value.chars() {
-        if character.is_control() {
-            escaped.extend(character.escape_default());
-        } else {
-            escaped.push(character);
-        }
-    }
-    escaped
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -732,18 +748,34 @@ fn try_write_progress_response(
     let mut payload = serde_json::to_vec(response)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     payload.push(b'\n');
+    if payload.len() > MAX_PROGRESS_FRAME_BYTES {
+        tracing::debug!(
+            event = "agentd.manual_run_progress_dropped",
+            frame_bytes = payload.len(),
+            max_frame_bytes = MAX_PROGRESS_FRAME_BYTES,
+            "dropped oversized manual run progress frame"
+        );
+        return Ok(());
+    }
+
+    if !progress_frame_has_reserved_capacity(stream, payload.len())? {
+        tracing::debug!(
+            event = "agentd.manual_run_progress_dropped",
+            frame_bytes = payload.len(),
+            terminal_reserve_bytes = TERMINAL_RESPONSE_RESERVE_BYTES,
+            "dropped manual run progress frame because the client connection is backpressured"
+        );
+        return Ok(());
+    }
 
     stream.set_nonblocking(true)?;
-    let write_result = write_response_nonblocking(stream, &payload);
+    let write_result = write_progress_frame_nonblocking(stream, &payload);
     let restore_result = stream.set_nonblocking(false);
 
     match (write_result, restore_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(error), Ok(())) if peer_disconnected_during_response(&error) => Ok(()),
-        (Err(error), Ok(())) if progress_response_would_block(&error) => {
-            let _ = stream.shutdown(std::net::Shutdown::Both);
-            Ok(())
-        }
+        (Err(error), Ok(())) if progress_response_would_block(&error) => Ok(()),
         (Err(error), Ok(())) => Err(error),
         (Ok(()), Err(error)) => Err(error),
         (Err(write_error), Err(restore_error)) => {
@@ -757,25 +789,66 @@ fn try_write_progress_response(
     }
 }
 
-fn write_response_nonblocking(stream: &mut UnixStream, mut bytes: &[u8]) -> Result<(), io::Error> {
-    while !bytes.is_empty() {
-        match stream.write(bytes) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "failed to write progress response",
-                ));
-            }
-            Ok(written) => bytes = &bytes[written..],
-            Err(error) if peer_disconnected_during_response(&error) => return Ok(()),
-            Err(error) => return Err(error),
-        }
-    }
-
-    match stream.flush() {
-        Ok(()) => Ok(()),
+fn write_progress_frame_nonblocking(
+    stream: &mut UnixStream,
+    bytes: &[u8],
+) -> Result<(), io::Error> {
+    match stream.write(bytes) {
+        Ok(written) if written == bytes.len() => Ok(()),
+        Ok(0) => Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "failed to write progress response",
+        )),
+        Ok(written) => Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            format!(
+                "partial progress frame write accepted {written} of {}",
+                bytes.len()
+            ),
+        )),
         Err(error) if peer_disconnected_during_response(&error) => Ok(()),
         Err(error) => Err(error),
+    }
+}
+
+fn progress_frame_has_reserved_capacity(
+    stream: &UnixStream,
+    frame_bytes: usize,
+) -> Result<bool, io::Error> {
+    let send_buffer_bytes = socket_send_buffer_bytes(stream)?;
+    let queued_bytes = socket_queued_output_bytes(stream)?;
+    Ok(queued_bytes.saturating_add(frame_bytes)
+        <= send_buffer_bytes.saturating_sub(TERMINAL_RESPONSE_RESERVE_BYTES))
+}
+
+fn socket_send_buffer_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
+    let mut size = 0_i32;
+    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &mut size as *mut i32 as *mut libc::c_void,
+            &mut size_len,
+        )
+    };
+    if result == 0 {
+        usize::try_from(size)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "SO_SNDBUF was negative"))
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn socket_queued_output_bytes(stream: &UnixStream) -> Result<usize, io::Error> {
+    let mut queued = 0_i32;
+    let result = unsafe { libc::ioctl(stream.as_raw_fd(), libc::TIOCOUTQ, &mut queued) };
+    if result == 0 {
+        usize::try_from(queued)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "TIOCOUTQ was negative"))
+    } else {
+        Err(io::Error::last_os_error())
     }
 }
 
@@ -1190,7 +1263,7 @@ source = "AGENTD_GITHUB_TOKEN"
 
         super::render_progress(
             ProgressMessage::TranscriptEvent {
-                session_id: "fake-session-1".to_string(),
+                session_id: "fake-session-1\rspoof".to_string(),
                 line: "{\"kind\":\"agent_input\"}\nspoof\u{1b}[2J".to_string(),
             },
             LiveObservationLevel::Full,
@@ -1201,12 +1274,41 @@ source = "AGENTD_GITHUB_TOKEN"
         let output = String::from_utf8(output).expect("full progress should be utf8");
         assert_eq!(
             output,
-            "session event: session_id=fake-session-1 {\"kind\":\"agent_input\"}\\nspoof\\u{1b}[2J\n"
+            "session event: session_id=fake-session-1\\rspoof {\"kind\":\"agent_input\"}\\nspoof\\u{1b}[2J\n"
         );
         assert!(
             !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
             "full output should not contain embedded terminal controls: {output:?}"
         );
+    }
+
+    #[test]
+    fn dispatch_progress_escapes_untrusted_request_fields_at_every_level() {
+        for level in [LiveObservationLevel::Summary, LiveObservationLevel::Full] {
+            let mut output = Vec::new();
+
+            super::render_progress(
+                ProgressMessage::DispatchStarted {
+                    agent: "site-builder\nspoof\u{1b}[2J".to_string(),
+                    work_unit: Some("issue-122\rrewrite".to_string()),
+                    input_present: true,
+                },
+                level,
+                &mut output,
+            )
+            .expect("dispatch progress should render");
+
+            let output = String::from_utf8(output).expect("dispatch progress should be utf8");
+            assert!(
+                output.contains("site-builder\\nspoof\\u{1b}[2J")
+                    && output.contains("issue-122\\rrewrite"),
+                "dispatch output should escape request fields: {output:?}"
+            );
+            assert!(
+                !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
+                "dispatch output should not contain embedded terminal controls: {output:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, TryLockError};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use agentd_runner::{
     RunnerError, SessionOutcome, SessionProgressEvent, StartupReconciliationReport,
@@ -32,6 +32,7 @@ const SHUTDOWN_MESSAGE: &str = "agentd is shutting down";
 const MAX_PROGRESS_FRAME_BYTES: usize = 128 * 1024;
 const PROGRESS_QUEUE_CAPACITY: usize = 64;
 const PROGRESS_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+const PROGRESS_SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Startup or runtime failures for the foreground daemon loop.
 #[derive(Debug)]
@@ -215,6 +216,7 @@ where
     runtime.bind_listener()?;
     let executor = Arc::new(executor);
     let mut handlers = Vec::new();
+    let progress_writers = ProgressWriterRegistry::default();
     let scheduler_handle = spawn_scheduler_thread(&config, Arc::clone(&shutdown))?;
     tracing::info!(
         event = "agentd.daemon_started",
@@ -240,6 +242,7 @@ where
                     stream,
                     config.clone(),
                     executor.clone(),
+                    progress_writers.clone(),
                 ));
             }
             Err(error) if accept_was_interrupted(&error) => continue,
@@ -247,10 +250,11 @@ where
         }
     };
 
-    let finish_result = shutdown_daemon(
+    let finish_result = shutdown_daemon_with_progress_writers(
         shutdown.as_ref(),
         || runtime.begin_shutdown(),
         handlers,
+        progress_writers,
         scheduler_handle,
         loop_result,
     );
@@ -259,6 +263,7 @@ where
     Ok(())
 }
 
+#[cfg(test)]
 fn shutdown_daemon<F>(
     shutdown: &AtomicBool,
     begin_shutdown: F,
@@ -269,9 +274,31 @@ fn shutdown_daemon<F>(
 where
     F: FnOnce() -> Result<(), io::Error>,
 {
+    shutdown_daemon_with_progress_writers(
+        shutdown,
+        begin_shutdown,
+        handlers,
+        ProgressWriterRegistry::default(),
+        scheduler_handle,
+        loop_result,
+    )
+}
+
+fn shutdown_daemon_with_progress_writers<F>(
+    shutdown: &AtomicBool,
+    begin_shutdown: F,
+    handlers: Vec<JoinHandle<()>>,
+    progress_writers: ProgressWriterRegistry,
+    scheduler_handle: Option<JoinHandle<()>>,
+    loop_result: Result<(), io::Error>,
+) -> Result<(), io::Error>
+where
+    F: FnOnce() -> Result<(), io::Error>,
+{
     shutdown.store(true, Ordering::Release);
     let shutdown_result = begin_shutdown();
     join_connection_handlers(handlers);
+    progress_writers.drain(PROGRESS_SHUTDOWN_DRAIN_TIMEOUT);
     join_scheduler_thread(scheduler_handle);
 
     match (loop_result, shutdown_result) {
@@ -301,12 +328,13 @@ fn spawn_connection_handler<E>(
     stream: UnixStream,
     config: Config,
     executor: Arc<E>,
+    progress_writers: ProgressWriterRegistry,
 ) -> JoinHandle<()>
 where
     E: SessionExecutor + Send + Sync + 'static,
 {
     thread::spawn(move || {
-        handle_connection(stream, &config, executor.as_ref());
+        handle_connection(stream, &config, executor.as_ref(), &progress_writers);
     })
 }
 
@@ -583,8 +611,13 @@ fn summarize_transcript_event(line: &str) -> String {
         .unwrap_or_else(|| "unparsed_event".to_string())
 }
 
-fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
-    if let Err(error) = handle_connection_inner(stream, config, executor) {
+fn handle_connection(
+    stream: UnixStream,
+    config: &Config,
+    executor: &impl SessionExecutor,
+    progress_writers: &ProgressWriterRegistry,
+) {
+    if let Err(error) = handle_connection_inner(stream, config, executor, progress_writers) {
         tracing::warn!(
             event = "agentd.operator_connection_failed",
             error = %error,
@@ -597,6 +630,7 @@ fn handle_connection_inner(
     mut stream: UnixStream,
     config: &Config,
     executor: &impl SessionExecutor,
+    progress_writers: &ProgressWriterRegistry,
 ) -> Result<(), io::Error> {
     let request = {
         let mut reader = BufReader::new(&mut stream);
@@ -629,7 +663,16 @@ fn handle_connection_inner(
             input,
         } => {
             return handle_run_connection(
-                stream, config, executor, agent, repo_url, work_unit, input,
+                stream,
+                config,
+                executor,
+                progress_writers,
+                RunRequest {
+                    agent,
+                    repo_url,
+                    work_unit,
+                    input,
+                },
             );
         }
     };
@@ -641,18 +684,18 @@ fn handle_run_connection(
     stream: UnixStream,
     config: &Config,
     executor: &impl SessionExecutor,
-    agent: String,
-    repo_url: Option<String>,
-    work_unit: Option<String>,
-    input: Option<agentd_runner::InvocationInput>,
+    progress_writers: &ProgressWriterRegistry,
+    request: RunRequest,
 ) -> Result<(), io::Error> {
-    let writer = ProgressWriter::spawn(stream)?;
+    let writer = ProgressWriter::spawn(stream, progress_writers)?;
+    let agent = request.agent.clone();
+    let work_unit = request.work_unit.clone();
     let response = {
         let dispatch_progress = ResponseMessage::Progress {
             progress: ProgressMessage::DispatchStarted {
                 agent: agent.clone(),
                 work_unit: work_unit.clone(),
-                input_present: input.is_some(),
+                input_present: request.input.is_some(),
             },
         };
         let write_progress = |event: SessionProgressEvent| {
@@ -664,12 +707,7 @@ fn handle_run_connection(
         };
         match dispatch_run_after_preflight(
             config,
-            &RunRequest {
-                agent: agent.clone(),
-                repo_url,
-                work_unit: work_unit.clone(),
-                input,
-            },
+            &request,
             executor,
             || {
                 writer.enqueue_dispatch_progress(dispatch_progress);
@@ -725,6 +763,74 @@ fn serialize_response_frame(response: &ResponseMessage) -> Result<Vec<u8>, io::E
     Ok(payload)
 }
 
+#[derive(Clone, Default)]
+struct ProgressWriterRegistry {
+    handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+}
+
+impl ProgressWriterRegistry {
+    fn track(&self, handle: JoinHandle<()>) {
+        let mut handles = self
+            .handles
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reap_finished_progress_writers(&mut handles);
+        handles.push(handle);
+    }
+
+    fn drain(&self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let active_writers = {
+                let mut handles = self
+                    .handles
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                reap_finished_progress_writers(&mut handles)
+            };
+            if active_writers == 0 {
+                return;
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                tracing::warn!(
+                    event = "agentd.manual_run_progress_writer_shutdown_drain_timed_out",
+                    active_writers,
+                    timeout_ms = timeout.as_millis(),
+                    "abandoned manual run progress writer drain at daemon shutdown deadline"
+                );
+                return;
+            }
+
+            thread::sleep((deadline - now).min(Duration::from_millis(10)));
+        }
+    }
+}
+
+fn reap_finished_progress_writers(handles: &mut Vec<JoinHandle<()>>) -> usize {
+    let mut active = Vec::with_capacity(handles.len());
+    for handle in std::mem::take(handles) {
+        if handle.is_finished() {
+            log_progress_writer_panic(handle);
+        } else {
+            active.push(handle);
+        }
+    }
+    let active_count = active.len();
+    *handles = active;
+    active_count
+}
+
+fn log_progress_writer_panic(handle: JoinHandle<()>) {
+    if handle.join().is_err() {
+        tracing::error!(
+            event = "agentd.manual_run_progress_writer_panicked",
+            "manual run progress writer panicked"
+        );
+    }
+}
+
 #[derive(Clone)]
 struct ProgressWriter {
     shared: Arc<ProgressWriterShared>,
@@ -752,7 +858,7 @@ enum ProgressWriterFrame {
 }
 
 impl ProgressWriter {
-    fn spawn(stream: UnixStream) -> Result<Self, io::Error> {
+    fn spawn(stream: UnixStream, registry: &ProgressWriterRegistry) -> Result<Self, io::Error> {
         stream.set_write_timeout(Some(PROGRESS_WRITE_TIMEOUT))?;
         let shared = Arc::new(ProgressWriterShared {
             state: Mutex::new(ProgressWriterState {
@@ -763,7 +869,7 @@ impl ProgressWriter {
             available: Condvar::new(),
         });
         let writer_shared = Arc::clone(&shared);
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 run_progress_writer(stream, writer_shared);
             }));
@@ -774,6 +880,7 @@ impl ProgressWriter {
                 );
             }
         });
+        registry.track(handle);
 
         Ok(Self { shared })
     }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, TryLockError};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -524,7 +524,11 @@ fn render_progress<W: Write>(
             )?;
         }
         (ProgressMessage::TranscriptEvent { session_id, line }, LiveObservationLevel::Full) => {
-            writeln!(writer, "session event: session_id={session_id} {line}")?;
+            writeln!(
+                writer,
+                "session event: session_id={session_id} {}",
+                escape_control_chars(&line)
+            )?;
         }
     }
     writer.flush()?;
@@ -546,6 +550,18 @@ fn summarize_transcript_event(line: &str) -> String {
 
 fn escape_transcript_event_kind(kind: &str) -> String {
     kind.chars().flat_map(char::escape_default).collect()
+}
+
+fn escape_control_chars(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else {
+            escaped.push(character);
+        }
+    }
+    escaped
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {
@@ -606,9 +622,9 @@ fn handle_connection_inner(
                 let progress = ResponseMessage::Progress {
                     progress: ProgressMessage::TranscriptEvent { session_id, line },
                 };
-                match stream.lock() {
+                match stream.try_lock() {
                     Ok(mut stream) => {
-                        if let Err(error) = write_response(&mut stream, &progress) {
+                        if let Err(error) = try_write_progress_response(&mut stream, &progress) {
                             tracing::warn!(
                                 event = "agentd.manual_run_progress_failed",
                                 error = %error,
@@ -616,7 +632,13 @@ fn handle_connection_inner(
                             );
                         }
                     }
-                    Err(_) => {
+                    Err(TryLockError::WouldBlock) => {
+                        tracing::debug!(
+                            event = "agentd.manual_run_progress_dropped",
+                            "dropped manual run progress while another response was in flight"
+                        );
+                    }
+                    Err(TryLockError::Poisoned(_)) => {
                         tracing::warn!(
                             event = "agentd.manual_run_progress_lock_poisoned",
                             "failed to lock manual run progress stream"
@@ -633,9 +655,11 @@ fn handle_connection_inner(
                     input,
                 },
                 executor,
-                || match stream.lock() {
+                || match stream.try_lock() {
                     Ok(mut stream) => {
-                        if let Err(error) = write_response(&mut stream, &dispatch_progress) {
+                        if let Err(error) =
+                            try_write_progress_response(&mut stream, &dispatch_progress)
+                        {
                             tracing::warn!(
                                 event = "agentd.manual_run_progress_failed",
                                 error = %error,
@@ -643,7 +667,13 @@ fn handle_connection_inner(
                             );
                         }
                     }
-                    Err(_) => {
+                    Err(TryLockError::WouldBlock) => {
+                        tracing::debug!(
+                            event = "agentd.manual_run_progress_dropped",
+                            "dropped manual run progress while another response was in flight"
+                        );
+                    }
+                    Err(TryLockError::Poisoned(_)) => {
                         tracing::warn!(
                             event = "agentd.manual_run_progress_lock_poisoned",
                             "failed to lock manual run progress stream"
@@ -693,6 +723,64 @@ fn write_response_part(stream: &mut UnixStream, bytes: &[u8]) -> Result<(), io::
         Err(error) if peer_disconnected_during_response(&error) => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+fn try_write_progress_response(
+    stream: &mut UnixStream,
+    response: &ResponseMessage,
+) -> Result<(), io::Error> {
+    let mut payload = serde_json::to_vec(response)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    payload.push(b'\n');
+
+    stream.set_nonblocking(true)?;
+    let write_result = write_response_nonblocking(stream, &payload);
+    let restore_result = stream.set_nonblocking(false);
+
+    match (write_result, restore_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) if peer_disconnected_during_response(&error) => Ok(()),
+        (Err(error), Ok(())) if progress_response_would_block(&error) => {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+            Ok(())
+        }
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(write_error), Err(restore_error)) => {
+            tracing::warn!(
+                event = "agentd.manual_run_progress_blocking_restore_failed",
+                error = %restore_error,
+                "failed to restore blocking mode after manual run progress write"
+            );
+            Err(write_error)
+        }
+    }
+}
+
+fn write_response_nonblocking(stream: &mut UnixStream, mut bytes: &[u8]) -> Result<(), io::Error> {
+    while !bytes.is_empty() {
+        match stream.write(bytes) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write progress response",
+                ));
+            }
+            Ok(written) => bytes = &bytes[written..],
+            Err(error) if peer_disconnected_during_response(&error) => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+
+    match stream.flush() {
+        Ok(()) => Ok(()),
+        Err(error) if peer_disconnected_during_response(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn progress_response_would_block(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::WouldBlock)
 }
 
 fn peer_disconnected_during_response(error: &io::Error) -> bool {
@@ -1093,6 +1181,31 @@ source = "AGENTD_GITHUB_TOKEN"
         assert!(
             !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
             "summary output should not contain embedded terminal controls: {output:?}"
+        );
+    }
+
+    #[test]
+    fn full_progress_escapes_untrusted_raw_transcript_line_controls() {
+        let mut output = Vec::new();
+
+        super::render_progress(
+            ProgressMessage::TranscriptEvent {
+                session_id: "fake-session-1".to_string(),
+                line: "{\"kind\":\"agent_input\"}\nspoof\u{1b}[2J".to_string(),
+            },
+            LiveObservationLevel::Full,
+            &mut output,
+        )
+        .expect("full progress should render");
+
+        let output = String::from_utf8(output).expect("full progress should be utf8");
+        assert_eq!(
+            output,
+            "session event: session_id=fake-session-1 {\"kind\":\"agent_input\"}\\nspoof\\u{1b}[2J\n"
+        );
+        assert!(
+            !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
+            "full output should not contain embedded terminal controls: {output:?}"
         );
     }
 

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use agentd_runner::{
-    InvocationInput, ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
-    SessionSpec, run_session,
+    InvocationInput, NoopSessionProgressObserver, ResolvedEnvironmentVariable, RunnerError,
+    SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
+    run_session_with_progress,
 };
 
 use crate::audit_root::prepare_audit_root;
@@ -87,6 +88,7 @@ pub trait SessionExecutor {
         &self,
         spec: SessionSpec,
         invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError>;
 }
 
@@ -99,8 +101,9 @@ impl SessionExecutor for RunnerSessionExecutor {
         &self,
         spec: SessionSpec,
         invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
-        run_session(spec, invocation)
+        run_session_with_progress(spec, invocation, progress)
     }
 }
 
@@ -110,7 +113,13 @@ pub fn dispatch_run(
     request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
-    dispatch_run_after_preflight(config, request, executor, || {})
+    dispatch_run_after_preflight(
+        config,
+        request,
+        executor,
+        || {},
+        &NoopSessionProgressObserver,
+    )
 }
 
 /// Resolve a named agent plus run request into a runner session, notify once
@@ -120,6 +129,7 @@ pub fn dispatch_run_after_preflight(
     request: &RunRequest,
     executor: &impl SessionExecutor,
     after_preflight: impl FnOnce(),
+    progress: &dyn SessionProgressObserver,
 ) -> Result<SessionOutcome, DispatchError> {
     let agent = config
         .agent(&request.agent)
@@ -186,6 +196,7 @@ pub fn dispatch_run_after_preflight(
                 input: request.input.clone(),
                 timeout: None,
             },
+            progress,
         )
         .map_err(DispatchError::from)
 }

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -110,6 +110,17 @@ pub fn dispatch_run(
     request: &RunRequest,
     executor: &impl SessionExecutor,
 ) -> Result<SessionOutcome, DispatchError> {
+    dispatch_run_after_preflight(config, request, executor, || {})
+}
+
+/// Resolve a named agent plus run request into a runner session, notify once
+/// preflight has passed, and run it.
+pub fn dispatch_run_after_preflight(
+    config: &Config,
+    request: &RunRequest,
+    executor: &impl SessionExecutor,
+    after_preflight: impl FnOnce(),
+) -> Result<SessionOutcome, DispatchError> {
     let agent = config
         .agent(&request.agent)
         .ok_or_else(|| DispatchError::UnknownAgent {
@@ -148,6 +159,8 @@ pub fn dispatch_run(
         .repo_token_source()
         .and_then(|source| std::env::var(source).ok())
         .filter(|value| !value.is_empty());
+
+    after_preflight();
 
     executor
         .run_session(

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -13,7 +13,10 @@ mod protocol;
 pub mod runtime_paths;
 mod scheduler;
 
-pub use daemon::{ClientError, DaemonError, request_run, run_daemon_until_shutdown};
+pub use daemon::{
+    ClientError, DaemonError, LiveObservationLevel, request_run, request_run_with_live_observation,
+    run_daemon_until_shutdown,
+};
 pub use dispatch::{
     DispatchError, RunRequest, RunnerSessionExecutor, SessionExecutor, dispatch_run,
 };

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -144,7 +144,7 @@ enum Command {
     /// Trigger a manual session through the running daemon.
     #[command(
         display_name = "agentd",
-        after_help = "Live observation:\n  agentd run streams concise session progress by default. Use --progress full for every available progress field.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
+        after_help = "Live observation:\n  agentd run streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
     )]
     Run {
         agent: String,
@@ -194,7 +194,7 @@ fn main() -> ExitCode {
 
 fn wish_after_help() -> String {
     format!(
-        "Live observation:\n  agentd wish streams concise session progress by default. Use --progress full for every available progress field.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}"
+        "Live observation:\n  agentd wish streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}"
     )
 }
 

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -7,11 +7,11 @@ use std::{io::BufRead, io::Write};
 
 use agentd::config::Config;
 use agentd::{
-    RunRequest, RunnerSessionExecutor, configure_tracing, request_run, resolve_client_socket_path,
-    run_daemon_until_shutdown,
+    LiveObservationLevel, RunRequest, RunnerSessionExecutor, configure_tracing,
+    request_run_with_live_observation, resolve_client_socket_path, run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 
 const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
@@ -19,6 +19,33 @@ const WISH_GREETING: &str = "Speak a wish: the state you want made true.";
 const WISH_STATEMENT_PROMPT: &str = "What do you wish to be true?";
 const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank if it has no target.";
 const WISH_ABOUT: &str = "Elicit a wish and seed one governed session.";
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ProgressLevel {
+    /// Print concise live session lifecycle messages.
+    Summary,
+    /// Print live session lifecycle messages with all available fields.
+    Full,
+}
+
+impl From<ProgressLevel> for LiveObservationLevel {
+    fn from(level: ProgressLevel) -> Self {
+        match level {
+            ProgressLevel::Summary => Self::Summary,
+            ProgressLevel::Full => Self::Full,
+        }
+    }
+}
+
+struct RunClientArgs {
+    agent: String,
+    repo: Option<String>,
+    progress: ProgressLevel,
+    work_unit: Option<String>,
+    intent: Option<String>,
+    artifact_file: Option<PathBuf>,
+    artifact_type: Option<String>,
+}
 
 #[derive(Debug)]
 enum RunCommandError {
@@ -117,13 +144,15 @@ enum Command {
     /// Trigger a manual session through the running daemon.
     #[command(
         display_name = "agentd",
-        after_help = "Work-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
+        after_help = "Live observation:\n  agentd run streams concise session progress by default. Use --progress full for every available progress field.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
     )]
     Run {
         agent: String,
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
+        progress: ProgressLevel,
         #[arg(long, conflicts_with = "intent")]
         work_unit: Option<String>,
         #[arg(long, conflicts_with_all = ["work_unit", "artifact_file"])]
@@ -143,6 +172,8 @@ enum Command {
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
+        progress: ProgressLevel,
     },
 }
 
@@ -162,7 +193,9 @@ fn main() -> ExitCode {
 }
 
 fn wish_after_help() -> String {
-    format!("Prompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}")
+    format!(
+        "Live observation:\n  agentd wish streams concise session progress by default. Use --progress full for every available progress field.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}"
+    )
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -180,6 +213,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             agent,
             repo,
             socket_path,
+            progress,
             work_unit,
             intent,
             artifact_file,
@@ -193,18 +227,22 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             run_client(
                 socket_path.as_deref(),
-                agent,
-                repo,
-                work_unit,
-                intent,
-                artifact_file,
-                artifact_type,
+                RunClientArgs {
+                    agent,
+                    repo,
+                    progress,
+                    work_unit,
+                    intent,
+                    artifact_file,
+                    artifact_type,
+                },
             )
         }
         Some(Command::Wish {
             agent,
             repo,
             socket_path,
+            progress,
         }) => {
             if cli.config.is_some() {
                 return Err(Box::new(std::io::Error::new(
@@ -212,7 +250,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     "--config is only supported for daemon mode, not `agentd wish`",
                 )));
             }
-            run_wish_client(socket_path.as_deref(), agent, repo)
+            run_wish_client(socket_path.as_deref(), agent, repo, progress)
         }
     }
 }
@@ -251,21 +289,24 @@ fn register_termination_handlers(shutdown: Arc<AtomicBool>) -> Result<(), std::i
 
 fn run_client(
     explicit_socket_path: Option<&std::path::Path>,
-    agent: String,
-    repo: Option<String>,
-    work_unit: Option<String>,
-    intent: Option<String>,
-    artifact_file: Option<PathBuf>,
-    artifact_type: Option<String>,
+    args: RunClientArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let input = resolve_invocation_input(intent, artifact_file, artifact_type)?;
-    run_client_with_input(explicit_socket_path, agent, repo, work_unit, input)
+    let input = resolve_invocation_input(args.intent, args.artifact_file, args.artifact_type)?;
+    run_client_with_input(
+        explicit_socket_path,
+        args.agent,
+        args.repo,
+        args.progress,
+        args.work_unit,
+        input,
+    )
 }
 
 fn run_wish_client(
     explicit_socket_path: Option<&std::path::Path>,
     agent: String,
     repo: Option<String>,
+    progress: ProgressLevel,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout();
@@ -275,6 +316,7 @@ fn run_wish_client(
         explicit_socket_path,
         agent,
         repo,
+        progress,
         None,
         Some(InvocationInput::IntentText { statement, target }),
     )
@@ -284,11 +326,13 @@ fn run_client_with_input(
     explicit_socket_path: Option<&std::path::Path>,
     agent: String,
     repo: Option<String>,
+    progress: ProgressLevel,
     work_unit: Option<String>,
     input: Option<InvocationInput>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let socket_path = resolve_client_socket_path(explicit_socket_path)?;
-    let outcome = request_run(
+    let mut stdout = std::io::stdout();
+    let outcome = request_run_with_live_observation(
         &socket_path,
         &RunRequest {
             agent,
@@ -296,6 +340,8 @@ fn run_client_with_input(
             work_unit,
             input,
         },
+        progress.into(),
+        &mut stdout,
     )?;
 
     if outcome.is_cli_success() {

--- a/crates/agentd/src/protocol.rs
+++ b/crates/agentd/src/protocol.rs
@@ -1,8 +1,8 @@
 //! Daemon Unix-socket wire messages.
 //!
 //! Wire format and connection lifecycle are specified in
-//! `docs/socket-protocol.md`: newline-delimited JSON, one request and one
-//! response per connection. The protocol is intentionally internal and
+//! `docs/socket-protocol.md`: newline-delimited JSON, one request followed by
+//! one or more response lines. The protocol is intentionally internal and
 //! unversioned in `v0.1.x` — daemon and CLI client must be the same build
 //! (see README § Running a Session), which is why these types are
 //! `pub(crate)` and carry no version field.
@@ -57,6 +57,8 @@ pub(crate) enum ProgressMessage {
         work_unit: Option<String>,
         input_present: bool,
     },
+    /// One event line emitted by the running session's transcript stream.
+    TranscriptEvent { session_id: String, line: String },
 }
 
 /// Terminal session outcome.

--- a/crates/agentd/src/protocol.rs
+++ b/crates/agentd/src/protocol.rs
@@ -30,19 +30,33 @@ pub(crate) enum RequestMessage {
     },
 }
 
-/// Daemon → client. Exactly one is written per accepted request, then the
-/// connection closes.
+/// Daemon → client. A run request may emit zero or more progress messages
+/// before its terminal outcome or error message, then the connection closes.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum ResponseMessage {
     /// Answer to [`RequestMessage::Ping`].
     Pong,
+    /// Human-observable progress for a running session.
+    Progress { progress: ProgressMessage },
     /// The session ran to a terminal outcome (which may be a failure
     /// outcome — transport success, not work success).
     SessionOutcome { outcome: OutcomeMessage },
     /// The request was rejected before a session outcome existed:
     /// malformed JSON, unknown agent, or dispatch failure.
     Error { message: String },
+}
+
+/// Non-terminal session progress.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+pub(crate) enum ProgressMessage {
+    /// The daemon accepted the request and is dispatching it to the runner.
+    DispatchStarted {
+        agent: String,
+        work_unit: Option<String>,
+        input_present: bool,
+    },
 }
 
 /// Terminal session outcome.

--- a/crates/agentd/src/scheduler.rs
+++ b/crates/agentd/src/scheduler.rs
@@ -107,7 +107,8 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use agentd_runner::{
-        RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+        RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver, SessionSpec,
+        StartupReconciliationReport,
     };
 
     use crate::SessionExecutor;
@@ -135,6 +136,7 @@ mod tests {
             &self,
             _spec: SessionSpec,
             invocation: SessionInvocation,
+            _progress: &dyn SessionProgressObserver,
         ) -> Result<SessionOutcome, RunnerError> {
             self.invocations
                 .lock()

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -425,6 +425,12 @@ fn binary_run_help_shows_socket_path_and_not_config() {
         "run help should advertise socket override: {stdout}"
     );
     assert!(
+        stdout.contains("--progress <PROGRESS>")
+            && stdout.contains("summary")
+            && stdout.contains("full"),
+        "run help should document live progress verbosity: {stdout}"
+    );
+    assert!(
         !stdout.contains("--config"),
         "run help should not advertise daemon config coupling: {stdout}"
     );
@@ -475,6 +481,12 @@ fn binary_wish_help_shows_evocative_intent_prompting_surface() {
     assert!(
         stdout.contains("Elicit a wish and seed one governed session."),
         "wish help should describe the wish session boundary exactly: {stdout}"
+    );
+    assert!(
+        stdout.contains("--progress <PROGRESS>")
+            && stdout.contains("summary")
+            && stdout.contains("full"),
+        "wish help should document live progress verbosity: {stdout}"
     );
     assert!(
         stdout.contains(
@@ -1311,11 +1323,10 @@ fn binary_run_command_exits_non_zero_and_reports_failed_sessions_on_stderr() {
         !output.status.success(),
         "run command should fail when the daemon reports a failed session"
     );
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be valid UTF-8")
-            .is_empty(),
-        "failed run should not print a success-style stdout message"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session running: site-builder\n",
+        "failed run should print only live progress on stdout"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
@@ -1366,11 +1377,10 @@ fn binary_run_command_exits_non_zero_and_reports_timed_out_sessions_on_stderr() 
         !output.status.success(),
         "run command should fail when the daemon reports a timed-out session"
     );
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be valid UTF-8")
-            .is_empty(),
-        "timed-out run should not print a success-style stdout message"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session running: site-builder\n",
+        "timed-out run should print only live progress on stdout"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
@@ -1427,11 +1437,10 @@ fn binary_run_command_exits_non_zero_and_reports_signal_terminated_sessions_on_s
         !output.status.success(),
         "run command should fail when the daemon reports a signal-terminated session"
     );
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be valid UTF-8")
-            .is_empty(),
-        "signal-terminated run should not print a success-style stdout message"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        "session running: site-builder\n",
+        "signal-terminated run should print only live progress on stdout"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be valid UTF-8");
@@ -1486,7 +1495,7 @@ fn binary_run_command_exits_zero_and_reports_blocked_sessions_on_stdout() {
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session blocked\n"
+        "session running: site-builder\nsession blocked\n"
     );
     assert!(
         String::from_utf8(output.stderr)
@@ -1541,7 +1550,7 @@ fn binary_run_command_exits_zero_and_reports_nothing_ready_sessions_on_stdout() 
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session nothing_ready\n"
+        "session running: site-builder\nsession nothing_ready\n"
     );
     assert!(
         String::from_utf8(output.stderr)
@@ -1608,7 +1617,7 @@ argv = ["site-builder", "exec"]
     );
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
-        "session success\n"
+        "session running: site-builder\nsession success\n"
     );
     assert_eq!(
         invocations.lock().expect("invocations should lock")[0].repo_url,

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -12,8 +12,8 @@ use agentd::SessionExecutor;
 use agentd::config::Config;
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
 use agentd_runner::{
-    InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionSpec,
-    StartupReconciliationReport,
+    InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver,
+    SessionSpec, StartupReconciliationReport,
 };
 use serde_json::json;
 
@@ -35,6 +35,7 @@ impl SessionExecutor for FixedOutcomeExecutor {
         &self,
         _spec: SessionSpec,
         _invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         Ok(self.outcome.clone())
     }
@@ -64,6 +65,7 @@ impl SessionExecutor for RecordingInvocationExecutor {
         &self,
         _spec: SessionSpec,
         invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         self.invocations
             .lock()

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -1712,6 +1712,8 @@ fn rejects_reserved_credential_names() {
     for reserved_name in [
         "AGENT_NAME",
         "RUNA_TRANSCRIPT_DIR",
+        "RUNA_TRANSCRIPT_DEPLOYMENT",
+        "RUNA_TRANSCRIPT_RUN_ID",
         "RUNA_TRANSCRIPT_REDACT_ENV",
     ] {
         let config = format!(

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -14,7 +14,8 @@ use agentd::{
 };
 use agentd_runner::InvocationInput;
 use agentd_runner::{
-    RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
+    RunnerError, SessionInvocation, SessionOutcome, SessionProgressEvent, SessionProgressObserver,
+    SessionSpec, StartupReconciliationReport,
 };
 use serde_json::json;
 
@@ -51,6 +52,7 @@ impl SessionExecutor for FixedOutcomeExecutor {
         &self,
         _spec: SessionSpec,
         _invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         Ok(self.outcome.clone())
     }
@@ -80,6 +82,7 @@ impl SessionExecutor for RecordingInvocationExecutor {
         &self,
         _spec: SessionSpec,
         invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         self.invocations
             .lock()
@@ -94,6 +97,7 @@ struct BlockingFirstRunExecutor {
     state: Arc<BlockingFirstRunState>,
     first_outcome: SessionOutcome,
     later_outcome: SessionOutcome,
+    first_progress_line: Option<String>,
 }
 
 struct BlockingFirstRunState {
@@ -112,7 +116,13 @@ impl BlockingFirstRunExecutor {
             }),
             first_outcome,
             later_outcome,
+            first_progress_line: None,
         }
+    }
+
+    fn with_first_progress_line(mut self, line: &str) -> Self {
+        self.first_progress_line = Some(line.to_string());
+        self
     }
 
     fn wait_for_first_run_to_start(&self) {
@@ -138,6 +148,7 @@ impl SessionExecutor for BlockingFirstRunExecutor {
         &self,
         _spec: SessionSpec,
         _invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         let call_index = self.state.calls.fetch_add(1, Ordering::AcqRel);
         if call_index == 0 {
@@ -148,6 +159,13 @@ impl SessionExecutor for BlockingFirstRunExecutor {
             *started = true;
             started_cvar.notify_all();
             drop(started);
+
+            if let Some(line) = &self.first_progress_line {
+                progress.observe(SessionProgressEvent::TranscriptEvent {
+                    session_id: "fake-session-1".to_string(),
+                    line: line.clone(),
+                });
+            }
 
             let (released_lock, released_cvar) = &self.state.first_released;
             let released = released_lock
@@ -282,7 +300,7 @@ fn daemon_reports_run_outcome_back_through_client_request() {
 }
 
 #[test]
-fn client_receives_live_progress_before_session_outcome() {
+fn client_receives_execution_progress_while_session_is_still_running() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -297,6 +315,9 @@ fn client_receives_live_progress_before_session_outcome() {
     let executor = BlockingFirstRunExecutor::new(
         SessionOutcome::Success { exit_code: 0 },
         SessionOutcome::Success { exit_code: 0 },
+    )
+    .with_first_progress_line(
+        r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working step"}"#,
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
@@ -321,27 +342,111 @@ fn client_receives_live_progress_before_session_outcome() {
         )
     });
 
+    executor.wait_for_first_run_to_start();
     let mut progress = String::new();
     let deadline = Instant::now() + Duration::from_secs(1);
-    while !progress.ends_with('\n') {
+    while !progress.contains("session event: agent_input") {
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
             !remaining.is_zero(),
-            "live progress should reach the client before the session completes"
+            "execution progress should reach the client before the session completes"
         );
         progress.push_str(
             &progress_rx
                 .recv_timeout(remaining)
-                .expect("live progress should reach the client before the session completes"),
+                .expect("execution progress should reach the client before the session completes"),
         );
     }
     assert!(
-        progress.contains("session running: site-builder (issue-122)"),
+        progress.contains("session event: agent_input"),
         "unexpected progress output: {progress}"
     );
     assert!(
         !client_request.is_finished(),
         "client should still be waiting for the terminal outcome after progress arrives"
+    );
+
+    executor.release_first_run();
+    assert_eq!(
+        client_request
+            .join()
+            .expect("client request thread should join")
+            .expect("client request should succeed"),
+        SessionOutcome::Success { exit_code: 0 }
+    );
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn client_full_progress_includes_raw_execution_event_detail() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("full-live-progress");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let executor = BlockingFirstRunExecutor::new(
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::Success { exit_code: 0 },
+    )
+    .with_first_progress_line(
+        r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working step"}"#,
+    );
+    let daemon_executor = executor.clone();
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let (progress_tx, progress_rx) = mpsc::channel();
+    let client_config = config.clone();
+    let client_request = thread::spawn(move || {
+        let mut writer = ChannelWriter { tx: progress_tx };
+        request_run_with_live_observation(
+            client_config.daemon(),
+            &RunRequest {
+                agent: "site-builder".to_string(),
+                repo_url: Some("https://example.com/repo.git".to_string()),
+                work_unit: Some("issue-122".to_string()),
+                input: None,
+            },
+            LiveObservationLevel::Full,
+            &mut writer,
+        )
+    });
+
+    executor.wait_for_first_run_to_start();
+    let mut progress = String::new();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !progress.contains(r#""content":"working step""#) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "full execution progress should reach the client before the session completes"
+        );
+        progress.push_str(
+            &progress_rx
+                .recv_timeout(remaining)
+                .expect("full execution progress should reach the client before completion"),
+        );
+    }
+    assert!(progress.contains("session_id=fake-session-1"), "{progress}");
+    assert!(
+        !client_request.is_finished(),
+        "client should still be waiting for the terminal outcome after full progress arrives"
     );
 
     executor.release_first_run();

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -9,13 +9,32 @@ use std::time::{Duration, Instant};
 use agentd::config::{Config, ConfigError};
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
 use agentd::{
-    ClientError, DaemonError, RunRequest, RunnerSessionExecutor, SessionExecutor, request_run,
+    ClientError, DaemonError, LiveObservationLevel, RunRequest, RunnerSessionExecutor,
+    SessionExecutor, request_run, request_run_with_live_observation,
 };
 use agentd_runner::InvocationInput;
 use agentd_runner::{
     RunnerError, SessionInvocation, SessionOutcome, SessionSpec, StartupReconciliationReport,
 };
 use serde_json::json;
+
+struct ChannelWriter {
+    tx: mpsc::Sender<String>,
+}
+
+impl std::io::Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let text = String::from_utf8_lossy(buf).to_string();
+        self.tx
+            .send(text)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "receiver closed"))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -251,6 +270,88 @@ fn daemon_reports_run_outcome_back_through_client_request() {
     .expect("client request should succeed");
 
     assert_eq!(outcome, SessionOutcome::GenericFailure { exit_code: 23 });
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn client_receives_live_progress_before_session_outcome() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("live-progress");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let executor = BlockingFirstRunExecutor::new(
+        SessionOutcome::Success { exit_code: 0 },
+        SessionOutcome::Success { exit_code: 0 },
+    );
+    let daemon_executor = executor.clone();
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let (progress_tx, progress_rx) = mpsc::channel();
+    let client_config = config.clone();
+    let client_request = thread::spawn(move || {
+        let mut writer = ChannelWriter { tx: progress_tx };
+        request_run_with_live_observation(
+            client_config.daemon(),
+            &RunRequest {
+                agent: "site-builder".to_string(),
+                repo_url: Some("https://example.com/repo.git".to_string()),
+                work_unit: Some("issue-122".to_string()),
+                input: None,
+            },
+            LiveObservationLevel::Summary,
+            &mut writer,
+        )
+    });
+
+    let mut progress = String::new();
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !progress.ends_with('\n') {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "live progress should reach the client before the session completes"
+        );
+        progress.push_str(
+            &progress_rx
+                .recv_timeout(remaining)
+                .expect("live progress should reach the client before the session completes"),
+        );
+    }
+    assert!(
+        progress.contains("session running: site-builder (issue-122)"),
+        "unexpected progress output: {progress}"
+    );
+    assert!(
+        !client_request.is_finished(),
+        "client should still be waiting for the terminal outcome after progress arrives"
+    );
+
+    executor.release_first_run();
+    assert_eq!(
+        client_request
+            .join()
+            .expect("client request thread should join")
+            .expect("client request should succeed"),
+        SessionOutcome::Success { exit_code: 0 }
+    );
 
     shutdown.store(true, Ordering::Release);
     handle

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -1,5 +1,4 @@
-use std::io::{BufRead, Write};
-use std::os::fd::AsRawFd;
+use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
@@ -126,13 +125,9 @@ impl BurstProgressExecutor {
             progress_events: SATURATING_PROGRESS_EVENTS,
             progress_line: format!(
                 r#"{{"schema_version":1,"source":"runa","kind":"agent_input","content":"{}"}}"#,
-                "x".repeat(8 * 1024)
+                "x".repeat(16 * 1024)
             ),
         }
-    }
-
-    fn total_progress_bytes(&self) -> usize {
-        self.progress_events * self.progress_line.len()
     }
 }
 
@@ -303,22 +298,6 @@ fn run_daemon_until_shutdown_for_test(
     run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
         Ok(StartupReconciliationReport::default())
     })
-}
-
-fn socket_send_buffer_size(stream: &UnixStream) -> usize {
-    let mut size = 0_i32;
-    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
-    let result = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_SNDBUF,
-            &mut size as *mut i32 as *mut libc::c_void,
-            &mut size_len,
-        )
-    };
-    assert_eq!(result, 0, "SO_SNDBUF should be readable");
-    usize::try_from(size).expect("SO_SNDBUF should be non-negative")
 }
 
 #[test]
@@ -535,21 +514,20 @@ fn client_full_progress_includes_raw_execution_event_detail() {
 }
 
 #[test]
-fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown() {
+fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcome() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
     }
-    let runtime_dir = unique_runtime_dir("non-reading-progress-client");
+    let runtime_dir = unique_runtime_dir("slow-reading-progress-client");
     let config = config_in_runtime_dir(&runtime_dir);
     let shutdown = Arc::new(AtomicBool::new(false));
     let daemon_config = config.clone();
     let daemon_shutdown = shutdown.clone();
     let (completed_tx, completed_rx) = mpsc::channel();
     let executor = BurstProgressExecutor::new(completed_tx);
-    let offered_progress_bytes = executor.total_progress_bytes();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
     });
@@ -557,11 +535,6 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
 
     let mut client =
         Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
-    let send_buffer_size = socket_send_buffer_size(client.as_ref().expect("client should exist"));
-    assert!(
-        offered_progress_bytes > send_buffer_size * 16,
-        "test must offer enough progress to saturate the socket send buffer: offered={offered_progress_bytes} SO_SNDBUF={send_buffer_size}"
-    );
     writeln!(
         client.as_mut().expect("client should exist"),
         "{}",
@@ -575,6 +548,8 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     )
     .expect("client request should write");
 
+    thread::sleep(Duration::from_millis(50));
+
     if completed_rx.recv_timeout(Duration::from_secs(5)).is_err() {
         drop(client.take());
         shutdown.store(true, Ordering::Release);
@@ -585,7 +560,7 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
         unsafe {
             std::env::remove_var("AGENTD_GITHUB_TOKEN");
         }
-        panic!("progress forwarding should not stall session cleanup for a non-reading client");
+        panic!("progress forwarding should not stall session cleanup for a slow-reading client");
     }
 
     shutdown.store(true, Ordering::Release);
@@ -609,30 +584,40 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
             unsafe {
                 std::env::remove_var("AGENTD_GITHUB_TOKEN");
             }
-            panic!("daemon shutdown should not wait for a non-reading progress client");
+            panic!("daemon shutdown should not wait for a slow-reading progress client");
         }
     };
 
     joiner.join().expect("join helper should join");
     join_result.expect("daemon should exit cleanly");
 
-    let client = client.take().expect("client should still be connected");
+    let mut client = client.take().expect("client should still be connected");
     client
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("client read timeout should be set");
-    let mut reader = std::io::BufReader::new(client);
-    let mut lines = Vec::new();
+    let mut response = Vec::new();
+    let mut buffer = [0_u8; 8192];
     loop {
-        let mut line = String::new();
-        let bytes_read = reader
-            .read_line(&mut line)
-            .expect("daemon stream should remain valid JSONL until EOF");
-        if bytes_read == 0 {
-            break;
+        match client.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(bytes_read) => {
+                response.extend_from_slice(&buffer[..bytes_read]);
+                thread::sleep(Duration::from_millis(1));
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                panic!("slow-reading client timed out before daemon closed the response stream")
+            }
+            Err(error) => panic!("slow-reading client failed to read daemon response: {error}"),
         }
-        lines.push(line);
     }
 
+    let response = String::from_utf8(response).expect("daemon response should be utf8 JSONL");
+    let lines: Vec<&str> = response.lines().collect();
     assert!(
         !lines.is_empty(),
         "daemon should write at least the terminal response"
@@ -650,11 +635,12 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     }
     assert!(
         saw_terminal_outcome,
-        "terminal outcome must survive saturated progress writes: {lines:?}"
+        "terminal outcome must survive slow-reader progress backpressure; parsed {} lines with {progress_frames} progress frames",
+        lines.len()
     );
     assert!(
         progress_frames < SATURATING_PROGRESS_EVENTS,
-        "saturated non-reading client should force progress drops, got all {progress_frames} frames"
+        "slow-reading client should force progress drops, got all {progress_frames} frames"
     );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -1,10 +1,12 @@
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
+use std::{io::Write, sync::mpsc::Sender};
 
 use agentd::config::{Config, ConfigError};
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
@@ -104,6 +106,46 @@ struct BlockingFirstRunState {
     calls: AtomicUsize,
     first_started: (Mutex<bool>, Condvar),
     first_released: (Mutex<bool>, Condvar),
+}
+
+#[derive(Clone)]
+struct BurstProgressExecutor {
+    completed: Sender<()>,
+    progress_events: usize,
+    progress_line: String,
+}
+
+impl BurstProgressExecutor {
+    fn new(completed: Sender<()>) -> Self {
+        Self {
+            completed,
+            progress_events: 32,
+            progress_line: format!(
+                r#"{{"schema_version":1,"source":"runa","kind":"agent_input","content":"{}"}}"#,
+                "x".repeat(256 * 1024)
+            ),
+        }
+    }
+}
+
+impl SessionExecutor for BurstProgressExecutor {
+    fn run_session(
+        &self,
+        _spec: SessionSpec,
+        _invocation: SessionInvocation,
+        progress: &dyn SessionProgressObserver,
+    ) -> Result<SessionOutcome, RunnerError> {
+        for index in 0..self.progress_events {
+            progress.observe(SessionProgressEvent::TranscriptEvent {
+                session_id: format!("fake-session-{index}"),
+                line: self.progress_line.clone(),
+            });
+        }
+        self.completed
+            .send(())
+            .expect("completion signal should send");
+        Ok(SessionOutcome::Success { exit_code: 0 })
+    }
 }
 
 impl BlockingFirstRunExecutor {
@@ -463,6 +505,87 @@ fn client_full_progress_includes_raw_execution_event_detail() {
         .join()
         .expect("daemon thread should join")
         .expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("non-reading-progress-client");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (completed_tx, completed_rx) = mpsc::channel();
+    let executor = BurstProgressExecutor::new(completed_tx);
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let mut client =
+        Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
+    writeln!(
+        client.as_mut().expect("client should exist"),
+        "{}",
+        json!({
+            "type": "run",
+            "agent": "site-builder",
+            "repo_url": "https://example.com/repo.git",
+            "work_unit": "issue-122",
+            "input": null
+        })
+    )
+    .expect("client request should write");
+
+    if completed_rx.recv_timeout(Duration::from_secs(1)).is_err() {
+        drop(client.take());
+        shutdown.store(true, Ordering::Release);
+        handle
+            .join()
+            .expect("daemon thread should join after client disconnect")
+            .expect("daemon should exit cleanly after client disconnect");
+        unsafe {
+            std::env::remove_var("AGENTD_GITHUB_TOKEN");
+        }
+        panic!("progress forwarding should not stall session cleanup for a non-reading client");
+    }
+
+    shutdown.store(true, Ordering::Release);
+    let (join_tx, join_rx) = mpsc::channel();
+    let joiner = thread::spawn(move || {
+        let result = handle.join().expect("daemon thread should not panic");
+        join_tx
+            .send(result)
+            .expect("daemon join result should send");
+    });
+
+    let join_result = match join_rx.recv_timeout(Duration::from_secs(1)) {
+        Ok(result) => result,
+        Err(_) => {
+            drop(client.take());
+            let result = join_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("daemon should join after client disconnect");
+            joiner.join().expect("join helper should join");
+            result.expect("daemon should exit cleanly after client disconnect");
+            unsafe {
+                std::env::remove_var("AGENTD_GITHUB_TOKEN");
+            }
+            panic!("daemon shutdown should not wait for a non-reading progress client");
+        }
+    };
+
+    drop(client.take());
+    joiner.join().expect("join helper should join");
+    join_result.expect("daemon should exit cleanly");
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
     }

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -1,12 +1,14 @@
+use std::io::{BufRead, Write};
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
-use std::{io::Write, sync::mpsc::Sender};
 
 use agentd::config::{Config, ConfigError};
 use agentd::daemon::run_daemon_until_shutdown_with_reconciler;
@@ -115,16 +117,22 @@ struct BurstProgressExecutor {
     progress_line: String,
 }
 
+const SATURATING_PROGRESS_EVENTS: usize = 4096;
+
 impl BurstProgressExecutor {
     fn new(completed: Sender<()>) -> Self {
         Self {
             completed,
-            progress_events: 32,
+            progress_events: SATURATING_PROGRESS_EVENTS,
             progress_line: format!(
                 r#"{{"schema_version":1,"source":"runa","kind":"agent_input","content":"{}"}}"#,
-                "x".repeat(256 * 1024)
+                "x".repeat(8 * 1024)
             ),
         }
+    }
+
+    fn total_progress_bytes(&self) -> usize {
+        self.progress_events * self.progress_line.len()
     }
 }
 
@@ -295,6 +303,22 @@ fn run_daemon_until_shutdown_for_test(
     run_daemon_until_shutdown_with_reconciler(config, executor, shutdown, || {
         Ok(StartupReconciliationReport::default())
     })
+}
+
+fn socket_send_buffer_size(stream: &UnixStream) -> usize {
+    let mut size = 0_i32;
+    let mut size_len = std::mem::size_of::<i32>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &mut size as *mut i32 as *mut libc::c_void,
+            &mut size_len,
+        )
+    };
+    assert_eq!(result, 0, "SO_SNDBUF should be readable");
+    usize::try_from(size).expect("SO_SNDBUF should be non-negative")
 }
 
 #[test]
@@ -525,6 +549,7 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     let daemon_shutdown = shutdown.clone();
     let (completed_tx, completed_rx) = mpsc::channel();
     let executor = BurstProgressExecutor::new(completed_tx);
+    let offered_progress_bytes = executor.total_progress_bytes();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
     });
@@ -532,6 +557,11 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
 
     let mut client =
         Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
+    let send_buffer_size = socket_send_buffer_size(client.as_ref().expect("client should exist"));
+    assert!(
+        offered_progress_bytes > send_buffer_size * 16,
+        "test must offer enough progress to saturate the socket send buffer: offered={offered_progress_bytes} SO_SNDBUF={send_buffer_size}"
+    );
     writeln!(
         client.as_mut().expect("client should exist"),
         "{}",
@@ -545,7 +575,7 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
     )
     .expect("client request should write");
 
-    if completed_rx.recv_timeout(Duration::from_secs(1)).is_err() {
+    if completed_rx.recv_timeout(Duration::from_secs(5)).is_err() {
         drop(client.take());
         shutdown.store(true, Ordering::Release);
         handle
@@ -583,9 +613,49 @@ fn non_reading_progress_client_does_not_stall_session_cleanup_or_daemon_shutdown
         }
     };
 
-    drop(client.take());
     joiner.join().expect("join helper should join");
     join_result.expect("daemon should exit cleanly");
+
+    let client = client.take().expect("client should still be connected");
+    client
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("client read timeout should be set");
+    let mut reader = std::io::BufReader::new(client);
+    let mut lines = Vec::new();
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader
+            .read_line(&mut line)
+            .expect("daemon stream should remain valid JSONL until EOF");
+        if bytes_read == 0 {
+            break;
+        }
+        lines.push(line);
+    }
+
+    assert!(
+        !lines.is_empty(),
+        "daemon should write at least the terminal response"
+    );
+    let mut progress_frames = 0_usize;
+    let mut saw_terminal_outcome = false;
+    for line in &lines {
+        let value: serde_json::Value =
+            serde_json::from_str(line).expect("daemon must not emit partial JSON frames");
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("progress") => progress_frames += 1,
+            Some("session_outcome") => saw_terminal_outcome = true,
+            other => panic!("unexpected response type after saturated progress writes: {other:?}"),
+        }
+    }
+    assert!(
+        saw_terminal_outcome,
+        "terminal outcome must survive saturated progress writes: {lines:?}"
+    );
+    assert!(
+        progress_frames < SATURATING_PROGRESS_EVENTS,
+        "saturated non-reading client should force progress drops, got all {progress_frames} frames"
+    );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");
     }

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -117,6 +117,7 @@ struct BurstProgressExecutor {
 }
 
 const SATURATING_PROGRESS_EVENTS: usize = 4096;
+const SHUTDOWN_DRAIN_TEST_TIMEOUT: Duration = Duration::from_secs(3);
 
 impl BurstProgressExecutor {
     fn new(completed: Sender<()>) -> Self {
@@ -300,6 +301,57 @@ fn run_daemon_until_shutdown_for_test(
     })
 }
 
+fn write_raw_run_request(client: &mut UnixStream, work_unit: &str) {
+    writeln!(
+        client,
+        "{}",
+        json!({
+            "type": "run",
+            "agent": "site-builder",
+            "repo_url": "https://example.com/repo.git",
+            "work_unit": work_unit,
+            "input": null
+        })
+    )
+    .expect("client request should write");
+}
+
+fn read_until_terminal_outcome(mut client: UnixStream) {
+    client
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("client read timeout should be set");
+    let mut response = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        match client.read(&mut buffer) {
+            Ok(0) => panic!("daemon closed the stream before the terminal outcome arrived"),
+            Ok(bytes_read) => {
+                response.extend_from_slice(&buffer[..bytes_read]);
+                while let Some(newline) = response.iter().position(|byte| *byte == b'\n') {
+                    let line: Vec<u8> = response.drain(..=newline).collect();
+                    let line = std::str::from_utf8(&line).expect("daemon response should be utf8");
+                    let value: serde_json::Value =
+                        serde_json::from_str(line).expect("daemon should emit complete JSON");
+                    if value.get("type").and_then(serde_json::Value::as_str)
+                        == Some("session_outcome")
+                    {
+                        return;
+                    }
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                panic!("timed out waiting for terminal outcome")
+            }
+            Err(error) => panic!("client failed while reading daemon response: {error}"),
+        }
+    }
+}
+
 #[test]
 fn daemon_reports_run_outcome_back_through_client_request() {
     let _guard = env_lock()
@@ -389,7 +441,7 @@ fn client_receives_execution_progress_while_session_is_still_running() {
 
     executor.wait_for_first_run_to_start();
     let mut progress = String::new();
-    let deadline = Instant::now() + Duration::from_secs(1);
+    let deadline = Instant::now() + Duration::from_secs(5);
     while !progress.contains("session event: agent_input") {
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
@@ -475,7 +527,7 @@ fn client_full_progress_includes_raw_execution_event_detail() {
 
     executor.wait_for_first_run_to_start();
     let mut progress = String::new();
-    let deadline = Instant::now() + Duration::from_secs(1);
+    let deadline = Instant::now() + Duration::from_secs(5);
     while !progress.contains(r#""content":"working step""#) {
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
@@ -535,18 +587,7 @@ fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcom
 
     let mut client =
         Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
-    writeln!(
-        client.as_mut().expect("client should exist"),
-        "{}",
-        json!({
-            "type": "run",
-            "agent": "site-builder",
-            "repo_url": "https://example.com/repo.git",
-            "work_unit": "issue-122",
-            "input": null
-        })
-    )
-    .expect("client request should write");
+    write_raw_run_request(client.as_mut().expect("client should exist"), "issue-122");
 
     thread::sleep(Duration::from_millis(50));
 
@@ -572,7 +613,7 @@ fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcom
             .expect("daemon join result should send");
     });
 
-    let join_result = match join_rx.recv_timeout(Duration::from_secs(1)) {
+    let join_result = match join_rx.recv_timeout(SHUTDOWN_DRAIN_TEST_TIMEOUT) {
         Ok(result) => result,
         Err(_) => {
             drop(client.take());
@@ -641,6 +682,158 @@ fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcom
     assert!(
         progress_frames < SATURATING_PROGRESS_EVENTS,
         "slow-reading client should force progress drops, got all {progress_frames} frames"
+    );
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn daemon_shutdown_drains_queued_terminal_outcome_to_a_paused_reading_client_before_returning() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("shutdown-drains-terminal-to-paused-reader");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (completed_tx, completed_rx) = mpsc::channel();
+    let executor = BurstProgressExecutor::new(completed_tx);
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let mut client =
+        Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
+    write_raw_run_request(
+        client.as_mut().expect("client should exist"),
+        "shutdown-drain-reading",
+    );
+    completed_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("session should complete while the client is paused");
+
+    shutdown.store(true, Ordering::Release);
+    let (join_tx, join_rx) = mpsc::channel();
+    let joiner = thread::spawn(move || {
+        let result = handle.join().expect("daemon thread should not panic");
+        join_tx
+            .send(result)
+            .expect("daemon join result should send");
+    });
+
+    match join_rx.recv_timeout(Duration::from_millis(250)) {
+        Ok(result) => {
+            drop(client.take());
+            joiner.join().expect("join helper should join");
+            result.expect("daemon should exit cleanly");
+            unsafe {
+                std::env::remove_var("AGENTD_GITHUB_TOKEN");
+            }
+            panic!("daemon returned before draining the queued terminal outcome");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {}
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("daemon join helper disconnected before reporting completion")
+        }
+    }
+
+    let (terminal_tx, terminal_rx) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        read_until_terminal_outcome(client.take().expect("client should still be connected"));
+        terminal_tx
+            .send(())
+            .expect("terminal outcome notification should send");
+    });
+
+    let deadline = Instant::now() + SHUTDOWN_DRAIN_TEST_TIMEOUT;
+    loop {
+        if terminal_rx.try_recv().is_ok() {
+            break;
+        }
+        match join_rx.try_recv() {
+            Ok(result) => {
+                reader.join().expect("reader should join");
+                joiner.join().expect("join helper should join");
+                result.expect("daemon should exit cleanly");
+                unsafe {
+                    std::env::remove_var("AGENTD_GITHUB_TOKEN");
+                }
+                panic!("daemon returned before the paused reader received the terminal outcome");
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Disconnected) => {
+                panic!("daemon join helper disconnected before reporting completion")
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "paused reader did not receive the terminal outcome within the shutdown drain bound"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    reader.join().expect("reader should join");
+    let result = join_rx
+        .recv_timeout(SHUTDOWN_DRAIN_TEST_TIMEOUT)
+        .expect("daemon should return after the terminal outcome is drained");
+    joiner.join().expect("join helper should join");
+    result.expect("daemon should exit cleanly");
+    unsafe {
+        std::env::remove_var("AGENTD_GITHUB_TOKEN");
+    }
+}
+
+#[test]
+fn daemon_shutdown_abandons_progress_writer_drain_for_a_non_reading_client() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
+    }
+    let runtime_dir = unique_runtime_dir("shutdown-bounds-non-reading-client");
+    let config = config_in_runtime_dir(&runtime_dir);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let daemon_config = config.clone();
+    let daemon_shutdown = shutdown.clone();
+    let (completed_tx, completed_rx) = mpsc::channel();
+    let executor = BurstProgressExecutor::new(completed_tx);
+    let handle = thread::spawn(move || {
+        run_daemon_until_shutdown_for_test(daemon_config, executor, daemon_shutdown)
+    });
+    wait_for_path(config.daemon().socket_path());
+
+    let mut client =
+        Some(UnixStream::connect(config.daemon().socket_path()).expect("client should connect"));
+    write_raw_run_request(
+        client.as_mut().expect("client should exist"),
+        "shutdown-drain-non-reading",
+    );
+    completed_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("session should complete while the client never reads");
+
+    let started = Instant::now();
+    shutdown.store(true, Ordering::Release);
+    let result = match handle.join() {
+        Ok(result) => result,
+        Err(payload) => {
+            drop(client.take());
+            std::panic::resume_unwind(payload);
+        }
+    };
+    let elapsed = started.elapsed();
+    drop(client.take());
+    result.expect("daemon should exit cleanly");
+    assert!(
+        elapsed < SHUTDOWN_DRAIN_TEST_TIMEOUT,
+        "non-reading client stalled daemon shutdown for {elapsed:?}"
     );
     unsafe {
         std::env::remove_var("AGENTD_GITHUB_TOKEN");

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -7,7 +7,7 @@ use agentd::config::{Config, ConfigError};
 use agentd::{DispatchError, RunRequest, SessionExecutor, dispatch_run};
 use agentd_runner::{
     InvocationInput, ResolvedEnvironmentVariable, RunnerError, SessionInvocation, SessionOutcome,
-    SessionSpec,
+    SessionProgressObserver, SessionSpec,
 };
 use serde_json::json;
 
@@ -59,6 +59,7 @@ impl SessionExecutor for RecordingExecutor {
         &self,
         spec: SessionSpec,
         invocation: SessionInvocation,
+        _progress: &dyn SessionProgressObserver,
     ) -> Result<SessionOutcome, RunnerError> {
         let mut state = self.state.lock().expect("recording state should lock");
         state.last_spec = Some(spec);

--- a/crates/agentd/tests/workspace_contract.rs
+++ b/crates/agentd/tests/workspace_contract.rs
@@ -259,6 +259,40 @@ fn operator_intent_documentation_describes_wish_and_run_intent_boundaries() {
 }
 
 #[test]
+fn manual_session_documentation_describes_live_progress_observation() {
+    let readme = read_workspace_file("README.md");
+    let quickstart = read_workspace_file("docs/quickstart.md");
+    let socket_protocol = read_workspace_file("docs/socket-protocol.md");
+    let architecture = read_workspace_file("ARCHITECTURE.md");
+    let changelog = read_workspace_file("CHANGELOG.md");
+
+    assert!(
+        readme.contains("`agentd wish` and `agentd run` stream live session progress")
+            && readme.contains("--progress summary")
+            && readme.contains("--progress full"),
+        "README should document live progress and its verbosity controls"
+    );
+    assert!(
+        quickstart.contains("streams live progress in that terminal"),
+        "quickstart should tell operators that the launching command shows progress"
+    );
+    assert!(
+        socket_protocol.contains("\"type\": \"progress\"")
+            && socket_protocol.contains("dispatch_started")
+            && socket_protocol.contains("--progress full"),
+        "socket protocol docs should describe progress frames and CLI rendering levels"
+    );
+    assert!(
+        architecture.contains("progress frames over that same client connection"),
+        "ARCHITECTURE.md should explain that live observation stays on the manual client connection"
+    );
+    assert!(
+        changelog.contains("stream live session progress"),
+        "CHANGELOG.md should record the operator-facing live progress feature"
+    );
+}
+
+#[test]
 fn release_adoption_verification_checks_hostile_user_config_cannot_override_workspace_pins() {
     let script = read_workspace_file("scripts/verify-release-adoption.sh");
 

--- a/docs/audit-record.md
+++ b/docs/audit-record.md
@@ -82,7 +82,9 @@ the manifest never overstates what the transcript captured.
 agentd sets `RUNA_TRANSCRIPT_DEPLOYMENT` and `RUNA_TRANSCRIPT_RUN_ID` before
 launching runa. It reads event files only below the matching nested deployment
 and run id, while allowing multiple work-unit stage directories to appear
-during one session.
+during one session. Every nested directory component below the trusted
+`agentd/transcript` base is traversed without following symlinks, and unsafe
+symlinked ancestors are refused rather than read through.
 
 ## Change policy
 

--- a/docs/audit-record.md
+++ b/docs/audit-record.md
@@ -17,7 +17,8 @@ One record per session at `<audit_root>/<agent>/<session_id>/`:
 └── agentd/
     ├── session.json               # agentd-written session metadata (schema below)
     └── transcript/
-        ├── events.jsonl           # structured transcript events (one JSON object per line)
+        ├── deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.jsonl
+        │                           # runa-owned structured event stream(s)
         ├── transcript.md          # human-readable rendering of the event stream
         └── manifest.json          # transcript schema version + coverage verdict
 ```
@@ -67,8 +68,9 @@ torn write.
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `schema_version` | integer | `1` |
+| `schema_version` | integer | `1` for this manifest format, not the runa event schema |
 | `coverage` | string | `full`, `missing_mcp_events`, `no_events`, or `finalization_failed` |
+| `event_schema_versions` | array of integers | sorted distinct `schema_version` values found in assembled runa events; empty when no events were found or finalization failed before events could be read |
 | `finalization_error` | string | present only with `finalization_failed` |
 
 Coverage is honest by construction: a failure while rendering the
@@ -76,6 +78,11 @@ transcript is itself recorded as `finalization_failed` with the error, so
 the manifest never overstates what the transcript captured.
 `missing_mcp_events` means runa ran but the agent runtime never launched
 `runa-mcp`, so tool-call events were not observable.
+
+agentd sets `RUNA_TRANSCRIPT_DEPLOYMENT` and `RUNA_TRANSCRIPT_RUN_ID` before
+launching runa. It reads event files only below the matching nested deployment
+and run id, while allowing multiple work-unit stage directories to appear
+during one session.
 
 ## Change policy
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -28,6 +28,8 @@ only the environment.
 | `AGENTD_WORK_UNIT` | the `--work-unit` identifier, when present | session tooling |
 | `AGENTD_REPO_TOKEN` | the resolved repo token, when configured | the generated clone step only: consumed for the one HTTPS `git clone` and unset before the agent command runs — it cannot authorize pushes. HTTPS pushes need a credential delivered via `[[agents.credentials]]`; SSH pushes use the mounted `.ssh` identity |
 | `RUNA_TRANSCRIPT_DIR` | the mounted transcript directory | runa / runa-mcp transcript emission |
+| `RUNA_TRANSCRIPT_DEPLOYMENT` | deterministic project identity composed by agentd from the session forge type and repository URL | runa transcript path selection |
+| `RUNA_TRANSCRIPT_RUN_ID` | the agentd session id for this run | runa transcript path selection |
 | `RUNA_TRANSCRIPT_REDACT_ENV` | names of session env vars whose values must be redacted from transcripts | runa / runa-mcp |
 | credential `name` variables (e.g. `GITHUB_TOKEN`) | value of the corresponding daemon-side `source` variable, delivered via ephemeral podman secret | agent process |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,9 +73,9 @@ In a second shell, trigger the canonical integration intent
 `What do you wish to be true?` For this smoke test, enter
 ``add a `greet(name)` function`` at that statement prompt, then leave the target
 prompt blank when asked `What is this wish aimed at? Leave blank if it has no
-target.` The command blocks until the session reaches a terminal outcome and
-reports it. `success` means the work completed; any other label is interpreted
-per
+target.` The command streams live progress in that terminal while it waits for
+the session to finish, then reports the terminal outcome. `success` means the
+work completed; any other label is interpreted per
 [commons EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
 
 ## 6. Inspect the audit record

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,8 +74,10 @@ In a second shell, trigger the canonical integration intent
 ``add a `greet(name)` function`` at that statement prompt, then leave the target
 prompt blank when asked `What is this wish aimed at? Leave blank if it has no
 target.` The command streams live progress in that terminal while it waits for
-the session to finish, then reports the terminal outcome. `success` means the
-work completed; any other label is interpreted per
+the session to finish, printing concise transcript event names by default. Use
+`--progress full` to include raw transcript event detail. It then reports the
+terminal outcome. `success` means the work completed; any other label is
+interpreted per
 [commons EXIT-CODES.md](https://github.com/tesserine/commons/blob/main/EXIT-CODES.md).
 
 ## 6. Inspect the audit record

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -59,11 +59,13 @@ target prompt; `agentd run --intent` has no target flag.
 
 `{"type": "pong"}` — answer to `ping`.
 
-`{"type": "progress", "progress": {"stage": "dispatch_started", ...}}` —
-non-terminal live progress for a run request. `agentd wish` and `agentd run`
-render these frames in the invoking terminal while they wait for the terminal
-outcome; `--progress summary` is the default and `--progress full` includes
-all fields carried by the frame.
+`{"type": "progress", "progress": {"stage": "...", ...}}` — non-terminal
+live progress for a run request. `dispatch_started` is a start marker;
+`transcript_event` carries execution-phase events from the running session's
+`agentd/transcript/events.jsonl` stream. `agentd wish` and `agentd run` render
+these frames in the invoking terminal while they wait for the terminal outcome;
+`--progress summary` prints concise event names and `--progress full` includes
+the raw transcript event line.
 
 `{"type": "error", "message": "..."}` — the request was rejected before a
 session outcome existed (malformed request, unknown agent, dispatch
@@ -81,6 +83,13 @@ operator connection and is dispatching it into session execution:
 
 ```json
 {"type":"progress","progress":{"stage":"dispatch_started","agent":"site-builder","work_unit":"issue-42","input_present":false}}
+```
+
+`transcript_event` means the running session appended a structured transcript
+event that the daemon forwarded before the terminal outcome:
+
+```json
+{"type":"progress","progress":{"stage":"transcript_event","session_id":"7f5a1c2d9e0b3a44","line":"{\"schema_version\":1,\"source\":\"runa\",\"kind\":\"agent_input\",\"content\":\"...\"}"}}
 ```
 
 ## Outcome statuses

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -15,11 +15,12 @@ integration surfaces are the CLI and the audit record
 ## Framing and connection lifecycle
 
 - Transport: `SOCK_STREAM` Unix domain socket.
-- Framing: newline-delimited JSON — one request line, one response line.
-- Lifecycle: connect → write one request + `\n` → read one response line →
-  connection closes. One session trigger per connection; the response is
-  not written until the session reaches a terminal outcome, so `run`
-  connections stay open for the session's duration.
+- Framing: newline-delimited JSON — one request line, followed by one or
+  more response lines.
+- Lifecycle: connect → write one request + `\n` → read response lines until
+  one terminal `session_outcome` or `error` line → connection closes. One
+  session trigger per connection; `run` connections stay open for the
+  session's duration and may carry progress lines before the terminal line.
 - An empty connection (EOF before a line) is ignored. A malformed request
   line gets an `error` response.
 
@@ -58,6 +59,12 @@ target prompt; `agentd run --intent` has no target flag.
 
 `{"type": "pong"}` — answer to `ping`.
 
+`{"type": "progress", "progress": {"stage": "dispatch_started", ...}}` —
+non-terminal live progress for a run request. `agentd wish` and `agentd run`
+render these frames in the invoking terminal while they wait for the terminal
+outcome; `--progress summary` is the default and `--progress full` includes
+all fields carried by the frame.
+
 `{"type": "error", "message": "..."}` — the request was rejected before a
 session outcome existed (malformed request, unknown agent, dispatch
 failure).
@@ -66,6 +73,15 @@ failure).
 session ran to a terminal outcome. A `session_outcome` response means the
 transport and dispatch succeeded; the work may still have failed — read
 `status`.
+
+### Progress stages
+
+`dispatch_started` means the daemon has accepted the run request on the
+operator connection and is dispatching it into session execution:
+
+```json
+{"type":"progress","progress":{"stage":"dispatch_started","agent":"site-builder","work_unit":"issue-42","input_present":false}}
+```
 
 ## Outcome statuses
 

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -65,7 +65,13 @@ live progress for a run request. `dispatch_started` is a start marker;
 `agentd/transcript/events.jsonl` stream. `agentd wish` and `agentd run` render
 these frames in the invoking terminal while they wait for the terminal outcome;
 `--progress summary` prints concise event names and `--progress full` includes
-the raw transcript event line.
+the raw transcript event line. Progress delivery is best-effort: oversized
+transcript records and progress frames that cannot fit without preserving room
+for the terminal response are dropped whole. The daemon never emits partial
+progress JSON frames, and the terminal `session_outcome` or terminal `error`
+remains the authoritative completion response. CLI rendering control-escapes
+untrusted request and transcript fields before they reach the operator's
+terminal.
 
 `{"type": "error", "message": "..."}` — the request was rejected before a
 session outcome existed (malformed request, unknown agent, dispatch

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -62,7 +62,7 @@ target prompt; `agentd run --intent` has no target flag.
 `{"type": "progress", "progress": {"stage": "...", ...}}` — non-terminal
 live progress for a run request. `dispatch_started` is a start marker;
 `transcript_event` carries execution-phase events from the running session's
-`agentd/transcript/events.jsonl` stream. `agentd wish` and `agentd run` render
+nested runa transcript event stream. `agentd wish` and `agentd run` render
 these frames in the invoking terminal while they wait for the terminal outcome;
 `--progress summary` prints concise event names and `--progress full` includes
 the raw transcript event line. Progress delivery is best-effort: oversized


### PR DESCRIPTION
Reconstructs the #122 verification build on current `main` after #169 was closed and its branch was deleted.

What changed:
- rebases `issue-162-nested-transcript-path` onto current `main` (`094bbf97`, including #166)
- restacks the preserved #122 commits from `refs/pull/169/head` onto the rebased #162 branch
- resolves the #166/#122 CLI conflicts by keeping the desired-state `wish` copy while preserving live progress plumbing, help text, docs, and tests

Validation:
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets`
- `cargo fmt --check`
