### PR TITLE
fix: render useful live transcript summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operator prompt, collecting the statement and optional target before reusing
   the existing canonical intent intake.
 - `agentd wish` and `agentd run` now stream live session progress in the
-  invoking terminal, with `--progress summary` as the default and
-  `--progress full` for raw transcript event detail while the session executes.
+  invoking terminal, with `--progress summary` as the default compact
+  transcript activity view and `--progress full` for raw transcript event detail
+  while the session executes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,9 @@ so runa resolves the reference fail-closed before scoped work begins.
 
 `agentd wish` and `agentd run` stream live session progress to the invoking
 terminal while the daemon runs the session. The default `--progress summary`
-prints concise transcript event names before the terminal `session <status>`
-line; `--progress full` includes the session id and raw transcript event line.
+prints compact transcript activity with payload, action, or exit details before
+the terminal `session <status>` line; `--progress full` includes the session id
+and raw transcript event line for detailed inspection.
 
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -59,6 +59,8 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 use transcript::{TranscriptEventFile, TranscriptEventSource};
@@ -66,6 +68,19 @@ use validation::{validate_invocation, validate_spec};
 
 const TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_LIVE_TRANSCRIPT_LINE_BYTES: usize = 32 * 1024;
+
+#[cfg(test)]
+#[derive(Default)]
+struct LiveTranscriptDiscoveryProbe {
+    session_id: Option<String>,
+    calls: usize,
+}
+
+#[cfg(test)]
+fn live_transcript_discovery_probe() -> &'static Mutex<LiveTranscriptDiscoveryProbe> {
+    static PROBE: OnceLock<Mutex<LiveTranscriptDiscoveryProbe>> = OnceLock::new();
+    PROBE.get_or_init(|| Mutex::new(LiveTranscriptDiscoveryProbe::default()))
+}
 
 /// Executes a single session from validation through teardown.
 ///
@@ -83,7 +98,7 @@ pub fn run_session(
     spec: SessionSpec,
     invocation: SessionInvocation,
 ) -> Result<SessionOutcome, RunnerError> {
-    run_session_with_progress(spec, invocation, &NoopSessionProgressObserver)
+    run_session_inner(spec, invocation, None)
 }
 
 /// Executes a single session and reports best-effort transcript progress while
@@ -92,6 +107,14 @@ pub fn run_session_with_progress(
     spec: SessionSpec,
     invocation: SessionInvocation,
     progress: &dyn SessionProgressObserver,
+) -> Result<SessionOutcome, RunnerError> {
+    run_session_inner(spec, invocation, Some(progress))
+}
+
+fn run_session_inner(
+    spec: SessionSpec,
+    invocation: SessionInvocation,
+    progress: Option<&dyn SessionProgressObserver>,
 ) -> Result<SessionOutcome, RunnerError> {
     validate_spec(&spec)?;
     validate_invocation(&invocation)?;
@@ -214,13 +237,28 @@ pub fn run_session_with_progress(
     }
 
     let secret_bindings = resources.all_secret_bindings();
-    let start_result = run_container_with_transcript_progress(
-        &resources,
-        &session_id,
-        &secret_bindings,
-        invocation.timeout,
-        progress,
-    );
+    let start_result = match progress {
+        Some(progress) => run_container_with_transcript_progress(
+            &resources,
+            &session_id,
+            &secret_bindings,
+            invocation.timeout,
+            progress,
+        ),
+        None => match invocation.timeout {
+            Some(timeout) => run_container_with_timeout(
+                &resources.container_name,
+                &session_id,
+                &secret_bindings,
+                timeout,
+            ),
+            None => run_container_to_completion(
+                &resources.container_name,
+                &session_id,
+                &secret_bindings,
+            ),
+        },
+    };
 
     match &start_result {
         Ok(outcome) => log_session_outcome(&session_id, &resources.container_name, outcome),
@@ -320,6 +358,8 @@ fn observe_transcript_events(
 ) {
     let mut readers = BTreeMap::<TranscriptEventFile, LiveTranscriptReader>::new();
     loop {
+        #[cfg(test)]
+        record_live_transcript_discovery_for_tests(session_id);
         let discovered = match source.discover_event_files() {
             Ok(discovered) => discovered,
             Err(error) => {
@@ -369,6 +409,41 @@ fn observe_transcript_events(
             return;
         }
         thread::sleep(TRANSCRIPT_POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+fn reset_live_transcript_discovery_probe_for_tests() {
+    let mut probe = live_transcript_discovery_probe()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *probe = LiveTranscriptDiscoveryProbe::default();
+}
+
+#[cfg(test)]
+fn set_live_transcript_discovery_probe_session_for_tests(session_id: String) {
+    let mut probe = live_transcript_discovery_probe()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    probe.session_id = Some(session_id);
+    probe.calls = 0;
+}
+
+#[cfg(test)]
+fn live_transcript_discovery_calls_for_tests() -> usize {
+    live_transcript_discovery_probe()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .calls
+}
+
+#[cfg(test)]
+fn record_live_transcript_discovery_for_tests(session_id: &str) {
+    let mut probe = live_transcript_discovery_probe()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if probe.session_id.as_deref() == Some(session_id) {
+        probe.calls += 1;
     }
 }
 
@@ -559,6 +634,37 @@ mod tests {
                 .expect("session metadata should be readable"),
         )
         .expect("session metadata should be valid json")
+    }
+
+    fn write_intent_methodology_fixture(methodology_dir: &Path) {
+        fs::create_dir_all(methodology_dir.join("schemas"))
+            .expect("methodology schemas dir should be created");
+        fs::write(
+            methodology_dir.join("manifest.toml"),
+            "[[artifact_types]]\nname = \"intent\"\n",
+        )
+        .expect("methodology manifest should be written");
+        fs::write(
+            methodology_dir.join("schemas/intent.schema.json"),
+            r#"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-tesserine-canonical": {
+    "version": "2.0.0",
+    "schema_url": "https://example.com/intent.schema.json",
+    "prose_url": "https://example.com/INTENT.md"
+  },
+  "type": "object",
+  "required": ["statement", "source"],
+  "additionalProperties": false,
+  "properties": {
+    "statement": { "type": "string", "minLength": 1 },
+    "source": { "type": "string", "minLength": 1 },
+    "target": { "type": "string", "minLength": 1 }
+  }
+}
+"#,
+        )
+        .expect("intent schema should be written");
     }
 
     fn make_tree_writable(path: &Path) {
@@ -880,6 +986,26 @@ mod tests {
 
         make_tree_writable(&audit_root);
         fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+    }
+
+    #[test]
+    fn run_session_does_not_poll_live_transcript_events() {
+        let discovery_calls = run_session_with_live_transcript_discovery_probe(false);
+
+        assert_eq!(
+            discovery_calls, 0,
+            "no-progress sessions must not start live transcript discovery"
+        );
+    }
+
+    #[test]
+    fn run_session_with_progress_polls_live_transcript_events() {
+        let discovery_calls = run_session_with_live_transcript_discovery_probe(true);
+
+        assert!(
+            discovery_calls > 0,
+            "progress sessions should start live transcript discovery"
+        );
     }
 
     #[test]
@@ -1452,6 +1578,130 @@ mod tests {
                 Instant::now() < deadline,
                 "timed out waiting for session record under {}",
                 agent_root.display()
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn run_session_with_live_transcript_discovery_probe(use_progress: bool) -> usize {
+        const REPO_URL: &str = "https://example.com/agentd.git";
+
+        let _guard = fake_podman_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fixture = FakePodmanFixture::new();
+        fixture.install(
+            &FakePodmanScenario::new().with_start(CommandBehavior::from_outcome(
+                CommandOutcome::new()
+                    .touch_file("start-blocked")
+                    .wait_for_file(
+                        "release-start",
+                        Duration::from_secs(5),
+                        "timed out waiting to release start",
+                        91,
+                    ),
+            )),
+        );
+        let methodology_dir = fixture.create_methodology_dir("runner-methodology");
+        write_intent_methodology_fixture(&methodology_dir);
+        let audit_root = unique_temp_dir("runner-live-transcript-opt-in");
+        fs::create_dir_all(&audit_root).expect("audit root should be created");
+        let helper_audit_root = audit_root.clone();
+        reset_live_transcript_discovery_probe_for_tests();
+
+        let discovery_calls = fixture.run_with_fake_podman_env(|| {
+            let log_dir = PathBuf::from(
+                std::env::var("AGENTD_FAKE_PODMAN_LOG_DIR")
+                    .expect("fake podman log dir should be configured"),
+            );
+            let helper = thread::spawn(move || {
+                release_start_after_live_transcript_probe(log_dir, helper_audit_root, use_progress);
+            });
+
+            let spec = SessionSpec {
+                methodology_dir,
+                audit_root: audit_root.clone(),
+                ..test_session_spec()
+            };
+            let invocation = SessionInvocation {
+                repo_url: REPO_URL.to_string(),
+                repo_token: None,
+                work_unit: Some("issue-176".to_string()),
+                input: None,
+                timeout: None,
+            };
+            let outcome = if use_progress {
+                let progress = |_event: SessionProgressEvent| {};
+                run_session_with_progress(spec, invocation, &progress)
+            } else {
+                run_session(spec, invocation)
+            }
+            .expect("session should succeed");
+
+            assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
+
+            helper
+                .join()
+                .expect("live transcript probe helper should complete");
+            live_transcript_discovery_calls_for_tests()
+        });
+
+        let record_dir = only_session_record_dir(&audit_root, "site-builder");
+        let metadata = read_session_metadata(&record_dir);
+        assert_eq!(metadata["outcome"], "success");
+
+        make_tree_writable(&audit_root);
+        fs::remove_dir_all(&audit_root).expect("temporary audit root should be removed");
+        reset_live_transcript_discovery_probe_for_tests();
+
+        discovery_calls
+    }
+
+    fn release_start_after_live_transcript_probe(
+        log_dir: PathBuf,
+        audit_root: PathBuf,
+        expect_progress: bool,
+    ) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !log_dir.join("start-blocked").exists() {
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            log_dir.join("start-blocked").exists(),
+            "fake podman start should block before probing live transcript discovery"
+        );
+
+        let record_dir = wait_for_only_session_record_dir(&audit_root, "site-builder", deadline);
+        let session_id = record_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("record dir should be named by utf-8 session id")
+            .to_string();
+        set_live_transcript_discovery_probe_session_for_tests(session_id);
+
+        let observed_progress = wait_for_live_transcript_discovery(expect_progress, deadline);
+        fs::write(log_dir.join("release-start"), b"release\n")
+            .expect("fake podman start should be released");
+        assert_eq!(
+            observed_progress, expect_progress,
+            "live transcript discovery observation did not match progress opt-in"
+        );
+    }
+
+    fn wait_for_live_transcript_discovery(expect_progress: bool, deadline: Instant) -> bool {
+        if !expect_progress {
+            thread::sleep(Duration::from_millis(250));
+            return live_transcript_discovery_calls_for_tests() > 0;
+        }
+
+        loop {
+            let observed = live_transcript_discovery_calls_for_tests() > 0;
+            if observed {
+                return observed;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for live transcript discovery"
             );
             thread::sleep(Duration::from_millis(25));
         }

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -32,6 +32,8 @@ const SHUTDOWN_MESSAGE: &str = "agentd is shutting down";
 const MAX_PROGRESS_FRAME_BYTES: usize = 128 * 1024;
 const PROGRESS_QUEUE_CAPACITY: usize = 64;
 const PROGRESS_TERMINAL_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+const SUMMARY_PREVIEW_CHARS: usize = 240;
+const SUMMARY_MAX_FIELDS: usize = 6;
 
 /// Startup or runtime failures for the foreground daemon loop.
 #[derive(Debug)]
@@ -93,9 +95,9 @@ pub enum ClientError {
 /// Client-side rendering level for live session observation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LiveObservationLevel {
-    /// Print concise lifecycle markers while waiting for the terminal outcome.
+    /// Print compact followable transcript activity while waiting for the terminal outcome.
     Summary,
-    /// Print lifecycle markers with every field carried by the progress frame.
+    /// Print raw progress frame detail for live session inspection.
     Full,
 }
 
@@ -571,16 +573,124 @@ impl fmt::Display for OperatorField<'_> {
 }
 
 fn summarize_transcript_event(line: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(line)
-        .ok()
-        .and_then(|event| {
-            event
-                .get("kind")
-                .and_then(serde_json::Value::as_str)
-                .filter(|kind| !kind.is_empty())
-                .map(str::to_string)
-        })
-        .unwrap_or_else(|| "unparsed_event".to_string())
+    let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+        return format!("unparsed_event {}", preview_field(line));
+    };
+    let Some(event) = event.as_object() else {
+        return format!("unparsed_event {}", preview_field(line));
+    };
+
+    let role = transcript_event_role(event);
+    if let Some(payload) = ["content", "message", "text"]
+        .iter()
+        .find_map(|key| nonempty_string_field(event, key))
+    {
+        return format!("{role} {}", preview_field(payload));
+    }
+
+    let fields = transcript_scalar_summary(event);
+    if fields.is_empty() {
+        format!("{role} {}", preview_field(line))
+    } else {
+        format!("{role} {}", fields.join(" "))
+    }
+}
+
+fn transcript_event_role(event: &serde_json::Map<String, serde_json::Value>) -> String {
+    let source = nonempty_string_field(event, "source");
+    let kind = nonempty_string_field(event, "kind");
+
+    match (source, kind) {
+        (Some(source), Some(kind)) => format!("{source}/{kind}"),
+        (None, Some(kind)) => kind.to_string(),
+        _ => "event".to_string(),
+    }
+}
+
+fn transcript_scalar_summary(event: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+    const PRIORITY_FIELDS: &[&str] = &[
+        "protocol",
+        "action",
+        "tool",
+        "name",
+        "success",
+        "exit_code",
+        "signal",
+        "error",
+    ];
+    const RESERVED_FIELDS: &[&str] = &[
+        "schema_version",
+        "source",
+        "kind",
+        "content",
+        "message",
+        "text",
+    ];
+
+    let mut fields = Vec::new();
+    for key in PRIORITY_FIELDS {
+        if let Some(value) = scalar_field_display(event.get(*key)) {
+            fields.push(format!("{key}={value}"));
+        }
+    }
+
+    let mut other_keys = event
+        .keys()
+        .filter(|key| !PRIORITY_FIELDS.contains(&key.as_str()))
+        .filter(|key| !RESERVED_FIELDS.contains(&key.as_str()))
+        .collect::<Vec<_>>();
+    other_keys.sort();
+
+    for key in other_keys {
+        if fields.len() >= SUMMARY_MAX_FIELDS {
+            break;
+        }
+        if let Some(value) = scalar_field_display(event.get(key)) {
+            fields.push(format!("{key}={value}"));
+        }
+    }
+
+    fields
+}
+
+fn nonempty_string_field<'a>(
+    event: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<&'a str> {
+    event
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn scalar_field_display(value: Option<&serde_json::Value>) -> Option<String> {
+    match value? {
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::String(value) if !value.trim().is_empty() => {
+            Some(preview_field(value.trim()))
+        }
+        _ => None,
+    }
+}
+
+fn preview_field(value: &str) -> String {
+    let mut preview = String::new();
+    let mut chars = value.chars();
+
+    for _ in 0..SUMMARY_PREVIEW_CHARS {
+        let Some(character) = chars.next() else {
+            return preview;
+        };
+        preview.push(character);
+    }
+
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+
+    preview
 }
 
 fn handle_connection(stream: UnixStream, config: &Config, executor: &impl SessionExecutor) {

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
+use std::net::Shutdown;
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -840,6 +841,7 @@ struct ProgressWriter {
     shared: Arc<ProgressWriterShared>,
     completion: mpsc::Receiver<Result<(), io::Error>>,
     handle: JoinHandle<()>,
+    abort_stream: UnixStream,
 }
 
 #[derive(Clone)]
@@ -870,6 +872,7 @@ enum ProgressWriterFrame {
 
 impl ProgressWriter {
     fn spawn(stream: UnixStream) -> Result<Self, io::Error> {
+        let abort_stream = stream.try_clone()?;
         let shared = Arc::new(ProgressWriterShared {
             state: Mutex::new(ProgressWriterState {
                 progress: VecDeque::new(),
@@ -901,6 +904,7 @@ impl ProgressWriter {
             shared,
             completion,
             handle,
+            abort_stream,
         })
     }
 
@@ -936,6 +940,8 @@ impl ProgressWriter {
                     timeout_ms = PROGRESS_TERMINAL_DRAIN_TIMEOUT.as_millis(),
                     "manual run progress writer did not drain the terminal response before the deadline"
                 );
+                abort_progress_writer(self.abort_stream);
+                join_progress_writer(self.handle);
                 Ok(())
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -1056,6 +1062,16 @@ impl ProgressWriterSink {
                 );
             }
         }
+    }
+}
+
+fn abort_progress_writer(stream: UnixStream) {
+    if let Err(error) = stream.shutdown(Shutdown::Both) {
+        tracing::debug!(
+            event = "agentd.manual_run_progress_writer_abort_failed",
+            error = %error,
+            "failed to abort manual run progress writer stream"
+        );
     }
 }
 
@@ -1340,7 +1356,8 @@ fn read_pid(pid_file: &Path) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DaemonError, LiveObservationLevel, ResponseMessage, reap_finished_handlers,
+        DaemonError, LiveObservationLevel, PROGRESS_QUEUE_CAPACITY,
+        PROGRESS_TERMINAL_DRAIN_TIMEOUT, ProgressWriter, ResponseMessage, reap_finished_handlers,
         run_daemon_until_shutdown_with_reconciler, write_response,
     };
     use crate::config::Config;
@@ -1361,6 +1378,7 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
     use std::{
+        os::fd::{AsRawFd, RawFd},
         os::unix::fs::FileTypeExt,
         os::unix::net::{UnixListener, UnixStream},
     };
@@ -1448,6 +1466,55 @@ source = "AGENTD_GITHUB_TOKEN"
         panic!("timed out waiting for {}", path.display());
     }
 
+    fn set_socket_buffer(stream: &UnixStream, option_name: libc::c_int, size: libc::c_int) {
+        let result = unsafe {
+            libc::setsockopt(
+                stream.as_raw_fd(),
+                libc::SOL_SOCKET,
+                option_name,
+                (&size as *const libc::c_int).cast(),
+                std::mem::size_of_val(&size) as libc::socklen_t,
+            )
+        };
+        assert_eq!(
+            result,
+            0,
+            "failed to constrain socket buffer: {}",
+            io::Error::last_os_error()
+        );
+    }
+
+    fn unread_socket_bytes(stream: &UnixStream) -> usize {
+        let mut bytes: libc::c_int = 0;
+        let result = unsafe { libc::ioctl(stream.as_raw_fd(), libc::FIONREAD, &mut bytes) };
+        assert_eq!(
+            result,
+            0,
+            "failed to inspect unread socket bytes: {}",
+            io::Error::last_os_error()
+        );
+        usize::try_from(bytes).expect("unread byte count should be non-negative")
+    }
+
+    fn wait_for_unread_socket_bytes(stream: &UnixStream, minimum_unread_bytes: usize) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if unread_socket_bytes(stream) >= minimum_unread_bytes {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        panic!(
+            "timed out waiting for {minimum_unread_bytes} unread socket bytes; last observed {}",
+            unread_socket_bytes(stream)
+        );
+    }
+
+    fn fd_is_open(fd: RawFd) -> bool {
+        unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
+    }
+
     fn spawn_blocked_handler() -> (thread::JoinHandle<()>, Sender<()>) {
         let (tx, rx) = mpsc::channel();
         let handler = thread::spawn(move || {
@@ -1512,6 +1579,53 @@ source = "AGENTD_GITHUB_TOKEN"
             result.is_ok(),
             "closed peer during response write should be treated as normal completion"
         );
+    }
+
+    #[test]
+    fn progress_writer_finish_timeout_forces_stalled_writer_closed() {
+        let (daemon_stream, client_stream) =
+            UnixStream::pair().expect("stream pair should be created");
+        set_socket_buffer(&daemon_stream, libc::SO_SNDBUF, 4096);
+        set_socket_buffer(&client_stream, libc::SO_RCVBUF, 4096);
+        let daemon_fd = daemon_stream.as_raw_fd();
+        let writer = ProgressWriter::spawn(daemon_stream).expect("progress writer should spawn");
+        let sink = writer.sink();
+        let progress_line = format!(
+            r#"{{"schema_version":1,"source":"runa","kind":"agent_output","content":"{}"}}"#,
+            "x".repeat(96 * 1024)
+        );
+        for index in 0..PROGRESS_QUEUE_CAPACITY {
+            sink.enqueue_progress(ResponseMessage::Progress {
+                progress: ProgressMessage::TranscriptEvent {
+                    session_id: format!("stalled-session-{index}"),
+                    line: progress_line.clone(),
+                },
+            });
+        }
+        drop(sink);
+        wait_for_unread_socket_bytes(&client_stream, 4 * 1024);
+
+        let started = Instant::now();
+        writer
+            .finish(ResponseMessage::SessionOutcome {
+                outcome: SessionOutcome::Success { exit_code: 0 }.into(),
+            })
+            .expect("timeout cleanup should not fail daemon completion");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= PROGRESS_TERMINAL_DRAIN_TIMEOUT,
+            "test must exercise the terminal drain timeout path, completed in {elapsed:?}"
+        );
+        assert!(
+            elapsed < PROGRESS_TERMINAL_DRAIN_TIMEOUT + Duration::from_secs(5),
+            "terminal drain timeout cleanup should remain bounded, took {elapsed:?}"
+        );
+        assert!(
+            !fd_is_open(daemon_fd),
+            "finish must not return while a stalled progress writer still owns the stream fd"
+        );
+        drop(client_stream);
     }
 
     fn render_transcript_line(line: &str, level: LiveObservationLevel) -> String {

--- a/crates/agentd/src/daemon.rs
+++ b/crates/agentd/src/daemon.rs
@@ -1404,25 +1404,182 @@ source = "AGENTD_GITHUB_TOKEN"
         );
     }
 
-    #[test]
-    fn summary_progress_escapes_untrusted_transcript_event_kind_controls() {
+    fn render_transcript_line(line: &str, level: LiveObservationLevel) -> String {
         let mut output = Vec::new();
 
         super::render_progress(
             ProgressMessage::TranscriptEvent {
                 session_id: "fake-session-1".to_string(),
-                line: "{\"kind\":\"agent_input\\nspoof\\u001b[2J\"}".to_string(),
+                line: line.to_string(),
             },
-            LiveObservationLevel::Summary,
+            level,
             &mut output,
         )
-        .expect("summary progress should render");
+        .expect("transcript progress should render");
 
-        let output = String::from_utf8(output).expect("summary progress should be utf8");
-        assert_eq!(output, "session event: agent_input\\nspoof\\u{1b}[2J\n");
+        String::from_utf8(output).expect("transcript progress should be utf8")
+    }
+
+    #[test]
+    fn summary_progress_renders_followable_transcript_activity() {
+        let cases = [
+            (
+                r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"build the release checklist"}"#,
+                ["runa/agent_input", "build the release checklist"].as_slice(),
+            ),
+            (
+                r#"{"schema_version":1,"source":"runa","kind":"agent_output","content":"reading repository state"}"#,
+                ["runa/agent_output", "reading repository state"].as_slice(),
+            ),
+            (
+                r#"{"schema_version":1,"source":"runa","kind":"agent_stderr","message":"warning: retrying tool call"}"#,
+                ["runa/agent_stderr", "warning: retrying tool call"].as_slice(),
+            ),
+            (
+                r#"{"schema_version":1,"source":"runa-mcp","kind":"tool_call","protocol":"mcp","action":"tools/call","tool":"shell"}"#,
+                [
+                    "runa-mcp/tool_call",
+                    "protocol=mcp",
+                    "action=tools/call",
+                    "tool=shell",
+                ]
+                .as_slice(),
+            ),
+            (
+                r#"{"schema_version":1,"source":"runa","kind":"agent_exit","success":true,"exit_code":0}"#,
+                ["runa/agent_exit", "success=true", "exit_code=0"].as_slice(),
+            ),
+        ];
+
+        for (line, expected_parts) in cases {
+            let output = render_transcript_line(line, LiveObservationLevel::Summary);
+            for expected in expected_parts {
+                assert!(
+                    output.contains(expected),
+                    "summary output should contain {expected:?}: {output:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_observation_level_renders_followable_transcript_content() {
+        let line = r#"{"schema_version":1,"source":"runa","kind":"agent_output","content":"useful live payload"}"#;
+
+        for level in [LiveObservationLevel::Summary, LiveObservationLevel::Full] {
+            let output = render_transcript_line(line, level);
+            assert!(
+                output.contains("useful live payload"),
+                "{level:?} output should include transcript payload: {output:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_progress_includes_session_context_and_raw_transcript_detail() {
+        let output = render_transcript_line(
+            r#"{"schema_version":1,"source":"runa-mcp","kind":"tool_call","protocol":"mcp","action":"tools/call","success":true,"content":"inspect"}"#,
+            LiveObservationLevel::Full,
+        );
+
+        for expected in [
+            "session_id=fake-session-1",
+            r#""source":"runa-mcp""#,
+            r#""kind":"tool_call""#,
+            r#""protocol":"mcp""#,
+            r#""action":"tools/call""#,
+            r#""success":true"#,
+            r#""content":"inspect""#,
+        ] {
+            assert!(
+                output.contains(expected),
+                "full output should contain raw detail {expected:?}: {output:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn transcript_fallbacks_remain_observable_at_every_level() {
+        let cases = [
+            (
+                "not json\nwith controls\u{1b}[2J",
+                ["unparsed_event", "not json\\nwith controls\\u{1b}[2J"].as_slice(),
+                ["not json\\nwith controls\\u{1b}[2J"].as_slice(),
+            ),
+            (
+                r#"{"schema_version":1,"source":"runa","kind":"heartbeat","sequence":7,"success":false}"#,
+                ["runa/heartbeat", "sequence=7", "success=false"].as_slice(),
+                [
+                    r#""kind":"heartbeat""#,
+                    r#""sequence":7"#,
+                    r#""success":false"#,
+                ]
+                .as_slice(),
+            ),
+            (
+                r#"{"schema_version":1,"kind":"custom_event","detail":"field summary"}"#,
+                ["custom_event", "detail=field summary"].as_slice(),
+                [r#""kind":"custom_event""#, r#""detail":"field summary""#].as_slice(),
+            ),
+        ];
+
+        for (line, summary_expected_parts, full_expected_parts) in cases {
+            let summary = render_transcript_line(line, LiveObservationLevel::Summary);
+            assert!(
+                summary.starts_with("session event: "),
+                "summary output should render a progress line: {summary:?}"
+            );
+            for expected in summary_expected_parts {
+                assert!(
+                    summary.contains(expected),
+                    "summary output should contain fallback detail {expected:?}: {summary:?}"
+                );
+            }
+            assert!(
+                !summary[..summary.len() - 1].contains('\n') && !summary.contains('\u{1b}'),
+                "summary output should escape fallback controls: {summary:?}"
+            );
+
+            let full = render_transcript_line(line, LiveObservationLevel::Full);
+            assert!(
+                full.starts_with("session event: session_id=fake-session-1 "),
+                "full output should include session context: {full:?}"
+            );
+            for expected in full_expected_parts {
+                assert!(
+                    full.contains(expected),
+                    "full output should contain raw detail {expected:?}: {full:?}"
+                );
+            }
+            assert!(
+                !full[..full.len() - 1].contains('\n') && !full.contains('\u{1b}'),
+                "full output should escape fallback controls: {full:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn summary_progress_escapes_untrusted_display_fields_and_bounds_payloads() {
+        let output = render_transcript_line(
+            &format!(
+                r#"{{"source":"runa","kind":"agent_input\nspoof\u001b[2J","content":"{}"}}"#,
+                "x".repeat(600)
+            ),
+            LiveObservationLevel::Summary,
+        );
+
         assert!(
             !output[..output.len() - 1].contains('\n') && !output.contains('\u{1b}'),
             "summary output should not contain embedded terminal controls: {output:?}"
+        );
+        assert!(
+            output.len() < 360,
+            "summary output should keep long payload previews bounded: {} bytes",
+            output.len()
+        );
+        assert!(
+            output.contains("agent_input\\nspoof\\u{1b}[2J") && output.contains("xxx"),
+            "summary output should retain escaped role and payload preview: {output:?}"
         );
     }
 

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -22,9 +22,9 @@ const WISH_ABOUT: &str = "Elicit a wish and seed one governed session.";
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum ProgressLevel {
-    /// Print concise live session lifecycle messages.
+    /// Print compact live transcript activity.
     Summary,
-    /// Print live session lifecycle messages with all available fields.
+    /// Print raw live transcript event detail.
     Full,
 }
 
@@ -144,7 +144,7 @@ enum Command {
     /// Trigger a manual session through the running daemon.
     #[command(
         display_name = "agentd",
-        after_help = "Live observation:\n  agentd run streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
+        after_help = "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
     )]
     Run {
         agent: String,
@@ -196,7 +196,7 @@ fn main() -> ExitCode {
 
 fn wish_after_help() -> String {
     format!(
-        "Live observation:\n  agentd wish streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\nOr seed the session from an existing work-unit instead of prose:\n  agentd wish <AGENT> [REPO] --work-unit <ID>"
+        "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\nOr seed the session from an existing work-unit instead of prose:\n  agentd wish <AGENT> [REPO] --work-unit <ID>"
     )
 }
 

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -433,6 +433,12 @@ fn binary_run_help_shows_socket_path_and_not_config() {
         "run help should document live progress verbosity: {stdout}"
     );
     assert!(
+        stdout.contains(
+            "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail."
+        ),
+        "run help should describe summary and full transcript rendering: {stdout}"
+    );
+    assert!(
         !stdout.contains("--config"),
         "run help should not advertise daemon config coupling: {stdout}"
     );
@@ -492,7 +498,7 @@ fn binary_wish_help_shows_evocative_intent_prompting_surface() {
     );
     assert!(
         stdout.contains(
-            "Live observation:\n  agentd wish streams concise transcript progress by default while the session executes. Use --progress full for raw event detail.\n\nPrompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
+            "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
         ),
         "wish help should document the exact prompt block: {stdout}"
     );

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -111,9 +111,6 @@ struct BlockingFirstRunState {
 
 const SATURATING_PROGRESS_EVENTS: usize = 256;
 const SMALL_SOCKET_RECEIVE_BUFFER_BYTES: libc::c_int = 4096;
-// This reproduces the rejected dade8ed writer timeout path; production no longer has it.
-const LEGACY_PROGRESS_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
-
 #[derive(Clone)]
 struct BlockingBurstProgressExecutor {
     state: Arc<BlockingBurstProgressState>,
@@ -667,14 +664,14 @@ fn client_full_progress_includes_raw_execution_event_detail() {
 }
 
 #[test]
-fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcome() {
+fn non_reading_progress_client_does_not_block_daemon_completion() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {
         std::env::set_var("AGENTD_GITHUB_TOKEN", "runtime-secret");
     }
-    let runtime_dir = unique_runtime_dir("slow-reading-progress-client");
+    let runtime_dir = unique_runtime_dir("non-reading-progress-client");
     let config = config_in_runtime_dir(&runtime_dir);
     let shutdown = Arc::new(AtomicBool::new(false));
     let daemon_config = config.clone();
@@ -710,51 +707,15 @@ fn slow_reading_progress_client_receives_complete_json_lines_and_terminal_outcom
     });
     executor.release();
 
-    thread::sleep(LEGACY_PROGRESS_WRITE_TIMEOUT + Duration::from_secs(15));
-
     let mut client = client.take().expect("client should still be connected");
     let response = read_response_stream(&mut client);
-
-    let response = String::from_utf8(response).expect("daemon response should be utf8 JSONL");
     assert!(
-        response.ends_with('\n'),
-        "daemon must not emit an unterminated JSONL tail under progress backpressure: last bytes {:?}",
-        response
-            .as_bytes()
-            .iter()
-            .rev()
-            .take(32)
-            .copied()
-            .collect::<Vec<_>>()
-    );
-    let lines: Vec<&str> = response.lines().collect();
-    assert!(
-        !lines.is_empty(),
-        "daemon should write at least the terminal response"
-    );
-    let mut progress_frames = 0_usize;
-    let mut saw_terminal_outcome = false;
-    for line in &lines {
-        let value: serde_json::Value =
-            serde_json::from_str(line).expect("daemon must not emit partial JSON frames");
-        match value.get("type").and_then(serde_json::Value::as_str) {
-            Some("progress") => progress_frames += 1,
-            Some("session_outcome") => saw_terminal_outcome = true,
-            other => panic!("unexpected response type after saturated progress writes: {other:?}"),
-        }
-    }
-    assert!(
-        saw_terminal_outcome,
-        "terminal outcome must survive slow-reader progress backpressure; parsed {} lines with {progress_frames} progress frames",
-        lines.len()
-    );
-    assert!(
-        progress_frames < SATURATING_PROGRESS_EVENTS,
-        "slow-reading client should force progress drops, got all {progress_frames} frames"
+        !response.is_empty(),
+        "daemon should have written progress before abandoning the stalled response"
     );
     let join_result = join_rx
         .recv_timeout(Duration::from_secs(5))
-        .expect("daemon should join after bounded slow-reader drain");
+        .expect("daemon should join after bounded non-reader cleanup");
     joiner.join().expect("join helper should join");
     join_result.expect("daemon should exit cleanly");
     unsafe {

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -100,7 +100,7 @@ struct BlockingFirstRunExecutor {
     state: Arc<BlockingFirstRunState>,
     first_outcome: SessionOutcome,
     later_outcome: SessionOutcome,
-    first_progress_line: Option<String>,
+    first_progress_lines: Vec<String>,
 }
 
 struct BlockingFirstRunState {
@@ -193,12 +193,18 @@ impl BlockingFirstRunExecutor {
             }),
             first_outcome,
             later_outcome,
-            first_progress_line: None,
+            first_progress_lines: Vec::new(),
         }
     }
 
     fn with_first_progress_line(mut self, line: &str) -> Self {
-        self.first_progress_line = Some(line.to_string());
+        self.first_progress_lines.push(line.to_string());
+        self
+    }
+
+    fn with_first_progress_lines(mut self, lines: &[&str]) -> Self {
+        self.first_progress_lines
+            .extend(lines.iter().map(|line| (*line).to_string()));
         self
     }
 
@@ -237,7 +243,7 @@ impl SessionExecutor for BlockingFirstRunExecutor {
             started_cvar.notify_all();
             drop(started);
 
-            if let Some(line) = &self.first_progress_line {
+            for line in &self.first_progress_lines {
                 progress.observe(SessionProgressEvent::TranscriptEvent {
                     session_id: "fake-session-1".to_string(),
                     line: line.clone(),
@@ -488,9 +494,11 @@ fn client_receives_execution_progress_while_session_is_still_running() {
         SessionOutcome::Success { exit_code: 0 },
         SessionOutcome::Success { exit_code: 0 },
     )
-    .with_first_progress_line(
+    .with_first_progress_lines(&[
         r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working step"}"#,
-    );
+        r#"{"schema_version":1,"source":"runa-mcp","kind":"tool_call","protocol":"mcp","action":"tools/call","tool":"shell"}"#,
+        r#"{"schema_version":1,"source":"runa","kind":"agent_exit","success":true,"exit_code":0}"#,
+    ]);
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
         run_daemon_until_shutdown_for_test(daemon_config, daemon_executor, daemon_shutdown)
@@ -517,7 +525,7 @@ fn client_receives_execution_progress_while_session_is_still_running() {
     executor.wait_for_first_run_to_start();
     let mut progress = String::new();
     let deadline = Instant::now() + Duration::from_secs(1);
-    while !progress.contains("session event: agent_input") {
+    while !progress.contains("success=true") {
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
             !remaining.is_zero(),
@@ -529,10 +537,16 @@ fn client_receives_execution_progress_while_session_is_still_running() {
                 .expect("execution progress should reach the client before the session completes"),
         );
     }
-    assert!(
-        progress.contains("session event: agent_input"),
-        "unexpected progress output: {progress}"
-    );
+    for expected in [
+        "session event: runa/agent_input working step",
+        "session event: runa-mcp/tool_call protocol=mcp action=tools/call tool=shell",
+        "session event: runa/agent_exit success=true exit_code=0",
+    ] {
+        assert!(
+            progress.contains(expected),
+            "default summary progress should include followable transcript detail {expected:?}: {progress}"
+        );
+    }
     assert!(
         !client_request.is_finished(),
         "client should still be waiting for the terminal outcome after progress arrives"
@@ -575,7 +589,7 @@ fn client_full_progress_includes_raw_execution_event_detail() {
         SessionOutcome::Success { exit_code: 0 },
     )
     .with_first_progress_line(
-        r#"{"schema_version":1,"source":"runa","kind":"agent_input","content":"working step"}"#,
+        r#"{"schema_version":1,"source":"runa-mcp","kind":"tool_call","protocol":"mcp","action":"tools/call","success":true,"content":"working step"}"#,
     );
     let daemon_executor = executor.clone();
     let handle = thread::spawn(move || {
@@ -616,6 +630,18 @@ fn client_full_progress_includes_raw_execution_event_detail() {
         );
     }
     assert!(progress.contains("session_id=fake-session-1"), "{progress}");
+    for expected in [
+        r#""source":"runa-mcp""#,
+        r#""kind":"tool_call""#,
+        r#""protocol":"mcp""#,
+        r#""action":"tools/call""#,
+        r#""success":true"#,
+    ] {
+        assert!(
+            progress.contains(expected),
+            "full progress should include raw event detail {expected:?}: {progress}"
+        );
+    }
     assert!(
         !client_request.is_finished(),
         "client should still be waiting for the terminal outcome after full progress arrives"

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -65,8 +65,9 @@ live progress for a run request. `dispatch_started` is a start marker;
 same nested runa event source that sealed audit finalization reads:
 `agentd/transcript/deployments/<deployment>/work-units/<work-unit>/runs/<run-id>/events.jsonl`.
 `agentd wish` and `agentd run` render these frames in the invoking terminal
-while they wait for the terminal outcome; `--progress summary` prints concise
-event names and `--progress full` includes the raw transcript event line.
+while they wait for the terminal outcome; `--progress summary` prints compact
+transcript activity with payload, action, or exit details and `--progress full`
+includes the raw transcript event line.
 Progress delivery is best-effort: oversized transcript records and progress
 frames that cannot fit without preserving room for the terminal response are
 dropped whole. The daemon never emits partial progress JSON frames, and the


### PR DESCRIPTION
## Summary

Implements tesserine/agentd#176 against contract comment 4912393422 and plan comment 4912464630, based on PR #163's current `issue-162-nested-transcript-path` branch.

This is render-only and intended to co-land with #163. It does not change transcript capture, live tailing, audit finalization, manifest rendering, or coverage classification.

## Changes

- Adds RED-first value-floor coverage for live transcript rendering before the renderer change.
- Renders default summary progress as compact followable transcript activity: role plus payload, action, tool, success, exit code, or fallback scalar/raw preview.
- Keeps full progress as session context plus the raw forwarded transcript line for inspection.
- Uses tolerant `serde_json::Value` presentation parsing and preserves terminal escaping through `OperatorField`.
- Updates CLI help, README, socket protocol docs, and changelog to describe summary/full live transcript behavior.

## Verification

RED evidence before renderer change:
- `cargo test -p agentd progress` failed on summary payload/value-floor expectations over the old kind-only renderer.
- `cargo test -p agentd client_receives_execution_progress_while_session_is_still_running` failed waiting for `success=true` from default summary.
- `cargo test -p agentd binary_run_help_shows_socket_path_and_not_config` failed on stale help text.
- `cargo test -p agentd binary_wish_help_shows_evocative_intent_prompting_surface` failed on stale help text.

Green evidence:
- `cargo test -p agentd progress`
- `cargo test -p agentd client_receives_execution_progress_while_session_is_still_running`
- `cargo test -p agentd client_full_progress_includes_raw_execution_event_detail`
- `cargo test -p agentd binary_run_help_shows_socket_path_and_not_config`
- `cargo test -p agentd binary_wish_help_shows_evocative_intent_prompting_surface`
- `cargo test -p agentd-runner finalize_session_transcript`
- `cargo test -p agentd-runner transcript_coverage_uses_parsed_event_sources`
- `cargo test -p agentd-runner restrictive`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets`
- `cargo fmt --check`

## Self-review

- Diff is limited to renderer/client presentation, tests, and current docs.
- No transcript resolver, live tailer, audit finalizer, sealed transcript markdown/manifest, or coverage code changed.
- Offered progress levels remain `summary` and `full`; no lifecycle-only selectable mode was added.
