### PR TITLE
feat(cli): wish seeds from a work-unit reference or prose intent, not both

### DIFF
--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -143,6 +143,8 @@ enum Command {
         repo: Option<String>,
         #[arg(long)]
         socket_path: Option<PathBuf>,
+        #[arg(long)]
+        work_unit: Option<String>,
     },
 }
 
@@ -162,7 +164,9 @@ fn main() -> ExitCode {
 }
 
 fn wish_after_help() -> String {
-    format!("Prompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}")
+    format!(
+        "Prompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\nOr seed the session from an existing work-unit instead of prose:\n  agentd wish <AGENT> [REPO] --work-unit <ID>"
+    )
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -205,6 +209,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             agent,
             repo,
             socket_path,
+            work_unit,
         }) => {
             if cli.config.is_some() {
                 return Err(Box::new(std::io::Error::new(
@@ -212,7 +217,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     "--config is only supported for daemon mode, not `agentd wish`",
                 )));
             }
-            run_wish_client(socket_path.as_deref(), agent, repo)
+            run_wish_client(socket_path.as_deref(), agent, repo, work_unit)
         }
     }
 }
@@ -266,7 +271,17 @@ fn run_wish_client(
     explicit_socket_path: Option<&std::path::Path>,
     agent: String,
     repo: Option<String>,
+    work_unit: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Work-unit arm: an operator naming an existing work-unit seeds the
+    // session with it as a work-unit, reaching the same downstream entry
+    // `agentd run --work-unit` reaches. Prose elicitation is skipped
+    // entirely, so a single wish invocation can never carry both a prose
+    // intent and a work-unit reference.
+    if let Some(work_unit) = work_unit {
+        return run_client_with_input(explicit_socket_path, agent, repo, Some(work_unit), None);
+    }
+
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout();
     let (statement, target) = read_wish(&mut stdin, &mut stdout)?;

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -1618,3 +1618,99 @@ argv = ["site-builder", "exec"]
         std::env::remove_var("XDG_RUNTIME_DIR");
     }
 }
+
+#[test]
+fn binary_wish_command_seeds_work_unit_arm_and_skips_prose_elicitation() {
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "agentd-cli-runtime-wish-work-unit-arm-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let socket_path = runtime_dir.join("agentd.sock");
+    let pid_file = runtime_dir.join("agentd.pid");
+    let config_path = write_temp_config(
+        "client-command-wish-work-unit-arm",
+        &daemon_test_config(&socket_path, &pid_file),
+    );
+    let (shutdown, handle, _config, invocations) =
+        start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
+
+    // stdin is closed: the work-unit arm must not block on or read prose.
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args([
+            "wish",
+            "--socket-path",
+            socket_path.to_str().expect("socket path should be utf-8"),
+            "site-builder",
+            "https://example.com/repo.git",
+            "--work-unit",
+            "issue-81",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("agentd binary should run");
+
+    shutdown.store(true, Ordering::Release);
+    handle
+        .join()
+        .expect("daemon thread should join")
+        .expect("daemon should exit cleanly");
+
+    assert!(
+        output.status.success(),
+        "wish work-unit arm should succeed without prose input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+    assert!(
+        !stdout.contains("Speak a wish: the state you want made true."),
+        "wish work-unit arm must not elicit prose, so a single invocation \
+         cannot carry both an intent and a work-unit: {stdout}"
+    );
+
+    let invocation = invocations.lock().expect("invocations should lock")[0].clone();
+    assert_eq!(
+        invocation.work_unit.as_deref(),
+        Some("issue-81"),
+        "wish work-unit arm should enter the reference as a work-unit"
+    );
+    assert_eq!(
+        invocation.input, None,
+        "wish work-unit arm should reach the same downstream shape as `run --work-unit`: \
+         a work-unit with no invocation input"
+    );
+}
+
+#[test]
+fn binary_wish_help_advertises_work_unit_arm() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
+        .args(["wish", "--help"])
+        .output()
+        .expect("agentd binary should run");
+
+    assert!(
+        output.status.success(),
+        "wish help should exit successfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+    assert!(
+        stdout.contains("--work-unit"),
+        "wish help should advertise the work-unit arm: {stdout}"
+    );
+    // The prose prompt surface remains documented unchanged.
+    assert!(
+        stdout.contains(
+            "Prompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
+        ),
+        "wish help should retain the exact prose prompt block: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #174.

## What

Adds a `--work-unit <ID>` arm to `agentd wish`. An operator naming an existing work-unit now enters it **as** a work-unit through the wish surface, rather than having it captured as free-text prose in the target prompt.

- **Work-unit arm** (`wish <AGENT> [REPO] --work-unit <ID>`): seeds the session with the work-unit and skips prose elicitation entirely, reaching `run_client_with_input` with `(work_unit: Some(ID), input: None)` — the same downstream shape `run --work-unit <ID>` produces.
- **Prose arm** (`wish <AGENT> [REPO]`): elicits the statement and optional target as today, unchanged.
- **Exclusivity**: because the work-unit arm skips prose elicitation, a single `wish` invocation can never carry both a prose intent and a work-unit reference. This is the structural form of the exclusivity the `run` surface declares via clap between its `intent` and `work_unit` inputs; the runner's `validate_invocation` already rejects `(work_unit + IntentText)` downstream.

## Acceptance criteria

- [x] A `wish` session can be seeded by a work-unit reference, entered as a work-unit.
- [x] A `wish` session can be seeded by a prose intent, as today.
- [x] A single invocation cannot carry both; the work-unit arm elicits no prose.
- [x] Both arms reach the same downstream session entry the equivalent `run` inputs reach.

## Verification

- New: `binary_wish_command_seeds_work_unit_arm_and_skips_prose_elicitation` asserts `work_unit == Some("issue-81")`, `input == None`, and that the greeting/prompts are not emitted (prose skipped).
- New: `binary_wish_help_advertises_work_unit_arm` asserts `--work-unit` is advertised while the exact prose prompt block is retained.
- Existing wish prose/target tests and the wish help exact-prompt-block test remain green.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test -p agentd --test cli_surface` green (30/30).

Produced station-direct.

## Unblocks

`pentaxis93/babbie-ops#67` (targeted-route acceptance).