### PR TITLE
fix: route work-unit seeds through runa resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,7 +200,7 @@ The runner prepares the execution environment:
 
 ### Phase 3: Execution (`agentd-runner`)
 
-The runner drops privileges with `gosu` and launches `runa run [--work-unit <id>] --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange. agentd sets `RUNA_TRANSCRIPT_DIR=/agentd/transcript` and `RUNA_TRANSCRIPT_REDACT_ENV` so runa can persist the execution events it observes.
+The runner drops privileges with `gosu` and launches `runa run --agent-command -- <argv>` as the unprivileged session user from `/home/{username}/repo`. When the invocation includes `work_unit`, agentd materializes that operator-supplied reference as `intent/operator-input.json` with `target` set to the reference, then leaves resolution to runa's unscoped resolving entry so unresolved references fail closed before scoped work begins. The argv comes from the declarative agent command, and `runa run` owns protocol execution from there. Tool invocations happen directly from the runtime to installed CLIs or configured external MCP servers; agentd does not sit in the middle of that protocol exchange. agentd sets `RUNA_TRANSCRIPT_DIR=/agentd/transcript` and `RUNA_TRANSCRIPT_REDACT_ENV` so runa can persist the execution events it observes.
 
 ### Phase 4: Teardown (`agentd-runner`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `agentd run --work-unit` and `agentd wish --work-unit` now route the
+  operator-supplied reference through runa's resolving entry by materializing a
+  target-bearing intent seed and invoking unscoped `runa run`, instead of
+  bypassing resolution with `runa run --work-unit`.
+
 - Manual text input now authors canonical intent v2 (`statement`, optional
   `target`, and `source`) end to end: `agentd run --intent`, the daemon
   socket `IntentText` variant, and `.runa/workspace/intent/operator-input.json`

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ documented in [docs/socket-protocol.md](docs/socket-protocol.md).
 Trigger a session through the running daemon:
 
 ```bash
-agentd run site-builder --work-unit issue-42
+agentd run site-builder --work-unit 42
 ```
 
 For operator intent, use `wish`:
@@ -296,7 +296,7 @@ through unchanged for the runtime to interpret.
 Manual invocation also supports lower-level intake-mode and work-mode
 surfaces:
 
-- `--work-unit <ID>` targets existing queued work
+- `--work-unit <ID>` seeds an existing work-unit reference
 - `--intent <TEXT>` synthesizes a canonical intent artifact at
   `.runa/workspace/intent/operator-input.json`
 - `--artifact-type <TYPE> --artifact-file <PATH>` validates and places a
@@ -308,11 +308,13 @@ artifact, combine the selected work-unit id with a matching `work-unit` artifact
 file:
 
 ```bash
-agentd run site-builder --work-unit issue-42 --artifact-type work-unit --artifact-file ./issue-42.json
+agentd run site-builder --work-unit 42 --artifact-type work-unit --artifact-file ./42.json
 ```
 
 The file stem becomes the artifact id, so the file stem must match
-`--work-unit`.
+`--work-unit`. agentd still routes the reference through runa's resolving entry:
+it materializes a target-bearing `intent` seed and launches unscoped `runa run`
+so runa resolves the reference fail-closed before scoped work begins.
 
 `agentd run` does not read `agentd.toml`. The client connects to the daemon by
 either:
@@ -330,8 +332,8 @@ may omit the positional repo argument when the named agent declares `repo`,
 and an explicit repo still overrides the configured default:
 
 ```bash
-agentd run --socket-path /custom/agentd.sock site-builder --work-unit issue-42
-agentd run site-builder https://github.com/pentaxis93/agentd.git --work-unit issue-42
+agentd run --socket-path /custom/agentd.sock site-builder --work-unit 42
+agentd run site-builder https://github.com/pentaxis93/agentd.git --work-unit 42
 ```
 
 Text input is methodology-gated. `--intent` is available only when the active
@@ -355,7 +357,7 @@ Examples:
 agentd wish site-builder
 agentd run site-builder --intent "Add a status page"
 agentd run site-builder --artifact-type claim --artifact-file ./claim.json
-agentd run site-builder --work-unit issue-42 --artifact-type work-unit --artifact-file ./issue-42.json
+agentd run site-builder --work-unit 42 --artifact-type work-unit --artifact-file ./42.json
 agentd run site-builder https://github.com/pentaxis93/agentd.git --intent "Review the last release candidate"
 ```
 
@@ -371,7 +373,7 @@ the container, the agent sees:
 - Credentials injected as environment variables
 - `GROUNDWORK_FORGE_TYPE` with the configured active forge type, defaulting to `github`
 - `AGENTD_WORK_UNIT` when the invocation includes one
-- A pre-materialized artifact under `.runa/workspace/...` when the invocation includes `wish`, `--intent`, or `--artifact-file`
+- A pre-materialized artifact under `.runa/workspace/...` when the invocation includes `wish`, `--intent`, `--work-unit`, or `--artifact-file`; `--work-unit` is materialized as `intent/operator-input.json` with the reference in `target`
 - `runa init` state followed by `runa run --agent-command -- <argv>` from the repo directory
 
 The container is force-removed on completion. The session's audit record

--- a/crates/agentd-runner/src/audit.rs
+++ b/crates/agentd-runner/src/audit.rs
@@ -921,7 +921,7 @@ mod tests {
             &SessionInvocation {
                 repo_url: "https://example.com/agentd.git".to_string(),
                 repo_token: None,
-                work_unit: Some("issue-76".to_string()),
+                work_unit: Some("76".to_string()),
                 input: None,
                 timeout: None,
             },
@@ -936,7 +936,7 @@ mod tests {
         assert_eq!(json["session_id"], "0123456789abcdef");
         assert_eq!(json["agent"], "site-builder");
         assert_eq!(json["repo_url"], "https://example.com/agentd.git");
-        assert_eq!(json["work_unit"], "issue-76");
+        assert_eq!(json["work_unit"], "76");
         assert!(json.get("end_timestamp").is_none());
         assert!(json.get("outcome").is_none());
         assert!(json.get("exit_code").is_none());

--- a/crates/agentd-runner/src/container.rs
+++ b/crates/agentd-runner/src/container.rs
@@ -8,7 +8,9 @@
 //! --attach` is ambiguous (podman infrastructure error vs. container process)
 //! and requires container state inspection to disambiguate.
 
-use crate::input::{INVOCATION_INPUT_MOUNT_PATH, ResolvedInvocationInput};
+use crate::input::{
+    INVOCATION_INPUT_MOUNT_PATH, ResolvedInvocationInput, work_unit_seed_resolved_input,
+};
 use crate::lifecycle::{LifecycleFailureKind, log_lifecycle_failure};
 use crate::podman::{run_podman_command, run_podman_command_until};
 use crate::resources::{SecretBinding, SessionResources, cleanup_podman_secrets};
@@ -271,31 +273,67 @@ fn build_container_script(
     script.push_str(" runa init --methodology ");
     script.push_str(&shell_quote(METHODOLOGY_MANIFEST_PATH));
     if let Some(resolved_input) = resolved_input {
-        let workspace_dir = format!("{repo_runa_dir}/workspace/{}", resolved_input.artifact_type);
-        let artifact_path = format!("{workspace_dir}/{}.json", resolved_input.artifact_id);
-        let staged_document_path = format!("{INVOCATION_INPUT_MOUNT_PATH}/document.json");
-        script.push_str("\ngosu ");
-        script.push_str(&shell_quote(&user_group));
-        script.push_str(" mkdir -p ");
-        script.push_str(&shell_quote(&workspace_dir));
-        script.push_str("\ngosu ");
-        script.push_str(&shell_quote(&user_group));
-        script.push_str(" cp ");
-        script.push_str(&shell_quote(&staged_document_path));
-        script.push(' ');
-        script.push_str(&shell_quote(&artifact_path));
+        append_staged_input_materialization(
+            &mut script,
+            &user_group,
+            &repo_runa_dir,
+            resolved_input,
+        );
+    }
+    if let Some(work_unit) = &invocation.work_unit {
+        let seed_input = work_unit_seed_resolved_input(work_unit);
+        append_inline_input_materialization(&mut script, &user_group, &repo_runa_dir, &seed_input);
     }
     script.push_str("\nexec gosu ");
     script.push_str(&shell_quote(&user_group));
     script.push_str(" runa run");
-    if let Some(work_unit) = &invocation.work_unit {
-        script.push_str(" --work-unit ");
-        script.push_str(&shell_quote(work_unit));
-    }
     script.push_str(" --agent-command -- ");
     script.push_str(&shell_join(&spec.agent_command));
 
     script
+}
+
+fn append_staged_input_materialization(
+    script: &mut String,
+    user_group: &str,
+    repo_runa_dir: &str,
+    resolved_input: &ResolvedInvocationInput,
+) {
+    let workspace_dir = format!("{repo_runa_dir}/workspace/{}", resolved_input.artifact_type);
+    let artifact_path = format!("{workspace_dir}/{}.json", resolved_input.artifact_id);
+    let staged_document_path = format!("{INVOCATION_INPUT_MOUNT_PATH}/document.json");
+    script.push_str("\ngosu ");
+    script.push_str(&shell_quote(user_group));
+    script.push_str(" mkdir -p ");
+    script.push_str(&shell_quote(&workspace_dir));
+    script.push_str("\ngosu ");
+    script.push_str(&shell_quote(user_group));
+    script.push_str(" cp ");
+    script.push_str(&shell_quote(&staged_document_path));
+    script.push(' ');
+    script.push_str(&shell_quote(&artifact_path));
+}
+
+fn append_inline_input_materialization(
+    script: &mut String,
+    user_group: &str,
+    repo_runa_dir: &str,
+    resolved_input: &ResolvedInvocationInput,
+) {
+    let workspace_dir = format!("{repo_runa_dir}/workspace/{}", resolved_input.artifact_type);
+    let artifact_path = format!("{workspace_dir}/{}.json", resolved_input.artifact_id);
+    let mut write_command = String::from("printf %s ");
+    write_command.push_str(&shell_quote(&resolved_input.document_json));
+    write_command.push_str(" > ");
+    write_command.push_str(&shell_quote(&artifact_path));
+    script.push_str("\ngosu ");
+    script.push_str(&shell_quote(user_group));
+    script.push_str(" mkdir -p ");
+    script.push_str(&shell_quote(&workspace_dir));
+    script.push_str("\ngosu ");
+    script.push_str(&shell_quote(user_group));
+    script.push_str(" /bin/sh -c ");
+    script.push_str(&shell_quote(&write_command));
 }
 
 fn build_home_ownership_command(

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -414,7 +414,7 @@ fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent
         &SessionInvocation {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
-            work_unit: Some("task-42".to_string()),
+            work_unit: Some("42".to_string()),
             input: None,
             timeout: None,
         },
@@ -454,7 +454,7 @@ fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent
         "\ngosu 'myagent:myagent' mkdir -p '/home/myagent/repo/.runa/workspace/intent'\n"
     ));
     assert!(
-        script.contains("\"target\":\"task-42\"")
+        script.contains("\"target\":\"42\"")
             && script.contains("/home/myagent/repo/.runa/workspace/intent/operator-input.json"),
         "work-unit reference should be materialized as a target-bearing intent: {script}"
     );

--- a/crates/agentd-runner/src/container/tests.rs
+++ b/crates/agentd-runner/src/container/tests.rs
@@ -451,8 +451,23 @@ fn build_container_script_creates_home_workspace_initializes_runa_and_runs_agent
     ));
     assert!(!script.contains(".runa/config.toml"));
     assert!(script.contains(
-        "\nexec gosu 'myagent:myagent' runa run --work-unit 'task-42' --agent-command -- 'site-builder' 'exec' '--sandbox' 'workspace-write'"
+        "\ngosu 'myagent:myagent' mkdir -p '/home/myagent/repo/.runa/workspace/intent'\n"
     ));
+    assert!(
+        script.contains("\"target\":\"task-42\"")
+            && script.contains("/home/myagent/repo/.runa/workspace/intent/operator-input.json"),
+        "work-unit reference should be materialized as a target-bearing intent: {script}"
+    );
+    assert!(
+        script.contains(
+            "\nexec gosu 'myagent:myagent' runa run --agent-command -- 'site-builder' 'exec' '--sandbox' 'workspace-write'"
+        ),
+        "work-unit reference should enter runa's resolving path instead of --work-unit: {script}"
+    );
+    assert!(
+        !script.contains("runa run --work-unit"),
+        "work-unit reference must not use runa's pre-bound --work-unit path: {script}"
+    );
 }
 
 #[test]
@@ -533,13 +548,13 @@ fn build_container_script_materializes_work_unit_input_before_work_mode_run() {
         &SessionInvocation {
             repo_url: VALID_REMOTE_REPO_URL.to_string(),
             repo_token: None,
-            work_unit: Some("issue-76".to_string()),
+            work_unit: Some("76".to_string()),
             input: None,
             timeout: None,
         },
         Some(&ResolvedInvocationInput {
             artifact_type: "work-unit".to_string(),
-            artifact_id: "issue-76".to_string(),
+            artifact_id: "76".to_string(),
             document_json: "{}\n".to_string(),
         }),
     );
@@ -547,12 +562,23 @@ fn build_container_script_materializes_work_unit_input_before_work_mode_run() {
     let materialize_offset = script
         .find("workspace/work-unit")
         .expect("script should materialize the work-unit artifact");
+    let seed_offset = script
+        .find("workspace/intent")
+        .expect("script should materialize the work-unit reference seed");
     let run_offset = script
-        .find("runa run --work-unit 'issue-76'")
-        .expect("script should run the selected work unit");
+        .find("runa run --agent-command")
+        .expect("script should run through the resolving entry path");
     assert!(
         materialize_offset < run_offset,
         "work-unit artifact should be materialized before work-mode run: {script}"
+    );
+    assert!(
+        seed_offset < run_offset,
+        "work-unit reference seed should be materialized before runa run resolves it: {script}"
+    );
+    assert!(
+        !script.contains("runa run --work-unit"),
+        "work-unit artifact input must still enter through the resolving path: {script}"
     );
 }
 

--- a/crates/agentd-runner/src/input.rs
+++ b/crates/agentd-runner/src/input.rs
@@ -9,6 +9,7 @@ pub(crate) const INVOCATION_INPUT_MOUNT_PATH: &str = "/agentd/invocation-input";
 const INTENT_ARTIFACT_TYPE: &str = "intent";
 const INTENT_ARTIFACT_ID: &str = "operator-input";
 const INTENT_SOURCE: &str = "operator";
+const WORK_UNIT_SEED_STATEMENT: &str = "Work on the referenced work unit.";
 const SUPPORTED_INTENT_CANONICAL_VERSIONS: &[&str] = &["2.0.0"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,6 +104,51 @@ pub(crate) fn resolve_invocation_input(
             }))
         }
     }
+}
+
+pub(crate) fn resolve_work_unit_seed_input(
+    methodology_dir: &Path,
+    work_unit: &str,
+) -> Result<ResolvedInvocationInput, RunnerError> {
+    let manifest = load_manifest(methodology_dir)?;
+    let schema_path = methodology_dir.join("schemas/intent.schema.json");
+    ensure_declared_artifact_type(&manifest, INTENT_ARTIFACT_TYPE).map_err(|message| {
+        RunnerError::InvalidInvocationInput {
+            message: format!("methodology does not support work-unit reference input: {message}"),
+        }
+    })?;
+    let schema =
+        load_schema(&schema_path).map_err(|message| RunnerError::InvalidInvocationInput {
+            message: format!("methodology does not support work-unit reference input: {message}"),
+        })?;
+    ensure_supported_intent_version(&schema).map_err(|message| {
+        RunnerError::InvalidInvocationInput {
+            message: format!("methodology does not support work-unit reference input: {message}"),
+        }
+    })?;
+
+    let document = work_unit_seed_document(work_unit);
+    validate_document(&schema, &document, INTENT_ARTIFACT_TYPE)?;
+
+    Ok(work_unit_seed_resolved_input(work_unit))
+}
+
+pub(crate) fn work_unit_seed_resolved_input(work_unit: &str) -> ResolvedInvocationInput {
+    let document = work_unit_seed_document(work_unit);
+    ResolvedInvocationInput {
+        artifact_type: INTENT_ARTIFACT_TYPE.to_string(),
+        artifact_id: INTENT_ARTIFACT_ID.to_string(),
+        document_json: serde_json::to_string(&document)
+            .expect("work-unit reference seed intent should serialize"),
+    }
+}
+
+fn work_unit_seed_document(work_unit: &str) -> Value {
+    json!({
+        "statement": WORK_UNIT_SEED_STATEMENT,
+        "source": INTENT_SOURCE,
+        "target": work_unit,
+    })
 }
 
 fn load_manifest(methodology_dir: &Path) -> Result<MethodologyManifest, RunnerError> {
@@ -207,7 +253,7 @@ fn render_document(document: &Value) -> Result<String, RunnerError> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_invocation_input;
+    use super::{resolve_invocation_input, resolve_work_unit_seed_input};
     use crate::types::{InvocationInput, RunnerError};
     use serde_json::json;
     use std::fs;
@@ -266,6 +312,29 @@ mod tests {
                 "statement": "Work on the tracker item",
                 "source": "operator",
                 "target": "tesserine/agentd#154",
+            })
+        );
+
+        fs::remove_dir_all(&methodology_dir).expect("temporary methodology dir should be removed");
+    }
+
+    #[test]
+    fn resolve_work_unit_seed_input_authors_target_bearing_intent() {
+        let methodology_dir = unique_methodology_dir("work-unit-seed-intent");
+        write_intent_methodology_fixture(&methodology_dir, "2.0.0");
+
+        let resolved = resolve_work_unit_seed_input(&methodology_dir, "tesserine/agentd#175")
+            .expect("work-unit reference seed should resolve");
+
+        assert_eq!(resolved.artifact_type, "intent");
+        assert_eq!(resolved.artifact_id, "operator-input");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&resolved.document_json)
+                .expect("resolved work-unit seed should be valid JSON"),
+            json!({
+                "statement": "Work on the referenced work unit.",
+                "source": "operator",
+                "target": "tesserine/agentd#175",
             })
         );
 

--- a/crates/agentd-runner/src/lib.rs
+++ b/crates/agentd-runner/src/lib.rs
@@ -42,7 +42,7 @@ use audit::{
     prepare_session_audit_record,
 };
 use container::{create_container, run_container_to_completion, run_container_with_timeout};
-use input::resolve_invocation_input;
+use input::{resolve_invocation_input, resolve_work_unit_seed_input};
 use lifecycle::{
     LifecycleFailureKind, log_lifecycle_failure, log_session_error, log_session_outcome,
     log_session_started, log_session_teardown,
@@ -74,6 +74,9 @@ pub fn run_session(
     validate_invocation(&invocation)?;
     let resolved_input =
         resolve_invocation_input(&spec.methodology_dir, invocation.input.as_ref())?;
+    if let Some(work_unit) = invocation.work_unit.as_deref() {
+        resolve_work_unit_seed_input(&spec.methodology_dir, work_unit)?;
+    }
     let session_id = unique_suffix()?;
 
     let container_name =

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -119,9 +119,9 @@ pub struct SessionInvocation {
     /// request for `https://` repository URLs. This token is not passed
     /// through to the agent runtime.
     pub repo_token: Option<String>,
-    /// Optional work unit identifier passed to `runa run --work-unit` and
-    /// exposed through the runner-managed `AGENTD_WORK_UNIT` environment
-    /// variable when set.
+    /// Optional work-unit reference exposed through the runner-managed
+    /// `AGENTD_WORK_UNIT` environment variable and seeded into runa as an
+    /// intent target so runa resolves the reference before scoped work begins.
     pub work_unit: Option<String>,
     /// Optional operator-supplied input to materialize into the repo
     /// workspace after `runa init` and before `runa run`. Artifact names supplied

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -1563,7 +1563,7 @@ mod tests {
     fn validate_invocation_accepts_supported_manual_intent_surfaces() {
         for (work_unit, input) in [
             (None, None),
-            (Some("issue-42".to_string()), None),
+            (Some("42".to_string()), None),
             (
                 None,
                 Some(InvocationInput::IntentText {
@@ -1572,11 +1572,11 @@ mod tests {
                 }),
             ),
             (
-                Some("issue-42".to_string()),
+                Some("42".to_string()),
                 Some(InvocationInput::Artifact {
                     artifact_type: "work-unit".to_string(),
-                    artifact_id: "issue-42".to_string(),
-                    document: serde_json::json!({ "id": "issue-42" }),
+                    artifact_id: "42".to_string(),
+                    document: serde_json::json!({ "id": "42" }),
                 }),
             ),
         ] {
@@ -1596,7 +1596,7 @@ mod tests {
         let error = validate_invocation(&SessionInvocation {
             repo_url: "https://example.com/agentd.git".to_string(),
             repo_token: None,
-            work_unit: Some("issue-42".to_string()),
+            work_unit: Some("42".to_string()),
             input: Some(InvocationInput::IntentText {
                 statement: "Add a status page".to_string(),
                 target: None,
@@ -1625,10 +1625,10 @@ mod tests {
         let error = validate_invocation(&SessionInvocation {
             repo_url: "https://example.com/agentd.git".to_string(),
             repo_token: None,
-            work_unit: Some("issue-42".to_string()),
+            work_unit: Some("42".to_string()),
             input: Some(InvocationInput::Artifact {
                 artifact_type: "claim".to_string(),
-                artifact_id: "issue-42".to_string(),
+                artifact_id: "42".to_string(),
                 document: serde_json::json!({ "summary": "Ship it" }),
             }),
             timeout: None,
@@ -1651,11 +1651,11 @@ mod tests {
         let error = validate_invocation(&SessionInvocation {
             repo_url: "https://example.com/agentd.git".to_string(),
             repo_token: None,
-            work_unit: Some("issue-42".to_string()),
+            work_unit: Some("42".to_string()),
             input: Some(InvocationInput::Artifact {
                 artifact_type: "work-unit".to_string(),
-                artifact_id: "issue-43".to_string(),
-                document: serde_json::json!({ "id": "issue-43" }),
+                artifact_id: "43".to_string(),
+                document: serde_json::json!({ "id": "43" }),
             }),
             timeout: None,
         })
@@ -1667,7 +1667,7 @@ mod tests {
         );
         let message = error.to_string();
         assert!(
-            message.contains("artifact id") && message.contains("issue-42"),
+            message.contains("artifact id") && message.contains("42"),
             "expected matching-id guidance in message, got {message}"
         );
     }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -96,6 +96,11 @@ fn install_intent_schema(path: &Path, version: &str) {
     .expect("intent schema should be written");
 }
 
+fn install_work_unit_seed_methodology(path: &Path) {
+    write_methodology_manifest(path, &["intent"]);
+    install_intent_schema(path, "2.0.0");
+}
+
 fn install_claim_schema(path: &Path) {
     let schema_dir = path.join("schemas");
     fs::create_dir_all(&schema_dir).expect("schema dir should be created");
@@ -145,6 +150,7 @@ fn succeeds_without_timeout_and_cleans_up_container() {
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new("success-run");
+    install_work_unit_seed_methodology(&fixture.methodology_dir());
     let image = fixture.build_image();
 
     let outcome = run_session_with_test_audit_root(
@@ -297,7 +303,8 @@ fn executes_work_mode_against_injected_work_unit_artifact() {
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new("work-mode-artifact-run");
-    write_methodology_manifest(&fixture.methodology_dir(), &["work-unit"]);
+    write_methodology_manifest(&fixture.methodology_dir(), &["intent", "work-unit"]);
+    install_intent_schema(&fixture.methodology_dir(), "2.0.0");
     install_work_unit_schema(&fixture.methodology_dir());
     let image = fixture.build_image();
 
@@ -320,12 +327,12 @@ fn executes_work_mode_against_injected_work_unit_artifact() {
         SessionInvocation {
             repo_url: fixture.repo_url(),
             repo_token: None,
-            work_unit: Some("issue-76".to_string()),
+            work_unit: Some("76".to_string()),
             input: Some(InvocationInput::Artifact {
                 artifact_type: "work-unit".to_string(),
-                artifact_id: "issue-76".to_string(),
+                artifact_id: "76".to_string(),
                 document: serde_json::json!({
-                    "id": "issue-76",
+                    "id": "76",
                     "title": "Execute work mode",
                 }),
             }),
@@ -340,12 +347,22 @@ fn executes_work_mode_against_injected_work_unit_artifact() {
     assert_eq!(
         fs::read_to_string(record_dir.join("runa/calls.log"))
             .expect("runa call log should persist"),
-        "init --methodology /agentd/methodology/manifest.toml\nrun --work-unit issue-76 --agent-command -- site-builder exec\n"
+        "init --methodology /agentd/methodology/manifest.toml\nrun --agent-command -- site-builder exec\n"
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &fs::read_to_string(record_dir.join("runa/workspace/intent/operator-input.json"))
+                .expect("work-unit reference seed should persist"),
+        )
+        .expect("work-unit reference seed should be valid JSON"),
+        serde_json::json!({
+            "statement": "Work on the referenced work unit.",
+            "source": "operator",
+            "target": "76",
+        })
     );
     assert!(
-        record_dir
-            .join("runa/workspace/work-unit/issue-76.json")
-            .exists(),
+        record_dir.join("runa/workspace/work-unit/76.json").exists(),
         "injected work-unit artifact should persist"
     );
     for artifact_path in [
@@ -372,7 +389,7 @@ fn executes_work_mode_against_injected_work_unit_artifact() {
             .expect("session metadata should persist"),
     )
     .expect("session metadata should be valid json");
-    assert_eq!(metadata["work_unit"], "issue-76");
+    assert_eq!(metadata["work_unit"], "76");
     assert_eq!(metadata["outcome"], "success");
     assert_eq!(metadata["exit_code"], 0);
 
@@ -447,6 +464,7 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new("mixed-env-run");
+    install_work_unit_seed_methodology(&fixture.methodology_dir());
     let image = fixture.build_image();
 
     let outcome = run_session_with_test_audit_root(
@@ -648,6 +666,7 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
         "comma-methodology-run",
         "agentd-runner,comma,methodology",
     );
+    install_work_unit_seed_methodology(&fixture.methodology_dir());
     let image = fixture.build_image();
 
     let outcome = run_session_with_test_audit_root(
@@ -948,6 +967,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new("audit-success-run");
+    install_work_unit_seed_methodology(&fixture.methodology_dir());
     let image = fixture.build_image();
 
     let outcome = run_session_with_test_audit_root(
@@ -969,7 +989,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
         SessionInvocation {
             repo_url: fixture.repo_url(),
             repo_token: None,
-            work_unit: Some("issue-76".to_string()),
+            work_unit: Some("76".to_string()),
             input: None,
             timeout: None,
         },
@@ -992,7 +1012,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
     assert_eq!(
         fs::read_to_string(record_dir.join("runa/calls.log"))
             .expect("runa call log should persist"),
-        "init --methodology /agentd/methodology/manifest.toml\nrun --work-unit issue-76 --agent-command -- site-builder exec\n"
+        "init --methodology /agentd/methodology/manifest.toml\nrun --agent-command -- site-builder exec\n"
     );
     let runa_config = fs::read_to_string(record_dir.join("runa/config.toml"))
         .expect("runa config should persist");
@@ -1008,7 +1028,7 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
     .expect("session metadata should be valid json");
     assert_eq!(metadata["agent"], "audit-success-run");
     assert_eq!(metadata["repo_url"], fixture.repo_url());
-    assert_eq!(metadata["work_unit"], "issue-76");
+    assert_eq!(metadata["work_unit"], "76");
     assert_eq!(metadata["outcome"], "success");
     assert_eq!(metadata["exit_code"], 0);
     assert!(metadata["start_timestamp"].is_string());
@@ -1268,6 +1288,7 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new("audit-restrictive-modes-run");
+    install_work_unit_seed_methodology(&fixture.methodology_dir());
     let image = fixture.build_image();
 
     let outcome = run_session_with_test_audit_root(
@@ -1289,7 +1310,7 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
         SessionInvocation {
             repo_url: fixture.repo_url(),
             repo_token: None,
-            work_unit: Some("issue-76".to_string()),
+            work_unit: Some("76".to_string()),
             input: None,
             timeout: None,
         },
@@ -1447,6 +1468,7 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
         .expect("podman test lock should be acquired");
 
     let fixture = SessionFixture::new("audit-failure-run");
+    install_work_unit_seed_methodology(&fixture.methodology_dir());
     let image = fixture.build_image();
 
     let outcome = run_session_with_test_audit_root(
@@ -1468,7 +1490,7 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
         SessionInvocation {
             repo_url: fixture.repo_url(),
             repo_token: None,
-            work_unit: Some("issue-76".to_string()),
+            work_unit: Some("76".to_string()),
             input: None,
             timeout: None,
         },
@@ -2684,9 +2706,9 @@ case "$command_name" in
         fi
 
         if [ "${SESSION_TEST_BEHAVIOR:-}" = "execute-work-mode-cascade" ]; then
-            [ "${AGENTD_WORK_UNIT:-}" = "issue-76" ]
-            [ -f "${HOME}/repo/.runa/workspace/work-unit/issue-76.json" ]
-            grep -F '"id":"issue-76"' "${HOME}/repo/.runa/workspace/work-unit/issue-76.json"
+            [ "${AGENTD_WORK_UNIT:-}" = "76" ]
+            [ -f "${HOME}/repo/.runa/workspace/work-unit/76.json" ]
+            grep -F '"id":"76"' "${HOME}/repo/.runa/workspace/work-unit/76.json"
             mkdir -p \
                 "${HOME}/repo/.runa/workspace/behavior-contract" \
                 "${HOME}/repo/.runa/workspace/implementation-plan" \

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -273,11 +273,10 @@ fn run_wish_client(
     repo: Option<String>,
     work_unit: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Work-unit arm: an operator naming an existing work-unit seeds the
-    // session with it as a work-unit, reaching the same downstream entry
-    // `agentd run --work-unit` reaches. Prose elicitation is skipped
-    // entirely, so a single wish invocation can never carry both a prose
-    // intent and a work-unit reference.
+    // Work-unit arm: an operator naming an existing work-unit reference
+    // reaches the same downstream entry as `agentd run --work-unit`. Prose
+    // elicitation is skipped entirely, so a single wish invocation can never
+    // carry both a prose intent and a work-unit reference.
     if let Some(work_unit) = work_unit {
         return run_client_with_input(explicit_socket_path, agent, repo, Some(work_unit), None);
     }

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -735,7 +735,7 @@ fn binary_run_command_rejects_intent_when_work_unit_is_also_supplied() {
             "site-builder",
             "https://example.com/repo.git",
             "--work-unit",
-            "issue-81",
+            "81",
             "--intent",
             "Add a status page",
         ])
@@ -1106,12 +1106,9 @@ fn binary_run_command_forwards_work_unit_with_matching_artifact_file() {
         "client-command-work-unit-artifact-input",
         &daemon_test_config(&socket_path, &pid_file),
     );
-    let artifact_path = runtime_dir.join("issue-76.json");
-    std::fs::write(
-        &artifact_path,
-        r#"{"id":"issue-76","title":"Execute work mode"}"#,
-    )
-    .expect("artifact file should be written");
+    let artifact_path = runtime_dir.join("76.json");
+    std::fs::write(&artifact_path, r#"{"id":"76","title":"Execute work mode"}"#)
+        .expect("artifact file should be written");
     let (shutdown, handle, _config, invocations) =
         start_recording_test_daemon(&config_path, SessionOutcome::Success { exit_code: 0 });
 
@@ -1123,7 +1120,7 @@ fn binary_run_command_forwards_work_unit_with_matching_artifact_file() {
             "site-builder",
             "https://example.com/repo.git",
             "--work-unit",
-            "issue-76",
+            "76",
             "--artifact-type",
             "work-unit",
             "--artifact-file",
@@ -1147,14 +1144,14 @@ fn binary_run_command_forwards_work_unit_with_matching_artifact_file() {
     );
 
     let invocation = invocations.lock().expect("invocations should lock")[0].clone();
-    assert_eq!(invocation.work_unit.as_deref(), Some("issue-76"));
+    assert_eq!(invocation.work_unit.as_deref(), Some("76"));
     assert_eq!(
         invocation.input,
         Some(InvocationInput::Artifact {
             artifact_type: "work-unit".to_string(),
-            artifact_id: "issue-76".to_string(),
+            artifact_id: "76".to_string(),
             document: json!({
-                "id": "issue-76",
+                "id": "76",
                 "title": "Execute work mode",
             }),
         })
@@ -1648,7 +1645,7 @@ fn binary_wish_command_seeds_work_unit_arm_and_skips_prose_elicitation() {
             "site-builder",
             "https://example.com/repo.git",
             "--work-unit",
-            "issue-81",
+            "81",
         ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -1678,13 +1675,13 @@ fn binary_wish_command_seeds_work_unit_arm_and_skips_prose_elicitation() {
     let invocation = invocations.lock().expect("invocations should lock")[0].clone();
     assert_eq!(
         invocation.work_unit.as_deref(),
-        Some("issue-81"),
+        Some("81"),
         "wish work-unit arm should enter the reference as a work-unit"
     );
     assert_eq!(
         invocation.input, None,
-        "wish work-unit arm should reach the same downstream shape as `run --work-unit`: \
-         a work-unit with no invocation input"
+        "wish work-unit arm should reach the same downstream request shape as `run --work-unit`: \
+         a work-unit reference with no explicit invocation input"
     );
 }
 

--- a/crates/agentd/tests/daemon_socket_interface.rs
+++ b/crates/agentd/tests/daemon_socket_interface.rs
@@ -421,11 +421,11 @@ fn daemon_round_trips_work_unit_artifact_input_through_the_socket_protocol() {
         &RunRequest {
             agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
-            work_unit: Some("issue-76".to_string()),
+            work_unit: Some("76".to_string()),
             input: Some(InvocationInput::Artifact {
                 artifact_type: "work-unit".to_string(),
-                artifact_id: "issue-76".to_string(),
-                document: json!({ "id": "issue-76" }),
+                artifact_id: "76".to_string(),
+                document: json!({ "id": "76" }),
             }),
         },
     )
@@ -433,13 +433,13 @@ fn daemon_round_trips_work_unit_artifact_input_through_the_socket_protocol() {
 
     assert_eq!(outcome, SessionOutcome::Success { exit_code: 0 });
     let invocation = invocations.lock().expect("invocations should lock")[0].clone();
-    assert_eq!(invocation.work_unit.as_deref(), Some("issue-76"));
+    assert_eq!(invocation.work_unit.as_deref(), Some("76"));
     assert_eq!(
         invocation.input,
         Some(InvocationInput::Artifact {
             artifact_type: "work-unit".to_string(),
-            artifact_id: "issue-76".to_string(),
-            document: json!({ "id": "issue-76" }),
+            artifact_id: "76".to_string(),
+            document: json!({ "id": "76" }),
         })
     );
 
@@ -476,7 +476,7 @@ fn daemon_rejects_conflicting_work_unit_and_input_from_socket_callers() {
         &RunRequest {
             agent: "site-builder".to_string(),
             repo_url: Some("https://example.com/repo.git".to_string()),
-            work_unit: Some("issue-42".to_string()),
+            work_unit: Some("42".to_string()),
             input: Some(InvocationInput::IntentText {
                 statement: "Add a status page".to_string(),
                 target: None,

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -47,7 +47,7 @@ materialized intent artifact. `agentd wish` can populate it from the optional
 target prompt; `agentd run --intent` has no target flag.
 
 ```json
-{"Artifact": {"artifact_type": "work-unit", "artifact_id": "issue-42", "document": { "...": "..." }}}
+{"Artifact": {"artifact_type": "work-unit", "artifact_id": "42", "document": { "...": "..." }}}
 ```
 
 `IntentText` is synthesized into a canonical intent artifact


### PR DESCRIPTION
## Summary

- Route `agentd run --work-unit` / `agentd wish --work-unit` through runa's resolving entry by materializing a target-bearing intent seed.
- Keep `AGENTD_WORK_UNIT` and agentd audit metadata as the operator-supplied reference while invoking unscoped `runa run --agent-command -- ...`.
- Update runner coverage, integration fixture expectations, README, architecture docs, and changelog for the new entry path.

## Why

agentd previously emitted `runa run --work-unit <id>`, which entered runa's pre-bound path and bypassed runa's reference-resolution vocabulary. This keeps resolution single-homed in runa while making unresolved work-unit references fail closed before scoped work begins.

Closes #175.

## Verification

- `cargo build`
- `cargo test`
- `cargo clippy --all-targets`
- `cargo fmt --check`
