### PR TITLE
docs(cli): make command help self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Root, `daemon`, `run`, and `wish` `--help` now state each command's effect,
+  when to choose it, the purpose of every argument and option, and canonical
+  examples for non-obvious invocation modes. These command-local surfaces are
+  the authoritative invocation contract for operators and scripts.
+
 - `agentd run --work-unit` and `agentd wish --work-unit` now route the
   operator-supplied reference through runa's resolving entry by materializing a
   target-bearing intent seed and invoking unscoped `runa run`, instead of

--- a/crates/agentd/src/cli.rs
+++ b/crates/agentd/src/cli.rs
@@ -1,0 +1,243 @@
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+use crate::LiveObservationLevel;
+
+pub const WISH_GREETING: &str = "Speak a wish: the state you want made true.";
+pub const WISH_STATEMENT_PROMPT: &str = "What do you wish to be true?";
+pub const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank if it has no target.";
+pub const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
+
+const ROOT_ABOUT: &str = "Run the agentd service or submit agent sessions through it.";
+const DAEMON_ABOUT: &str = "Run the foreground service that accepts and supervises agent sessions.";
+const DAEMON_LONG_ABOUT: &str = "Run the foreground service that accepts manual and scheduled session requests over its control socket and supervises their containerized agent sessions.\n\nStart daemon before using run or wish. Use run or wish to submit work to an already-running daemon.";
+const RUN_ABOUT: &str = "Submit one manual session request with explicitly supplied input.";
+const RUN_LONG_ABOUT: &str = "Submit one manual session request with explicitly supplied input to the running agentd daemon.\n\nUse run when the session input is already prepared. Use wish to elicit a desired state interactively, or daemon to start the service that accepts requests.";
+const WISH_ABOUT: &str =
+    "Elicit a desired state and seed one agent session through the running daemon.";
+const WISH_LONG_ABOUT: &str = "Interactively elicit the state the operator wants made true and an optional target, or accept an existing tracker work-unit reference, then ask the running daemon to seed one agent session. Prose input is validated as a canonical intent against the active methodology's intent schema.\n\nUse wish for guided desired-state entry. Use run when invocation input is already prepared, or daemon to start the service that accepts requests.";
+const AGENT_HELP: &str = "Select an agent declared under this name in the daemon configuration";
+const REPO_HELP: &str = "Clone this Git repository for the session; when omitted, use the selected agent's daemon-configured repository";
+const SOCKET_PATH_HELP: &str =
+    "Send the request through this control socket instead of $XDG_RUNTIME_DIR/agentd/agentd.sock";
+const PROGRESS_HELP: &str =
+    "Choose how much live transcript activity to print while the session runs";
+
+pub const ROOT_EXAMPLES: &[&[&str]] = &[&["agentd"], &["agentd", "--config", "<PATH>"]];
+pub const DAEMON_EXAMPLES: &[&[&str]] = &[
+    &["agentd", "daemon"],
+    &["agentd", "daemon", "--config", "<PATH>"],
+];
+pub const RUN_EXAMPLES: &[&[&str]] = &[
+    &["agentd", "run", "<AGENT>", "[REPO]"],
+    &[
+        "agentd",
+        "run",
+        "<AGENT>",
+        "[REPO]",
+        "--intent",
+        "<STATEMENT>",
+    ],
+    &[
+        "agentd",
+        "run",
+        "<AGENT>",
+        "[REPO]",
+        "--work-unit",
+        "<REFERENCE>",
+    ],
+    &[
+        "agentd",
+        "run",
+        "<AGENT>",
+        "[REPO]",
+        "--artifact-type",
+        "<TYPE>",
+        "--artifact-file",
+        "<ID>.json",
+    ],
+    &[
+        "agentd",
+        "run",
+        "<AGENT>",
+        "[REPO]",
+        "--work-unit",
+        "<REFERENCE>",
+        "--artifact-type",
+        "work-unit",
+        "--artifact-file",
+        "<ID>.json",
+    ],
+];
+pub const WISH_EXAMPLES: &[&[&str]] = &[
+    &["agentd", "wish", "<AGENT>", "[REPO]"],
+    &[
+        "agentd",
+        "wish",
+        "<AGENT>",
+        "[REPO]",
+        "--work-unit",
+        "<REFERENCE>",
+    ],
+];
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ProgressLevel {
+    /// Print compact live transcript activity.
+    Summary,
+    /// Print raw live transcript event detail.
+    Full,
+}
+
+impl From<ProgressLevel> for LiveObservationLevel {
+    fn from(level: ProgressLevel) -> Self {
+        match level {
+            ProgressLevel::Summary => Self::Summary,
+            ProgressLevel::Full => Self::Full,
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "agentd",
+    version,
+    propagate_version = true,
+    about = ROOT_ABOUT,
+    long_about = root_long_about(),
+    after_help = examples_after_help(ROOT_EXAMPLES)
+)]
+pub struct Cli {
+    #[arg(long, help = root_config_help())]
+    pub config: Option<PathBuf>,
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Args, Debug, Default)]
+pub struct DaemonArgs {
+    #[arg(long, help = daemon_config_help())]
+    pub config: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    #[command(
+        about = DAEMON_ABOUT,
+        long_about = DAEMON_LONG_ABOUT,
+        after_help = examples_after_help(DAEMON_EXAMPLES)
+    )]
+    Daemon(DaemonArgs),
+    #[command(
+        display_name = "agentd",
+        about = RUN_ABOUT,
+        long_about = RUN_LONG_ABOUT,
+        after_help = run_after_help()
+    )]
+    Run {
+        #[arg(help = AGENT_HELP)]
+        agent: String,
+        #[arg(help = REPO_HELP)]
+        repo: Option<String>,
+        #[arg(long, help = SOCKET_PATH_HELP)]
+        socket_path: Option<PathBuf>,
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = ProgressLevel::Summary,
+            help = PROGRESS_HELP
+        )]
+        progress: ProgressLevel,
+        #[arg(
+            long,
+            conflicts_with = "intent",
+            help = "Seed the session from this tracker work-unit reference through runa; conflicts with --intent"
+        )]
+        work_unit: Option<String>,
+        #[arg(
+            long,
+            conflicts_with_all = ["work_unit", "artifact_file"],
+            help = "Synthesize this prose statement into a canonical intent artifact; the active methodology must declare a compatible intent schema"
+        )]
+        intent: Option<String>,
+        #[arg(
+            long,
+            requires = "artifact_type",
+            conflicts_with = "intent",
+            help = "Supply this complete JSON artifact document as invocation input; its file stem becomes the artifact ID and --artifact-type is required"
+        )]
+        artifact_file: Option<PathBuf>,
+        #[arg(
+            long,
+            requires = "artifact_file",
+            help = "Declare the active methodology's artifact type for --artifact-file; --artifact-file is required"
+        )]
+        artifact_type: Option<String>,
+    },
+    #[command(
+        display_name = "agentd",
+        about = WISH_ABOUT,
+        long_about = WISH_LONG_ABOUT,
+        after_help = wish_after_help()
+    )]
+    Wish {
+        #[arg(help = AGENT_HELP)]
+        agent: String,
+        #[arg(help = REPO_HELP)]
+        repo: Option<String>,
+        #[arg(long, help = SOCKET_PATH_HELP)]
+        socket_path: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "Seed from this existing tracker work-unit reference instead of eliciting prose; runa resolves it before scoped work begins"
+        )]
+        work_unit: Option<String>,
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = ProgressLevel::Summary,
+            help = PROGRESS_HELP
+        )]
+        progress: ProgressLevel,
+    },
+}
+
+fn root_long_about() -> String {
+    format!(
+        "Run the agentd service or submit agent sessions through it.\n\nWith no subcommand, agentd starts the foreground daemon using {DEFAULT_CONFIG_PATH}. Use daemon to make service startup explicit, run to submit prepared session input, or wish to elicit a desired state interactively."
+    )
+}
+
+fn root_config_help() -> String {
+    format!(
+        "Load daemon configuration from this path when agentd starts in daemon mode [default: {DEFAULT_CONFIG_PATH}]"
+    )
+}
+
+fn daemon_config_help() -> String {
+    format!("Load daemon configuration from this path [default: {DEFAULT_CONFIG_PATH}]")
+}
+
+fn examples_after_help(examples: &[&[&str]]) -> String {
+    let examples = examples
+        .iter()
+        .map(|example| format!("  {}", example.join(" ")))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("Examples:\n{examples}")
+}
+
+fn run_after_help() -> String {
+    format!(
+        "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\n{}",
+        examples_after_help(RUN_EXAMPLES)
+    )
+}
+
+fn wish_after_help() -> String {
+    format!(
+        "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\n{}",
+        examples_after_help(WISH_EXAMPLES)
+    )
+}

--- a/crates/agentd/src/lib.rs
+++ b/crates/agentd/src/lib.rs
@@ -5,6 +5,7 @@
 //! configuration and starts the daemon.
 
 mod audit_root;
+pub mod cli;
 pub mod config;
 pub mod daemon;
 pub mod dispatch;

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -5,37 +5,18 @@ use std::sync::atomic::AtomicBool;
 use std::{error::Error, fmt};
 use std::{io::BufRead, io::Write};
 
+use agentd::cli::{
+    Cli, Command, DEFAULT_CONFIG_PATH, ProgressLevel, WISH_GREETING, WISH_STATEMENT_PROMPT,
+    WISH_TARGET_PROMPT,
+};
 use agentd::config::Config;
 use agentd::{
-    LiveObservationLevel, RunRequest, RunnerSessionExecutor, configure_tracing,
-    request_run_with_live_observation, resolve_client_socket_path, run_daemon_until_shutdown,
+    RunRequest, RunnerSessionExecutor, configure_tracing, request_run_with_live_observation,
+    resolve_client_socket_path, run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::Parser;
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
-
-const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
-const WISH_GREETING: &str = "Speak a wish: the state you want made true.";
-const WISH_STATEMENT_PROMPT: &str = "What do you wish to be true?";
-const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank if it has no target.";
-const WISH_ABOUT: &str = "Elicit a wish and seed one governed session.";
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum ProgressLevel {
-    /// Print compact live transcript activity.
-    Summary,
-    /// Print raw live transcript event detail.
-    Full,
-}
-
-impl From<ProgressLevel> for LiveObservationLevel {
-    fn from(level: ProgressLevel) -> Self {
-        match level {
-            ProgressLevel::Summary => Self::Summary,
-            ProgressLevel::Full => Self::Full,
-        }
-    }
-}
 
 struct RunClientArgs {
     agent: String,
@@ -122,63 +103,6 @@ impl fmt::Display for RunCommandError {
 
 impl Error for RunCommandError {}
 
-#[derive(Parser, Debug)]
-#[command(name = "agentd", version, propagate_version = true)]
-struct Cli {
-    #[arg(long)]
-    config: Option<PathBuf>,
-    #[command(subcommand)]
-    command: Option<Command>,
-}
-
-#[derive(Args, Debug, Default)]
-struct DaemonArgs {
-    #[arg(long)]
-    config: Option<PathBuf>,
-}
-
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// Start the foreground daemon.
-    Daemon(DaemonArgs),
-    /// Trigger a manual session through the running daemon.
-    #[command(
-        display_name = "agentd",
-        after_help = "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
-    )]
-    Run {
-        agent: String,
-        repo: Option<String>,
-        #[arg(long)]
-        socket_path: Option<PathBuf>,
-        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
-        progress: ProgressLevel,
-        #[arg(long, conflicts_with = "intent")]
-        work_unit: Option<String>,
-        #[arg(long, conflicts_with_all = ["work_unit", "artifact_file"])]
-        intent: Option<String>,
-        #[arg(long, requires = "artifact_type", conflicts_with = "intent")]
-        artifact_file: Option<PathBuf>,
-        #[arg(long, requires = "artifact_file")]
-        artifact_type: Option<String>,
-    },
-    #[command(
-        display_name = "agentd",
-        about = WISH_ABOUT,
-        after_help = wish_after_help()
-    )]
-    Wish {
-        agent: String,
-        repo: Option<String>,
-        #[arg(long)]
-        socket_path: Option<PathBuf>,
-        #[arg(long)]
-        work_unit: Option<String>,
-        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
-        progress: ProgressLevel,
-    },
-}
-
 fn main() -> ExitCode {
     if let Err(error) = configure_tracing() {
         eprintln!("failed to initialize tracing: {error}");
@@ -192,12 +116,6 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
-}
-
-fn wish_after_help() -> String {
-    format!(
-        "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\nOr seed the session from an existing work-unit instead of prose:\n  agentd wish <AGENT> [REPO] --work-unit <ID>"
-    )
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -15,6 +15,7 @@ use agentd_runner::{
     InvocationInput, RunnerError, SessionInvocation, SessionOutcome, SessionProgressObserver,
     SessionSpec, StartupReconciliationReport,
 };
+use clap::{CommandFactory as _, Parser as _};
 use serde_json::json;
 
 type DaemonHandle = thread::JoinHandle<Result<(), agentd::DaemonError>>;
@@ -273,6 +274,53 @@ fn start_recording_test_daemon(
     (shutdown, handle, config, invocations)
 }
 
+fn assert_complete_help(command: &clap::Command) {
+    let about = command
+        .get_about()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    assert!(
+        !about.trim().is_empty(),
+        "{} must state what it does and when to use it",
+        command.get_name()
+    );
+
+    for argument in command.get_arguments() {
+        let help = argument
+            .get_help()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            !help.trim().is_empty(),
+            "{} input {} must state its purpose",
+            command.get_name(),
+            argument.get_id()
+        );
+    }
+
+    for subcommand in command.get_subcommands() {
+        assert_complete_help(subcommand);
+    }
+}
+
+#[test]
+fn command_help_structurally_explains_every_surface_and_examples_parse() {
+    let command = agentd::cli::Cli::command();
+    assert_complete_help(&command);
+
+    let examples = [
+        agentd::cli::ROOT_EXAMPLES,
+        agentd::cli::DAEMON_EXAMPLES,
+        agentd::cli::RUN_EXAMPLES,
+        agentd::cli::WISH_EXAMPLES,
+    ];
+
+    for example in examples.into_iter().flatten() {
+        agentd::cli::Cli::try_parse_from(*example)
+            .unwrap_or_else(|error| panic!("example {example:?} must parse: {error}"));
+    }
+}
+
 #[test]
 fn binary_top_level_version_reports_crate_version() {
     let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
@@ -408,120 +456,202 @@ fn binary_bare_command_with_config_starts_daemon_mode() {
     );
 }
 
-#[test]
-fn binary_run_help_shows_socket_path_and_not_config() {
+fn assert_help(args: &[&str], expected: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["run", "--help"])
+        .args(args)
         .output()
         .expect("agentd binary should run");
 
     assert!(
         output.status.success(),
-        "run help should exit successfully: {}",
+        "help {args:?} should exit successfully: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--socket-path"),
-        "run help should advertise socket override: {stdout}"
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be valid UTF-8"),
+        ""
     );
-    assert!(
-        stdout.contains("--progress <PROGRESS>")
-            && stdout.contains("summary")
-            && stdout.contains("full"),
-        "run help should document live progress verbosity: {stdout}"
-    );
-    assert!(
-        stdout.contains(
-            "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail."
-        ),
-        "run help should describe summary and full transcript rendering: {stdout}"
-    );
-    assert!(
-        !stdout.contains("--config"),
-        "run help should not advertise daemon config coupling: {stdout}"
-    );
-    assert!(
-        stdout.contains("--work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"),
-        "run help should document work-mode artifact invocation: {stdout}"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        expected
     );
 }
 
+const ROOT_HELP: &str = r#"Run the agentd service or submit agent sessions through it.
+
+With no subcommand, agentd starts the foreground daemon using /etc/agentd/agentd.toml. Use daemon to make service startup explicit, run to submit prepared session input, or wish to elicit a desired state interactively.
+
+Usage: agentd [OPTIONS] [COMMAND]
+
+Commands:
+  daemon  Run the foreground service that accepts and supervises agent sessions.
+  run     Submit one manual session request with explicitly supplied input.
+  wish    Elicit a desired state and seed one agent session through the running daemon.
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --config <CONFIG>
+          Load daemon configuration from this path when agentd starts in daemon mode [default: /etc/agentd/agentd.toml]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Examples:
+  agentd
+  agentd --config <PATH>
+"#;
+
 #[test]
-fn binary_top_level_help_shows_wish_operator_verb() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .arg("--help")
-        .output()
-        .expect("agentd binary should run");
-
-    assert!(
-        output.status.success(),
-        "help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("wish"),
-        "top-level help should advertise the wish operator verb: {stdout}"
-    );
+fn binary_root_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["--help"], ROOT_HELP);
 }
 
+const DAEMON_HELP: &str = r#"Run the foreground service that accepts manual and scheduled session requests over its control socket and supervises their containerized agent sessions.
+
+Start daemon before using run or wish. Use run or wish to submit work to an already-running daemon.
+
+Usage: agentd daemon [OPTIONS]
+
+Options:
+      --config <CONFIG>
+          Load daemon configuration from this path [default: /etc/agentd/agentd.toml]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Examples:
+  agentd daemon
+  agentd daemon --config <PATH>
+"#;
+
 #[test]
-fn binary_wish_help_shows_evocative_intent_prompting_surface() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["wish", "--help"])
-        .output()
-        .expect("agentd binary should run");
-
-    assert!(
-        output.status.success(),
-        "wish help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--socket-path"),
-        "wish help should advertise socket override: {stdout}"
-    );
-    assert!(
-        stdout.contains("Elicit a wish and seed one governed session."),
-        "wish help should describe the wish session boundary exactly: {stdout}"
-    );
-    assert!(
-        stdout.contains("--progress <PROGRESS>")
-            && stdout.contains("summary")
-            && stdout.contains("full"),
-        "wish help should document live progress verbosity: {stdout}"
-    );
-    assert!(
-        stdout.contains(
-            "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
-        ),
-        "wish help should document the exact prompt block: {stdout}"
-    );
+fn binary_daemon_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["daemon", "--help"], DAEMON_HELP);
 }
 
+const RUN_HELP: &str = concat!(
+    r#"Submit one manual session request with explicitly supplied input to the running agentd daemon.
+
+Use run when the session input is already prepared. Use wish to elicit a desired state interactively, or daemon to start the service that accepts requests.
+
+Usage: agentd run [OPTIONS] <AGENT> [REPO]
+
+Arguments:
+  <AGENT>
+          Select an agent declared under this name in the daemon configuration
+
+  [REPO]
+          Clone this Git repository for the session; when omitted, use the selected agent's daemon-configured repository
+
+Options:
+      --socket-path <SOCKET_PATH>
+          Send the request through this control socket instead of $XDG_RUNTIME_DIR/agentd/agentd.sock
+
+      --progress <PROGRESS>
+          Choose how much live transcript activity to print while the session runs
+
+          Possible values:
+          - summary: Print compact live transcript activity
+          - full:    Print raw live transcript event detail
+"#,
+    "          \n",
+    r#"          [default: summary]
+
+      --work-unit <WORK_UNIT>
+          Seed the session from this tracker work-unit reference through runa; conflicts with --intent
+
+      --intent <INTENT>
+          Synthesize this prose statement into a canonical intent artifact; the active methodology must declare a compatible intent schema
+
+      --artifact-file <ARTIFACT_FILE>
+          Supply this complete JSON artifact document as invocation input; its file stem becomes the artifact ID and --artifact-type is required
+
+      --artifact-type <ARTIFACT_TYPE>
+          Declare the active methodology's artifact type for --artifact-file; --artifact-file is required
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Live observation:
+  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.
+
+Examples:
+  agentd run <AGENT> [REPO]
+  agentd run <AGENT> [REPO] --intent <STATEMENT>
+  agentd run <AGENT> [REPO] --work-unit <REFERENCE>
+  agentd run <AGENT> [REPO] --artifact-type <TYPE> --artifact-file <ID>.json
+  agentd run <AGENT> [REPO] --work-unit <REFERENCE> --artifact-type work-unit --artifact-file <ID>.json
+"#
+);
+
 #[test]
-fn binary_daemon_help_shows_config() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["daemon", "--help"])
-        .output()
-        .expect("agentd binary should run");
+fn binary_run_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["run", "--help"], RUN_HELP);
+}
 
-    assert!(
-        output.status.success(),
-        "daemon help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+const WISH_HELP: &str = concat!(
+    r#"Interactively elicit the state the operator wants made true and an optional target, or accept an existing tracker work-unit reference, then ask the running daemon to seed one agent session. Prose input is validated as a canonical intent against the active methodology's intent schema.
 
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--config"),
-        "daemon help should retain config loading: {stdout}"
-    );
+Use wish for guided desired-state entry. Use run when invocation input is already prepared, or daemon to start the service that accepts requests.
+
+Usage: agentd wish [OPTIONS] <AGENT> [REPO]
+
+Arguments:
+  <AGENT>
+          Select an agent declared under this name in the daemon configuration
+
+  [REPO]
+          Clone this Git repository for the session; when omitted, use the selected agent's daemon-configured repository
+
+Options:
+      --socket-path <SOCKET_PATH>
+          Send the request through this control socket instead of $XDG_RUNTIME_DIR/agentd/agentd.sock
+
+      --work-unit <WORK_UNIT>
+          Seed from this existing tracker work-unit reference instead of eliciting prose; runa resolves it before scoped work begins
+
+      --progress <PROGRESS>
+          Choose how much live transcript activity to print while the session runs
+
+          Possible values:
+          - summary: Print compact live transcript activity
+          - full:    Print raw live transcript event detail
+"#,
+    "          \n",
+    r#"          [default: summary]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Live observation:
+  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.
+
+Prompts:
+  Speak a wish: the state you want made true.
+  What do you wish to be true?
+  What is this wish aimed at? Leave blank if it has no target.
+
+Examples:
+  agentd wish <AGENT> [REPO]
+  agentd wish <AGENT> [REPO] --work-unit <REFERENCE>
+"#
+);
+
+#[test]
+fn binary_wish_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["wish", "--help"], WISH_HELP);
 }
 
 #[test]
@@ -1699,32 +1829,5 @@ fn binary_wish_command_seeds_work_unit_arm_and_skips_prose_elicitation() {
         invocation.input, None,
         "wish work-unit arm should reach the same downstream request shape as `run --work-unit`: \
          a work-unit reference with no explicit invocation input"
-    );
-}
-
-#[test]
-fn binary_wish_help_advertises_work_unit_arm() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["wish", "--help"])
-        .output()
-        .expect("agentd binary should run");
-
-    assert!(
-        output.status.success(),
-        "wish help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--work-unit"),
-        "wish help should advertise the work-unit arm: {stdout}"
-    );
-    // The prose prompt surface remains documented unchanged.
-    assert!(
-        stdout.contains(
-            "Prompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
-        ),
-        "wish help should retain the exact prose prompt block: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

- make the root, `daemon`, `run`, and `wish` help surfaces explain each command's effect, when to choose it, and how to invoke it
- give every positional argument and option purpose-stating help, with canonical examples derived from parse-tested argument tables
- move the Clap command tree into an introspectable library module and pin all four rendered help surfaces byte-for-byte
- preserve the existing CLI grammar and desired-state wish prompts
- record the operator-visible help contract in the changelog

## Why

The existing help surfaces named commands but left key arguments and options undescribed. Operators meeting agentd at `--help` could not determine the command-selection boundary or construct non-obvious invocation modes without consulting narrative documentation or source.

This change applies the invocation-surface transmission standard to the complete agentd command-help set. README, architecture, quickstart, environment/socket documentation, examples, and runbooks were audited and remain aligned with the shipped grammar.

## Impact

Operators and automation authors can now use each command-local help surface as the authoritative invocation contract. Runtime behavior, argument relationships, and the wish prompt flow are unchanged.

## Validation

- `cargo build`
- `cargo test`
- `cargo clippy --all-targets`
- `cargo fmt --check`
- `git diff --check`
- exact-output pin sensitivity confirmed with a deliberate one-character mismatch

Closes #172
