### PR TITLE
docs(cli): make command help self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Root, `daemon`, `run`, and `wish` command-local help now states each
+  command's effect and selection boundary, the purpose of every input, the
+  unseeded and supplied `run` modes, supported remote repository URL forms,
+  and the matching work-unit/artifact identity required by combined work mode.
+
 - `agentd run --work-unit` and `agentd wish --work-unit` now route the
   operator-supplied reference through runa's resolving entry by materializing a
   target-bearing intent seed and invoking unscoped `runa run`, instead of

--- a/crates/agentd/src/cli.rs
+++ b/crates/agentd/src/cli.rs
@@ -1,0 +1,299 @@
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+pub(super) const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
+pub(super) const WISH_GREETING: &str = "Speak a wish: the state you want made true.";
+pub(super) const WISH_STATEMENT_PROMPT: &str = "What do you wish to be true?";
+pub(super) const WISH_TARGET_PROMPT: &str =
+    "What is this wish aimed at? Leave blank if it has no target.";
+
+const ROOT_ABOUT: &str = "Run the agentd service or submit agent sessions through it.";
+const DAEMON_ABOUT: &str =
+    "Start the foreground service that accepts and supervises agent sessions";
+const DAEMON_LONG_ABOUT: &str = "Run the foreground agentd service that accepts manual and scheduled session requests over its control socket and supervises their execution.\n\nUse daemon to start the service. Use run for direct manual submission or wish for guided desired-state entry after the service is running.";
+const RUN_ABOUT: &str = "Submit one manual session request, with optional invocation input";
+const RUN_LONG_ABOUT: &str = "Submit one manual session request to an already-running agentd daemon.\n\nInvocation input may be omitted for an unseeded session or supplied as a work-unit reference, a prose intent statement, a complete artifact document, or a matching work-unit reference and work-unit artifact. Use run for direct manual submission; use wish for guided desired-state entry or daemon to start the service.";
+const WISH_ABOUT: &str =
+    "Elicit a desired state or select a work unit, then seed one agent session";
+const WISH_LONG_ABOUT: &str = "Interactively elicit the state the operator wants made true and an optional target, validate the resulting canonical intent for the active methodology, and ask the running daemon to seed one agent session. With --work-unit, bypass prose elicitation and seed from the named tracker work unit.\n\nUse wish for guided desired-state entry. Use run for direct manual submission or daemon to start the service.";
+const AGENT_HELP: &str = "Select an agent declared under this name in the daemon configuration";
+const REPO_HELP: &str = "Use the selected agent's daemon-configured repository when omitted; otherwise clone a remote https://, http://, git://, ssh://, or user@host:path URL; local paths, credential-bearing URLs, queries, and fragments are rejected";
+const SOCKET_PATH_HELP: &str = "Connect through this daemon control socket instead of resolving $XDG_RUNTIME_DIR/agentd/agentd.sock";
+const PROGRESS_HELP: &str =
+    "Choose how much live transcript activity to print while the session runs";
+
+const ROOT_EXAMPLES: &[&[&str]] = &[&["agentd"], &["agentd", "--config", "<PATH>"]];
+const DAEMON_EXAMPLES: &[&[&str]] = &[
+    &["agentd", "daemon"],
+    &["agentd", "daemon", "--config", "<PATH>"],
+];
+const RUN_EXAMPLES: &[&[&str]] = &[
+    &["agentd", "run", "<AGENT>"],
+    &["agentd", "run", "<AGENT>", "<REPO>"],
+    &["agentd", "run", "<AGENT>", "--intent", "<STATEMENT>"],
+    &["agentd", "run", "<AGENT>", "--work-unit", "<REFERENCE>"],
+    &[
+        "agentd",
+        "run",
+        "<AGENT>",
+        "--artifact-type",
+        "<TYPE>",
+        "--artifact-file",
+        "<ID>.json",
+    ],
+    &[
+        "agentd",
+        "run",
+        "<AGENT>",
+        "--work-unit",
+        "<REFERENCE>",
+        "--artifact-type",
+        "work-unit",
+        "--artifact-file",
+        "<REFERENCE>.json",
+    ],
+];
+const WISH_EXAMPLES: &[&[&str]] = &[
+    &["agentd", "wish", "<AGENT>"],
+    &["agentd", "wish", "<AGENT>", "<REPO>"],
+    &["agentd", "wish", "<AGENT>", "--work-unit", "<REFERENCE>"],
+];
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(super) enum ProgressLevel {
+    /// Print compact live transcript activity.
+    Summary,
+    /// Print raw live transcript event detail.
+    Full,
+}
+
+impl From<ProgressLevel> for agentd::LiveObservationLevel {
+    fn from(level: ProgressLevel) -> Self {
+        match level {
+            ProgressLevel::Summary => Self::Summary,
+            ProgressLevel::Full => Self::Full,
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "agentd",
+    version,
+    propagate_version = true,
+    about = ROOT_ABOUT,
+    long_about = root_long_about(),
+    after_help = examples_after_help(ROOT_EXAMPLES)
+)]
+pub(super) struct Cli {
+    #[arg(long, help = root_config_help())]
+    pub(super) config: Option<PathBuf>,
+    #[command(subcommand)]
+    pub(super) command: Option<Command>,
+}
+
+#[derive(Args, Debug, Default)]
+pub(super) struct DaemonArgs {
+    #[arg(long, help = daemon_config_help())]
+    pub(super) config: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Debug)]
+pub(super) enum Command {
+    #[command(
+        about = DAEMON_ABOUT,
+        long_about = DAEMON_LONG_ABOUT,
+        after_help = examples_after_help(DAEMON_EXAMPLES)
+    )]
+    Daemon(DaemonArgs),
+    #[command(
+        display_name = "agentd",
+        about = RUN_ABOUT,
+        long_about = RUN_LONG_ABOUT,
+        after_help = run_after_help()
+    )]
+    Run {
+        #[arg(help = AGENT_HELP)]
+        agent: String,
+        #[arg(help = REPO_HELP)]
+        repo: Option<String>,
+        #[arg(long, help = SOCKET_PATH_HELP)]
+        socket_path: Option<PathBuf>,
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = ProgressLevel::Summary,
+            help = PROGRESS_HELP
+        )]
+        progress: ProgressLevel,
+        #[arg(
+            long,
+            conflicts_with = "intent",
+            help = "Seed from this tracker work-unit reference through runa; when combined with an artifact, its type must be work-unit and its file stem must equal this reference; conflicts with --intent"
+        )]
+        work_unit: Option<String>,
+        #[arg(
+            long,
+            conflicts_with_all = ["work_unit", "artifact_file"],
+            help = "Synthesize this prose statement into a canonical intent artifact; the active methodology must declare a compatible intent schema; conflicts with --work-unit and --artifact-file"
+        )]
+        intent: Option<String>,
+        #[arg(
+            long,
+            requires = "artifact_type",
+            conflicts_with = "intent",
+            help = "Supply this complete UTF-8 JSON artifact document; its file stem becomes the artifact id and --artifact-type is required"
+        )]
+        artifact_file: Option<PathBuf>,
+        #[arg(
+            long,
+            requires = "artifact_file",
+            help = "Declare the active methodology's artifact type for --artifact-file; use work-unit when combining with --work-unit"
+        )]
+        artifact_type: Option<String>,
+    },
+    #[command(
+        display_name = "agentd",
+        about = WISH_ABOUT,
+        long_about = WISH_LONG_ABOUT,
+        after_help = wish_after_help()
+    )]
+    Wish {
+        #[arg(help = AGENT_HELP)]
+        agent: String,
+        #[arg(help = REPO_HELP)]
+        repo: Option<String>,
+        #[arg(long, help = SOCKET_PATH_HELP)]
+        socket_path: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "Bypass prose elicitation and seed from this existing tracker work-unit reference through runa"
+        )]
+        work_unit: Option<String>,
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = ProgressLevel::Summary,
+            help = PROGRESS_HELP
+        )]
+        progress: ProgressLevel,
+    },
+}
+
+fn root_long_about() -> String {
+    format!(
+        "Run the agentd service or submit agent sessions through it.\n\nWith no subcommand, agentd starts the foreground daemon using {DEFAULT_CONFIG_PATH}. Use daemon to make service startup explicit, run to submit one manual session request, or wish for guided desired-state entry."
+    )
+}
+
+fn root_config_help() -> String {
+    format!(
+        "Load daemon configuration from this path when starting the service [default: {DEFAULT_CONFIG_PATH}]"
+    )
+}
+
+fn daemon_config_help() -> String {
+    format!("Load daemon configuration from this path [default: {DEFAULT_CONFIG_PATH}]")
+}
+
+fn examples_after_help(examples: &[&[&str]]) -> String {
+    let examples = examples
+        .iter()
+        .map(|example| format!("  {}", example.join(" ")))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("Examples:\n{examples}")
+}
+
+fn run_after_help() -> String {
+    format!(
+        "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\n{}",
+        examples_after_help(RUN_EXAMPLES)
+    )
+}
+
+fn wish_after_help() -> String {
+    format!(
+        "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\n{}",
+        examples_after_help(WISH_EXAMPLES)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory as _;
+
+    fn assert_complete_help(command: &clap::Command) {
+        let about = command
+            .get_about()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            !about.trim().is_empty(),
+            "{} must state what it does and when to use it",
+            command.get_name()
+        );
+
+        for argument in command.get_arguments() {
+            let help = argument
+                .get_help()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            assert!(
+                !help.trim().is_empty(),
+                "{} input {} must state its purpose",
+                command.get_name(),
+                argument.get_id()
+            );
+        }
+
+        for subcommand in command.get_subcommands() {
+            assert_complete_help(subcommand);
+        }
+    }
+
+    #[test]
+    fn command_help_structurally_explains_every_surface() {
+        assert_complete_help(&Cli::command());
+    }
+
+    #[test]
+    fn canonical_help_examples_parse_and_preserve_work_mode_identity() {
+        for example in [ROOT_EXAMPLES, DAEMON_EXAMPLES, RUN_EXAMPLES, WISH_EXAMPLES]
+            .into_iter()
+            .flatten()
+        {
+            Cli::try_parse_from(*example)
+                .unwrap_or_else(|error| panic!("example {example:?} must parse: {error}"));
+        }
+
+        let combined = Cli::try_parse_from(
+            *RUN_EXAMPLES
+                .last()
+                .expect("run examples should include combined work mode"),
+        )
+        .expect("combined work-mode example should parse");
+        let Cli {
+            command:
+                Some(Command::Run {
+                    work_unit: Some(work_unit),
+                    artifact_file: Some(artifact_file),
+                    artifact_type: Some(artifact_type),
+                    ..
+                }),
+            ..
+        } = combined
+        else {
+            panic!("last run example must be combined work mode");
+        };
+
+        assert_eq!(artifact_type, "work-unit");
+        assert_eq!(
+            artifact_file.file_stem().and_then(|stem| stem.to_str()),
+            Some(work_unit.as_str()),
+            "combined work-mode example must use one work-unit identity"
+        );
+    }
+}

--- a/crates/agentd/src/main.rs
+++ b/crates/agentd/src/main.rs
@@ -5,37 +5,20 @@ use std::sync::atomic::AtomicBool;
 use std::{error::Error, fmt};
 use std::{io::BufRead, io::Write};
 
+mod cli;
+
 use agentd::config::Config;
 use agentd::{
-    LiveObservationLevel, RunRequest, RunnerSessionExecutor, configure_tracing,
-    request_run_with_live_observation, resolve_client_socket_path, run_daemon_until_shutdown,
+    RunRequest, RunnerSessionExecutor, configure_tracing, request_run_with_live_observation,
+    resolve_client_socket_path, run_daemon_until_shutdown,
 };
 use agentd_runner::InvocationInput;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::Parser;
+use cli::{
+    Cli, Command, DEFAULT_CONFIG_PATH, ProgressLevel, WISH_GREETING, WISH_STATEMENT_PROMPT,
+    WISH_TARGET_PROMPT,
+};
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
-
-const DEFAULT_CONFIG_PATH: &str = "/etc/agentd/agentd.toml";
-const WISH_GREETING: &str = "Speak a wish: the state you want made true.";
-const WISH_STATEMENT_PROMPT: &str = "What do you wish to be true?";
-const WISH_TARGET_PROMPT: &str = "What is this wish aimed at? Leave blank if it has no target.";
-const WISH_ABOUT: &str = "Elicit a wish and seed one governed session.";
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum ProgressLevel {
-    /// Print compact live transcript activity.
-    Summary,
-    /// Print raw live transcript event detail.
-    Full,
-}
-
-impl From<ProgressLevel> for LiveObservationLevel {
-    fn from(level: ProgressLevel) -> Self {
-        match level {
-            ProgressLevel::Summary => Self::Summary,
-            ProgressLevel::Full => Self::Full,
-        }
-    }
-}
 
 struct RunClientArgs {
     agent: String,
@@ -122,63 +105,6 @@ impl fmt::Display for RunCommandError {
 
 impl Error for RunCommandError {}
 
-#[derive(Parser, Debug)]
-#[command(name = "agentd", version, propagate_version = true)]
-struct Cli {
-    #[arg(long)]
-    config: Option<PathBuf>,
-    #[command(subcommand)]
-    command: Option<Command>,
-}
-
-#[derive(Args, Debug, Default)]
-struct DaemonArgs {
-    #[arg(long)]
-    config: Option<PathBuf>,
-}
-
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// Start the foreground daemon.
-    Daemon(DaemonArgs),
-    /// Trigger a manual session through the running daemon.
-    #[command(
-        display_name = "agentd",
-        after_help = "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nWork-mode artifact invocation:\n  agentd run <AGENT> [REPO] --work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"
-    )]
-    Run {
-        agent: String,
-        repo: Option<String>,
-        #[arg(long)]
-        socket_path: Option<PathBuf>,
-        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
-        progress: ProgressLevel,
-        #[arg(long, conflicts_with = "intent")]
-        work_unit: Option<String>,
-        #[arg(long, conflicts_with_all = ["work_unit", "artifact_file"])]
-        intent: Option<String>,
-        #[arg(long, requires = "artifact_type", conflicts_with = "intent")]
-        artifact_file: Option<PathBuf>,
-        #[arg(long, requires = "artifact_file")]
-        artifact_type: Option<String>,
-    },
-    #[command(
-        display_name = "agentd",
-        about = WISH_ABOUT,
-        after_help = wish_after_help()
-    )]
-    Wish {
-        agent: String,
-        repo: Option<String>,
-        #[arg(long)]
-        socket_path: Option<PathBuf>,
-        #[arg(long)]
-        work_unit: Option<String>,
-        #[arg(long, value_enum, default_value_t = ProgressLevel::Summary)]
-        progress: ProgressLevel,
-    },
-}
-
 fn main() -> ExitCode {
     if let Err(error) = configure_tracing() {
         eprintln!("failed to initialize tracing: {error}");
@@ -192,12 +118,6 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
-}
-
-fn wish_after_help() -> String {
-    format!(
-        "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  {WISH_GREETING}\n  {WISH_STATEMENT_PROMPT}\n  {WISH_TARGET_PROMPT}\n\nOr seed the session from an existing work-unit instead of prose:\n  agentd wish <AGENT> [REPO] --work-unit <ID>"
-    )
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/agentd/tests/cli_surface.rs
+++ b/crates/agentd/tests/cli_surface.rs
@@ -408,120 +408,204 @@ fn binary_bare_command_with_config_starts_daemon_mode() {
     );
 }
 
-#[test]
-fn binary_run_help_shows_socket_path_and_not_config() {
+fn assert_help(args: &[&str], expected: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["run", "--help"])
+        .args(args)
         .output()
         .expect("agentd binary should run");
 
     assert!(
         output.status.success(),
-        "run help should exit successfully: {}",
+        "help {args:?} should exit successfully: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--socket-path"),
-        "run help should advertise socket override: {stdout}"
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be valid UTF-8"),
+        ""
     );
-    assert!(
-        stdout.contains("--progress <PROGRESS>")
-            && stdout.contains("summary")
-            && stdout.contains("full"),
-        "run help should document live progress verbosity: {stdout}"
-    );
-    assert!(
-        stdout.contains(
-            "Live observation:\n  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail."
-        ),
-        "run help should describe summary and full transcript rendering: {stdout}"
-    );
-    assert!(
-        !stdout.contains("--config"),
-        "run help should not advertise daemon config coupling: {stdout}"
-    );
-    assert!(
-        stdout.contains("--work-unit <ID> --artifact-type work-unit --artifact-file <ID>.json"),
-        "run help should document work-mode artifact invocation: {stdout}"
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be valid UTF-8"),
+        expected
     );
 }
 
+const ROOT_HELP: &str = r#"Run the agentd service or submit agent sessions through it.
+
+With no subcommand, agentd starts the foreground daemon using /etc/agentd/agentd.toml. Use daemon to make service startup explicit, run to submit one manual session request, or wish for guided desired-state entry.
+
+Usage: agentd [OPTIONS] [COMMAND]
+
+Commands:
+  daemon  Start the foreground service that accepts and supervises agent sessions
+  run     Submit one manual session request, with optional invocation input
+  wish    Elicit a desired state or select a work unit, then seed one agent session
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --config <CONFIG>
+          Load daemon configuration from this path when starting the service [default: /etc/agentd/agentd.toml]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Examples:
+  agentd
+  agentd --config <PATH>
+"#;
+
 #[test]
-fn binary_top_level_help_shows_wish_operator_verb() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .arg("--help")
-        .output()
-        .expect("agentd binary should run");
-
-    assert!(
-        output.status.success(),
-        "help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("wish"),
-        "top-level help should advertise the wish operator verb: {stdout}"
-    );
+fn binary_root_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["--help"], ROOT_HELP);
 }
 
+const DAEMON_HELP: &str = r#"Run the foreground agentd service that accepts manual and scheduled session requests over its control socket and supervises their execution.
+
+Use daemon to start the service. Use run for direct manual submission or wish for guided desired-state entry after the service is running.
+
+Usage: agentd daemon [OPTIONS]
+
+Options:
+      --config <CONFIG>
+          Load daemon configuration from this path [default: /etc/agentd/agentd.toml]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Examples:
+  agentd daemon
+  agentd daemon --config <PATH>
+"#;
+
 #[test]
-fn binary_wish_help_shows_evocative_intent_prompting_surface() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["wish", "--help"])
-        .output()
-        .expect("agentd binary should run");
-
-    assert!(
-        output.status.success(),
-        "wish help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--socket-path"),
-        "wish help should advertise socket override: {stdout}"
-    );
-    assert!(
-        stdout.contains("Elicit a wish and seed one governed session."),
-        "wish help should describe the wish session boundary exactly: {stdout}"
-    );
-    assert!(
-        stdout.contains("--progress <PROGRESS>")
-            && stdout.contains("summary")
-            && stdout.contains("full"),
-        "wish help should document live progress verbosity: {stdout}"
-    );
-    assert!(
-        stdout.contains(
-            "Live observation:\n  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.\n\nPrompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
-        ),
-        "wish help should document the exact prompt block: {stdout}"
-    );
+fn binary_daemon_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["daemon", "--help"], DAEMON_HELP);
 }
 
+const RUN_HELP: &str = concat!(
+    r#"Submit one manual session request to an already-running agentd daemon.
+
+Invocation input may be omitted for an unseeded session or supplied as a work-unit reference, a prose intent statement, a complete artifact document, or a matching work-unit reference and work-unit artifact. Use run for direct manual submission; use wish for guided desired-state entry or daemon to start the service.
+
+Usage: agentd run [OPTIONS] <AGENT> [REPO]
+
+Arguments:
+  <AGENT>
+          Select an agent declared under this name in the daemon configuration
+
+  [REPO]
+          Use the selected agent's daemon-configured repository when omitted; otherwise clone a remote https://, http://, git://, ssh://, or user@host:path URL; local paths, credential-bearing URLs, queries, and fragments are rejected
+
+Options:
+      --socket-path <SOCKET_PATH>
+          Connect through this daemon control socket instead of resolving $XDG_RUNTIME_DIR/agentd/agentd.sock
+
+      --progress <PROGRESS>
+          Choose how much live transcript activity to print while the session runs
+
+          Possible values:
+          - summary: Print compact live transcript activity
+          - full:    Print raw live transcript event detail
+"#,
+    "          \n",
+    r#"          [default: summary]
+
+      --work-unit <WORK_UNIT>
+          Seed from this tracker work-unit reference through runa; when combined with an artifact, its type must be work-unit and its file stem must equal this reference; conflicts with --intent
+
+      --intent <INTENT>
+          Synthesize this prose statement into a canonical intent artifact; the active methodology must declare a compatible intent schema; conflicts with --work-unit and --artifact-file
+
+      --artifact-file <ARTIFACT_FILE>
+          Supply this complete UTF-8 JSON artifact document; its file stem becomes the artifact id and --artifact-type is required
+
+      --artifact-type <ARTIFACT_TYPE>
+          Declare the active methodology's artifact type for --artifact-file; use work-unit when combining with --work-unit
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Live observation:
+  agentd run streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.
+
+Examples:
+  agentd run <AGENT>
+  agentd run <AGENT> <REPO>
+  agentd run <AGENT> --intent <STATEMENT>
+  agentd run <AGENT> --work-unit <REFERENCE>
+  agentd run <AGENT> --artifact-type <TYPE> --artifact-file <ID>.json
+  agentd run <AGENT> --work-unit <REFERENCE> --artifact-type work-unit --artifact-file <REFERENCE>.json
+"#
+);
+
 #[test]
-fn binary_daemon_help_shows_config() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["daemon", "--help"])
-        .output()
-        .expect("agentd binary should run");
+fn binary_run_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["run", "--help"], RUN_HELP);
+}
 
-    assert!(
-        output.status.success(),
-        "daemon help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+const WISH_HELP: &str = concat!(
+    r#"Interactively elicit the state the operator wants made true and an optional target, validate the resulting canonical intent for the active methodology, and ask the running daemon to seed one agent session. With --work-unit, bypass prose elicitation and seed from the named tracker work unit.
 
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--config"),
-        "daemon help should retain config loading: {stdout}"
-    );
+Use wish for guided desired-state entry. Use run for direct manual submission or daemon to start the service.
+
+Usage: agentd wish [OPTIONS] <AGENT> [REPO]
+
+Arguments:
+  <AGENT>
+          Select an agent declared under this name in the daemon configuration
+
+  [REPO]
+          Use the selected agent's daemon-configured repository when omitted; otherwise clone a remote https://, http://, git://, ssh://, or user@host:path URL; local paths, credential-bearing URLs, queries, and fragments are rejected
+
+Options:
+      --socket-path <SOCKET_PATH>
+          Connect through this daemon control socket instead of resolving $XDG_RUNTIME_DIR/agentd/agentd.sock
+
+      --work-unit <WORK_UNIT>
+          Bypass prose elicitation and seed from this existing tracker work-unit reference through runa
+
+      --progress <PROGRESS>
+          Choose how much live transcript activity to print while the session runs
+
+          Possible values:
+          - summary: Print compact live transcript activity
+          - full:    Print raw live transcript event detail
+"#,
+    "          \n",
+    r#"          [default: summary]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+Live observation:
+  agentd wish streams compact followable transcript activity by default while the session executes. Use --progress full for raw transcript event detail.
+
+Prompts:
+  Speak a wish: the state you want made true.
+  What do you wish to be true?
+  What is this wish aimed at? Leave blank if it has no target.
+
+Examples:
+  agentd wish <AGENT>
+  agentd wish <AGENT> <REPO>
+  agentd wish <AGENT> --work-unit <REFERENCE>
+"#
+);
+
+#[test]
+fn binary_wish_help_matches_the_invocation_contract_exactly() {
+    assert_help(&["wish", "--help"], WISH_HELP);
 }
 
 #[test]
@@ -1699,32 +1783,5 @@ fn binary_wish_command_seeds_work_unit_arm_and_skips_prose_elicitation() {
         invocation.input, None,
         "wish work-unit arm should reach the same downstream request shape as `run --work-unit`: \
          a work-unit reference with no explicit invocation input"
-    );
-}
-
-#[test]
-fn binary_wish_help_advertises_work_unit_arm() {
-    let output = Command::new(env!("CARGO_BIN_EXE_agentd"))
-        .args(["wish", "--help"])
-        .output()
-        .expect("agentd binary should run");
-
-    assert!(
-        output.status.success(),
-        "wish help should exit successfully: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
-    assert!(
-        stdout.contains("--work-unit"),
-        "wish help should advertise the work-unit arm: {stdout}"
-    );
-    // The prose prompt surface remains documented unchanged.
-    assert!(
-        stdout.contains(
-            "Prompts:\n  Speak a wish: the state you want made true.\n  What do you wish to be true?\n  What is this wish aimed at? Leave blank if it has no target."
-        ),
-        "wish help should retain the exact prose prompt block: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

- make root, `daemon`, `run`, and `wish` help self-contained for command selection and invocation
- describe every positional and option, including unseeded and supplied `run` modes
- publish parse-tested examples that match repository URL and work-mode runtime constraints
- pin all four rendered help surfaces byte-for-byte and record the operator-visible change

## Why

The existing help named commands but left key inputs and selection boundaries undescribed. A cold operator could not choose or construct non-obvious invocations without consulting narrative documentation or source.

This regenerated implementation also incorporates the findings from closed PR #181: `run` explicitly retains its unseeded mode and live `--intent` arm, repository help enumerates the runner-supported remote forms, and the combined work-mode example uses one identity for the work-unit reference and artifact file stem.

## Impact

Operators and automation authors can treat each command-local help surface as its invocation contract. The CLI grammar, runtime behavior, and exact wish prompt flow are unchanged.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets`
- targeted structural/example, exact-output, and runner-validator tests
- cold-read documentation and honest-signal audits recorded in the completion-evidence artifact on #172

Closes #172