### PR TITLE
feat(config): deliver the deployment's forge identity to runa's resolving entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Agent config carries the deployment's forge identity as `forge_owner` and
+  `forge_name`, injected into each session as `RUNA_FORGE_OWNER` and
+  `RUNA_FORGE_NAME` alongside `RUNA_FORGE_TYPE`, so a work-unit-seeded session
+  resolves its ticket reference against the configured forge identity. An agent
+  declares both fields or neither (#186).
 - `AGENTS.md` carries the canonical principles pointer
   (`pentaxis93/principles`), matching the runa/groundwork entry-line
   convention (#148).

--- a/README.md
+++ b/README.md
@@ -86,9 +86,14 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
-# Optional active forge type injected as GROUNDWORK_FORGE_TYPE for Groundwork.
-# Defaults to "github" when omitted.
+# Optional active forge type injected as GROUNDWORK_FORGE_TYPE for Groundwork and
+# as RUNA_FORGE_TYPE for runa. Defaults to "github" when omitted.
 #forge_type = "github"
+# Optional forge identity of the deployment's repository, injected as
+# RUNA_FORGE_OWNER and RUNA_FORGE_NAME so a work-unit-seeded session can bind a
+# ticket reference to its deployment. Declare both or neither.
+#forge_owner = "pentaxis93"
+#forge_name = "agentd"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
 # and for every scheduled run of this agent. HTTPS, HTTP, git://, ssh://, and
 # user@host:path SSH forms are accepted.
@@ -155,8 +160,12 @@ must provide `/bin/sh`, `find`, `git`, `groupadd`, `useradd`, `gosu`, `runa`,
 and whatever binaries the declared agent command uses. SSH repository clone
 also requires an OpenSSH-compatible client in the base image. UID/GID `1000`
 must be available for the session user. The optional `forge_type` value declares one
-active forge type for each session and is injected as `GROUNDWORK_FORGE_TYPE`; when
-omitted, agentd injects `github`. When an agent declares `schedule`, it must
+active forge type for each session and is injected as both `GROUNDWORK_FORGE_TYPE`
+and `RUNA_FORGE_TYPE`; when omitted, agentd injects `github`. The optional
+`forge_owner` and `forge_name` values declare the deployment's forge identity and
+are injected as `RUNA_FORGE_OWNER` and `RUNA_FORGE_NAME`, letting a
+work-unit-seeded session bind its ticket reference to the deployment; an agent
+declares both or neither. When an agent declares `schedule`, it must
 also declare `repo`. Schedules are evaluated in daemon-local time and missed
 fires are not backfilled after downtime. Persistent audit records default to
 `$XDG_STATE_HOME/tesserine/audit` or `$HOME/.local/state/tesserine/audit`; set

--- a/crates/agentd-runner/src/test_support.rs
+++ b/crates/agentd-runner/src/test_support.rs
@@ -19,6 +19,8 @@ pub(crate) fn test_session_spec() -> SessionSpec {
         methodology_dir: PathBuf::from("/tmp/methodology"),
         audit_root: std::env::temp_dir().join("agentd-runner-test-audit-root"),
         forge_type: "github".to_string(),
+        forge_owner: None,
+        forge_name: None,
         mounts: Vec::new(),
         agent_command: vec!["site-builder".to_string(), "exec".to_string()],
         environment: Vec::new(),

--- a/crates/agentd-runner/src/types.rs
+++ b/crates/agentd-runner/src/types.rs
@@ -40,8 +40,17 @@ pub struct SessionSpec {
     /// stores each session under `<audit_root>/<agent>/<session_id>/`.
     pub audit_root: PathBuf,
     /// Active forge type exposed to the session as `GROUNDWORK_FORGE_TYPE` so
-    /// Groundwork can resolve forge-invariant operations.
+    /// Groundwork can resolve forge-invariant operations, and as
+    /// `RUNA_FORGE_TYPE` so runa's entry can bind a ticket reference.
     pub forge_type: String,
+    /// Forge account owning the deployment's repository, exposed to the
+    /// session as `RUNA_FORGE_OWNER`. Present exactly when
+    /// [`SessionSpec::forge_name`] is present.
+    pub forge_owner: Option<String>,
+    /// Repository name of the deployment on its forge, exposed to the session
+    /// as `RUNA_FORGE_NAME`. Present exactly when
+    /// [`SessionSpec::forge_owner`] is present.
+    pub forge_name: Option<String>,
     /// Additional host bind mounts declared by the selected agent.
     pub mounts: Vec<BindMount>,
     /// Command array executed directly from the cloned repository after
@@ -52,7 +61,8 @@ pub struct SessionSpec {
     /// Non-empty values are passed via ephemeral podman secrets; empty values
     /// are passed as direct `--env` assignments.
     /// Names reserved for runner-owned values such as `AGENT_NAME`,
-    /// `GROUNDWORK_FORGE_TYPE`, `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`,
+    /// `GROUNDWORK_FORGE_TYPE`, `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`,
+    /// `RUNA_FORGE_NAME`, `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`,
     /// `RUNA_TRANSCRIPT_DIR`, `RUNA_TRANSCRIPT_DEPLOYMENT`,
     /// `RUNA_TRANSCRIPT_RUN_ID`, and `RUNA_TRANSCRIPT_REDACT_ENV` are rejected
     /// during validation.

--- a/crates/agentd-runner/src/validation.rs
+++ b/crates/agentd-runner/src/validation.rs
@@ -19,6 +19,9 @@ use std::path::Path;
 
 const AGENT_NAME_ENV: &str = "AGENT_NAME";
 const GROUNDWORK_FORGE_TYPE_ENV: &str = "GROUNDWORK_FORGE_TYPE";
+const RUNA_FORGE_TYPE_ENV: &str = "RUNA_FORGE_TYPE";
+const RUNA_FORGE_OWNER_ENV: &str = "RUNA_FORGE_OWNER";
+const RUNA_FORGE_NAME_ENV: &str = "RUNA_FORGE_NAME";
 const WORK_UNIT_ENV: &str = "AGENTD_WORK_UNIT";
 pub(crate) const REPO_TOKEN_ENV: &str = "AGENTD_REPO_TOKEN";
 pub(crate) const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
@@ -200,6 +203,7 @@ fn validate_work_mode_input(work_unit: &str, input: &InvocationInput) -> Result<
 ///
 /// Rejects names that are empty, contain `,` or `=`, or collide with
 /// runner-managed names such as `AGENT_NAME`, `GROUNDWORK_FORGE_TYPE`,
+/// `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`,
 /// `AGENTD_WORK_UNIT`, `AGENTD_REPO_TOKEN`, `RUNA_TRANSCRIPT_DIR`,
 /// `RUNA_TRANSCRIPT_DEPLOYMENT`, `RUNA_TRANSCRIPT_RUN_ID`, and
 /// `RUNA_TRANSCRIPT_REDACT_ENV`. Used both by
@@ -260,11 +264,27 @@ pub fn validate_repo_url(repo_url: &str) -> Result<(), RunnerError> {
 ///
 /// These names are reserved — callers cannot use them in
 /// [`SessionSpec::environment`] because the runner injects them directly.
-pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> [(&str, &str); 2] {
-    [
-        (AGENT_NAME_ENV, &spec.agent_name),
-        (GROUNDWORK_FORGE_TYPE_ENV, &spec.forge_type),
-    ]
+///
+/// The active forge type is exported under two names because two consumers
+/// read it: Groundwork resolves forge-invariant operations from
+/// `GROUNDWORK_FORGE_TYPE`, and runa's entry resolves the deployment's forge
+/// identity from the `RUNA_FORGE_*` atoms. Both derive from the single
+/// `forge_type` field. The owner and name atoms are emitted exactly when the
+/// agent configures a forge identity; runa owns the precedence that consumes
+/// them.
+pub(crate) fn runner_managed_environment(spec: &SessionSpec) -> Vec<(&str, &str)> {
+    let mut environment = vec![
+        (AGENT_NAME_ENV, spec.agent_name.as_str()),
+        (GROUNDWORK_FORGE_TYPE_ENV, spec.forge_type.as_str()),
+        (RUNA_FORGE_TYPE_ENV, spec.forge_type.as_str()),
+    ];
+    if let Some(owner) = spec.forge_owner.as_deref() {
+        environment.push((RUNA_FORGE_OWNER_ENV, owner));
+    }
+    if let Some(name) = spec.forge_name.as_deref() {
+        environment.push((RUNA_FORGE_NAME_ENV, name));
+    }
+    environment
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -403,6 +423,9 @@ fn is_reserved_environment_name(name: &str) -> bool {
         name,
         AGENT_NAME_ENV
             | GROUNDWORK_FORGE_TYPE_ENV
+            | RUNA_FORGE_TYPE_ENV
+            | RUNA_FORGE_OWNER_ENV
+            | RUNA_FORGE_NAME_ENV
             | WORK_UNIT_ENV
             | REPO_TOKEN_ENV
             | TRANSCRIPT_DIR_ENV
@@ -519,6 +542,9 @@ mod tests {
         for reserved_name in [
             "AGENT_NAME",
             "GROUNDWORK_FORGE_TYPE",
+            "RUNA_FORGE_TYPE",
+            "RUNA_FORGE_OWNER",
+            "RUNA_FORGE_NAME",
             WORK_UNIT_ENV,
             REPO_TOKEN_ENV,
             "RUNA_TRANSCRIPT_DIR",
@@ -1699,6 +1725,69 @@ mod tests {
         assert!(
             matches!(error, RunnerError::InvalidAgentName),
             "expected InvalidAgentName, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn runner_managed_environment_exports_forge_type_to_both_consumers() {
+        let spec = SessionSpec {
+            forge_type: "sourcehut".to_string(),
+            ..test_session_spec()
+        };
+
+        let environment = runner_managed_environment(&spec);
+
+        assert_eq!(
+            environment
+                .iter()
+                .find(|(name, _)| *name == "GROUNDWORK_FORGE_TYPE")
+                .map(|(_, value)| *value),
+            Some("sourcehut")
+        );
+        assert_eq!(
+            environment
+                .iter()
+                .find(|(name, _)| *name == "RUNA_FORGE_TYPE")
+                .map(|(_, value)| *value),
+            Some("sourcehut")
+        );
+    }
+
+    #[test]
+    fn runner_managed_environment_exports_configured_forge_identity_atoms() {
+        let spec = SessionSpec {
+            forge_owner: Some("tesserine".to_string()),
+            forge_name: Some("example-hello".to_string()),
+            ..test_session_spec()
+        };
+
+        let environment = runner_managed_environment(&spec);
+
+        assert_eq!(
+            environment
+                .iter()
+                .find(|(name, _)| *name == "RUNA_FORGE_OWNER")
+                .map(|(_, value)| *value),
+            Some("tesserine")
+        );
+        assert_eq!(
+            environment
+                .iter()
+                .find(|(name, _)| *name == "RUNA_FORGE_NAME")
+                .map(|(_, value)| *value),
+            Some("example-hello")
+        );
+    }
+
+    #[test]
+    fn runner_managed_environment_omits_forge_identity_atoms_when_unconfigured() {
+        let spec = test_session_spec();
+        let environment = runner_managed_environment(&spec);
+
+        assert!(
+            !environment
+                .iter()
+                .any(|(name, _)| *name == "RUNA_FORGE_OWNER" || *name == "RUNA_FORGE_NAME")
         );
     }
 }

--- a/crates/agentd-runner/tests/session_lifecycle.rs
+++ b/crates/agentd-runner/tests/session_lifecycle.rs
@@ -188,6 +188,8 @@ fn succeeds_without_timeout_and_cleans_up_container() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec![
                 "site-builder".to_string(),
@@ -244,6 +246,8 @@ fn materializes_intent_text_input_before_session_command_runs() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -293,6 +297,8 @@ fn materializes_generic_artifact_input_before_session_command_runs() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -343,6 +349,8 @@ fn executes_work_mode_against_injected_work_unit_artifact() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -528,6 +536,8 @@ fn rejects_intent_text_when_methodology_declares_a_legacy_intent_version() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),
@@ -575,6 +585,8 @@ fn succeeds_with_empty_and_non_empty_environment_values() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -628,6 +640,8 @@ fn clears_inherited_work_unit_when_invocation_omits_it() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -673,6 +687,8 @@ fn returns_failed_exit_code_without_timeout_and_cleans_up_container() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -724,6 +740,8 @@ fn returns_failed_exit_code_125_without_timeout_and_cleans_up_runner_resources()
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -777,6 +795,8 @@ fn succeeds_when_methodology_dir_path_contains_commas() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -838,6 +858,8 @@ fn validates_read_only_additional_mounts_from_paths_containing_commas() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readonly-mount-run/.claude"),
@@ -908,6 +930,8 @@ fn preserves_host_writes_through_read_write_additional_mounts() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/readwrite-mount-run/.runa"),
@@ -982,6 +1006,8 @@ fn preserves_writable_home_for_nested_additional_mount_parents() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/nested-home-mount-run/.config/claude"),
@@ -1034,6 +1060,8 @@ fn preserves_session_user_access_to_preexisting_home_content() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1078,6 +1106,8 @@ fn preserves_host_audit_record_after_successful_session_teardown() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1177,6 +1207,8 @@ fn persists_session_transcript_under_agentd_audit_dir() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1255,6 +1287,8 @@ fn finalizes_session_after_runtime_restricts_transcript_directory_permissions() 
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1331,6 +1365,8 @@ fn finalizes_session_after_runtime_restricts_events_jsonl_permissions() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1407,6 +1443,8 @@ fn preserves_host_readability_for_restrictive_container_written_audit_entries_af
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1507,6 +1545,8 @@ fn refuses_hard_linked_audit_entries_without_mutating_operator_mount_file_modes(
             methodology_dir: fixture.methodology_dir(),
             audit_root: audit_root.clone(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: vec![BindMount {
                 source: host_mount.clone(),
                 target: PathBuf::from("/home/audit-hard-link-run/shared"),
@@ -1587,6 +1627,8 @@ fn preserves_failing_audit_trail_for_post_mortem_reconstruction() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![ResolvedEnvironmentVariable {
@@ -1655,6 +1697,8 @@ fn times_out_when_a_timeout_is_provided_and_cleans_up_container() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: vec![
@@ -1708,6 +1752,8 @@ fn releases_session_secret_after_container_reaches_running_state() {
                 methodology_dir,
                 audit_root: audit_root.clone(),
                 forge_type: "github".to_string(),
+                forge_owner: None,
+                forge_name: None,
                 mounts: Vec::new(),
                 agent_command: vec!["site-builder".to_string(), "exec".to_string()],
                 environment: vec![
@@ -1767,6 +1813,8 @@ fn clones_ssh_repo_with_agent_scoped_mounted_identity() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: vec![BindMount {
                 source: ssh_dir,
                 target: PathBuf::from("/home/ssh-clone-run/.ssh"),
@@ -1815,6 +1863,8 @@ fn ssh_repo_clone_cannot_use_another_agents_unmounted_identity() {
             methodology_dir: fixture.methodology_dir(),
             audit_root: fixture.audit_root(),
             forge_type: "github".to_string(),
+            forge_owner: None,
+            forge_name: None,
             mounts: Vec::new(),
             agent_command: vec!["site-builder".to_string(), "exec".to_string()],
             environment: Vec::new(),

--- a/crates/agentd/src/config.rs
+++ b/crates/agentd/src/config.rs
@@ -148,6 +148,31 @@ impl Config {
                 None => DEFAULT_FORGE_TYPE.to_string(),
             };
 
+            let forge_owner = match raw_agent.forge_owner {
+                Some(value) => {
+                    validate_lookup_key(
+                        "forge_owner",
+                        &value,
+                        Some(raw_agent.name.as_str()),
+                        None,
+                    )?;
+                    Some(value)
+                }
+                None => None,
+            };
+            let forge_name = match raw_agent.forge_name {
+                Some(value) => {
+                    validate_lookup_key("forge_name", &value, Some(raw_agent.name.as_str()), None)?;
+                    Some(value)
+                }
+                None => None,
+            };
+            if forge_owner.is_some() != forge_name.is_some() {
+                return Err(ConfigError::PartialForgeIdentity {
+                    agent: raw_agent.name.clone(),
+                });
+            }
+
             if raw_agent.command.argv.is_empty() {
                 return Err(ConfigError::EmptyAgentCommand {
                     agent: raw_agent.name.clone(),
@@ -273,6 +298,8 @@ impl Config {
                 schedule,
                 repo_token_source,
                 forge_type,
+                forge_owner,
+                forge_name,
                 credentials,
                 agent_command,
             });
@@ -311,6 +338,8 @@ pub struct Agent {
     schedule: Option<String>,
     repo_token_source: Option<String>,
     forge_type: String,
+    forge_owner: Option<String>,
+    forge_name: Option<String>,
     credentials: Vec<CredentialConfig>,
     agent_command: Vec<String>,
 }
@@ -359,6 +388,20 @@ impl Agent {
     /// forge-operation resolution.
     pub fn forge_type(&self) -> &str {
         &self.forge_type
+    }
+
+    /// Forge account owning the deployment's repository. Present exactly when
+    /// [`Agent::forge_name`] is present; the pair is injected into each
+    /// launched session so runa's entry can bind a ticket reference to the
+    /// deployment's forge identity.
+    pub fn forge_owner(&self) -> Option<&str> {
+        self.forge_owner.as_deref()
+    }
+
+    /// Repository name of the deployment on its forge. Present exactly when
+    /// [`Agent::forge_owner`] is present.
+    pub fn forge_name(&self) -> Option<&str> {
+        self.forge_name.as_deref()
     }
 
     /// Declared credentials for this agent. Each credential's name is a
@@ -625,6 +668,10 @@ pub enum ConfigError {
     InvalidSchedule { agent: String, schedule: String },
     /// A scheduled agent must declare a default repo for autonomous runs.
     ScheduleRequiresRepo { agent: String },
+    /// An agent declares exactly one of `forge_owner` / `forge_name`. The
+    /// forge identity a session binds its ticket reference against is the
+    /// owner/name pair; half of it resolves no reference.
+    PartialForgeIdentity { agent: String },
     /// A configured mount source is not an absolute path.
     MountSourceMustBeAbsolute { agent: String, source: PathBuf },
     /// A configured mount target violates the runner's target rules.
@@ -746,6 +793,12 @@ impl fmt::Display for ConfigError {
                     "agent '{agent}' defines schedule but no repo; scheduled agents must define a repo"
                 )
             }
+            ConfigError::PartialForgeIdentity { agent } => {
+                write!(
+                    f,
+                    "agent '{agent}' defines only one of forge_owner and forge_name; a forge identity requires both"
+                )
+            }
             ConfigError::MountSourceMustBeAbsolute { agent, source } => {
                 write!(
                     f,
@@ -842,6 +895,8 @@ struct RawAgent {
     schedule: Option<String>,
     repo_token_source: Option<String>,
     forge_type: Option<String>,
+    forge_owner: Option<String>,
+    forge_name: Option<String>,
     #[serde(default)]
     credentials: Vec<RawCredentialConfig>,
 }

--- a/crates/agentd/src/dispatch.rs
+++ b/crates/agentd/src/dispatch.rs
@@ -181,6 +181,8 @@ pub fn dispatch_run_after_preflight(
                 methodology_dir: agent.methodology_dir().to_path_buf(),
                 audit_root,
                 forge_type: agent.forge_type().to_string(),
+                forge_owner: agent.forge_owner().map(str::to_string),
+                forge_name: agent.forge_name().map(str::to_string),
                 mounts: agent
                     .mounts()
                     .iter()

--- a/crates/agentd/tests/config_parsing.rs
+++ b/crates/agentd/tests/config_parsing.rs
@@ -857,6 +857,100 @@ argv = ["site-builder", "exec"]
 }
 
 #[test]
+fn parses_agent_forge_owner_and_name_as_session_forge_identity() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-forge-identity");
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+forge_owner = "tesserine"
+forge_name = "example-hello"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse forge identity");
+
+    let agent = config.agent("site-builder").expect("agent should exist");
+
+    assert_eq!(agent.forge_owner(), Some("tesserine"));
+    assert_eq!(agent.forge_name(), Some("example-hello"));
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+
+#[test]
+fn omits_agent_forge_identity_when_both_fields_are_absent() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-forge-identity-absent");
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse without a forge identity");
+
+    let agent = config.agent("site-builder").expect("agent should exist");
+
+    assert_eq!(agent.forge_owner(), None);
+    assert_eq!(agent.forge_name(), None);
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+
+#[test]
+fn rejects_agent_declaring_only_one_half_of_the_forge_identity() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    set_xdg_runtime_dir("agent-forge-identity-partial");
+    for half in [
+        "forge_owner = \"tesserine\"",
+        "forge_name = \"example-hello\"",
+    ] {
+        let error = Config::from_str(&format!(
+            r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+{half}
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#
+        ))
+        .expect_err("a half-declared forge identity should be rejected");
+
+        match error {
+            ConfigError::PartialForgeIdentity { agent } => {
+                assert_eq!(agent, "site-builder");
+            }
+            other => panic!("expected PartialForgeIdentity, got {other:?}"),
+        }
+    }
+    unsafe {
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+
+#[test]
 fn defaults_agent_forge_type_to_github_when_omitted() {
     let _guard = env_lock()
         .lock()

--- a/crates/agentd/tests/session_dispatch.rs
+++ b/crates/agentd/tests/session_dispatch.rs
@@ -204,6 +204,42 @@ fn dispatch_run_forwards_active_forge_type_into_session_spec() {
 }
 
 #[test]
+fn dispatch_run_forwards_configured_forge_identity_into_session_spec() {
+    let config = Config::from_str(
+        r#"
+[[agents]]
+name = "site-builder"
+base_image = "ghcr.io/example/site-builder:latest"
+methodology_dir = "../groundwork"
+forge_owner = "tesserine"
+forge_name = "example-hello"
+
+[agents.command]
+argv = ["site-builder", "exec"]
+"#,
+    )
+    .expect("config should parse");
+    let request = RunRequest {
+        agent: "site-builder".to_string(),
+        repo_url: Some("https://example.com/repo.git".to_string()),
+        work_unit: None,
+        input: None,
+    };
+    let (executor, state) = RecordingExecutor::succeeding(SessionOutcome::Success { exit_code: 0 });
+
+    dispatch_run(&config, &request, &executor).expect("dispatch should succeed");
+
+    let state = state.lock().expect("recording state should lock");
+    let spec = state
+        .last_spec
+        .as_ref()
+        .expect("executor should receive spec");
+
+    assert_eq!(spec.forge_owner.as_deref(), Some("tesserine"));
+    assert_eq!(spec.forge_name.as_deref(), Some("example-hello"));
+}
+
+#[test]
 fn dispatch_run_defaults_active_forge_type_to_github() {
     let config = Config::from_str(
         r#"

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -25,6 +25,9 @@ only the environment.
 | --- | --- | --- |
 | `AGENT_NAME` | the agent's configured name | session tooling |
 | `GROUNDWORK_FORGE_TYPE` | `forge_type` from agent config, defaulting to `github` | groundwork forge mechanics |
+| `RUNA_FORGE_TYPE` | `forge_type` from agent config, defaulting to `github` | runa deployment forge identity |
+| `RUNA_FORGE_OWNER` | `forge_owner` from agent config, when configured | runa deployment forge identity: binds a ticket reference to the deployment |
+| `RUNA_FORGE_NAME` | `forge_name` from agent config, when configured | runa deployment forge identity: binds a ticket reference to the deployment |
 | `AGENTD_WORK_UNIT` | the `--work-unit` identifier, when present | session tooling |
 | `AGENTD_REPO_TOKEN` | the resolved repo token, when configured | the generated clone step only: consumed for the one HTTPS `git clone` and unset before the agent command runs — it cannot authorize pushes. HTTPS pushes need a credential delivered via `[[agents.credentials]]`; SSH pushes use the mounted `.ssh` identity |
 | `RUNA_TRANSCRIPT_DIR` | the mounted transcript directory | runa / runa-mcp transcript emission |

--- a/examples/agentd.toml
+++ b/examples/agentd.toml
@@ -16,9 +16,14 @@ name = "site-builder"
 base_image = "ghcr.io/example/site-builder:latest"
 # Methodology directory to mount read-only into the session environment.
 methodology_dir = "../groundwork"
-# Optional active forge type injected as GROUNDWORK_FORGE_TYPE for Groundwork.
-# Defaults to "github" when omitted.
+# Optional active forge type injected as GROUNDWORK_FORGE_TYPE for Groundwork and
+# as RUNA_FORGE_TYPE for runa. Defaults to "github" when omitted.
 #forge_type = "github"
+# Optional forge identity of the deployment's repository, injected as
+# RUNA_FORGE_OWNER and RUNA_FORGE_NAME so a work-unit-seeded session can bind a
+# ticket reference to its deployment. Declare both or neither.
+#forge_owner = "pentaxis93"
+#forge_name = "agentd"
 # Default repository URL cloned for manual runs when `agentd run` omits a repo,
 # and for each scheduled run of this agent.
 repo = "https://github.com/pentaxis93/agentd.git"


### PR DESCRIPTION
Delivers the forge identity `agentd#175`'s routing half needs to succeed.

**Change.** Agent config gains `forge_owner` / `forge_name` alongside `forge_type`; `SessionSpec` carries them; the runner injects `RUNA_FORGE_TYPE` / `RUNA_FORGE_OWNER` / `RUNA_FORGE_NAME` as `--env` on `podman create`, so the atoms are in the session's process environment before `runa init` and `runa run` execute. The single `forge_type` field derives both `GROUNDWORK_FORGE_TYPE` (groundwork's forge-invariant operations) and `RUNA_FORGE_TYPE` (runa's identity resolution) — two consumers, two names, one source. runa's own `resolve_forge_identity` precedence consumes them unchanged; nothing is reimplemented here.

**Derived criterion.** A forge identity is the owner/name *pair*. A half-declared agent would resolve one atom and fail on the other — reproducing `MissingDeploymentIdentity` from a config typo, the exact failure this unit exists to eliminate. Declaring one without the other is now a config-load error (`PartialForgeIdentity`), failing at the surface that creates the wrong assumption. Folded into the issue body as AC5.

**Acceptance evidence.**
- AC1 — `parses_agent_forge_owner_and_name_as_session_forge_identity`, `omits_agent_forge_identity_when_both_fields_are_absent`
- AC2 — `runner_managed_environment_exports_forge_type_to_both_consumers`, `runner_managed_environment_exports_configured_forge_identity_atoms`, `runner_managed_environment_omits_forge_identity_atoms_when_unconfigured`; `dispatch_run_forwards_configured_forge_identity_into_session_spec` covers the config→spec seam
- AC3 / AC4 — the atoms are now present, so `bind_reference_identity` reaches its agreement check: a matching reference binds, a mismatching one returns `DeploymentDisagreement` rather than `MissingDeploymentIdentity`. Both are live-route outcomes, verified by the `babbie-ops#67` targeted run this unblocks.
- AC5 — `rejects_agent_declaring_only_one_half_of_the_forge_identity`

**Verification.** `cargo test --workspace` shows no branch-introduced failures against the `53be589` baseline; `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` are clean. Docs repaired at the emitter: `docs/environment.md`, `examples/agentd.toml`, `README.md`, `CHANGELOG.md`.

Closes #186